### PR TITLE
fix(scan): ignore hidden/AppleDouble ROM sidecar files by default (adds toggle, fixes #35)

### DIFF
--- a/lib/data/datasources/sqlite_config_service.dart
+++ b/lib/data/datasources/sqlite_config_service.dart
@@ -117,6 +117,12 @@ class SqliteConfigService {
             (int.tryParse(userConfig?['scan_on_startup']?.toString() ?? '1') ??
                 1) ==
             1,
+        includeHiddenFiles:
+            !((int.tryParse(
+                      userConfig?['ignore_hidden_files']?.toString() ?? '1',
+                    ) ??
+                    1) ==
+                1),
         setupCompleted:
             (int.tryParse(userConfig?['setup_completed']?.toString() ?? '0') ??
                 0) ==
@@ -173,6 +179,7 @@ class SqliteConfigService {
         isFullscreen: config.isFullscreen ? 1 : 0,
         bartopExitPoweroff: config.bartopExitPoweroff ? 1 : 0,
         scanOnStartup: config.scanOnStartup ? 1 : 0,
+        ignoreHiddenFiles: config.includeHiddenFiles ? 0 : 1,
         setupCompleted: config.setupCompleted ? 1 : 0,
         hideBottomScreen: config.hideBottomScreen ? 1 : 0,
         videoSound: config.videoSound ? 1 : 0,

--- a/lib/data/datasources/sqlite_config_service.dart
+++ b/lib/data/datasources/sqlite_config_service.dart
@@ -117,12 +117,12 @@ class SqliteConfigService {
             (int.tryParse(userConfig?['scan_on_startup']?.toString() ?? '1') ??
                 1) ==
             1,
-        includeHiddenFiles:
-            !((int.tryParse(
-                      userConfig?['ignore_hidden_files']?.toString() ?? '1',
-                    ) ??
-                    1) ==
-                1),
+        ignoreHiddenFiles:
+            (int.tryParse(
+                  userConfig?['ignore_hidden_files']?.toString() ?? '1',
+                ) ??
+                1) ==
+            1,
         setupCompleted:
             (int.tryParse(userConfig?['setup_completed']?.toString() ?? '0') ??
                 0) ==
@@ -179,7 +179,7 @@ class SqliteConfigService {
         isFullscreen: config.isFullscreen ? 1 : 0,
         bartopExitPoweroff: config.bartopExitPoweroff ? 1 : 0,
         scanOnStartup: config.scanOnStartup ? 1 : 0,
-        ignoreHiddenFiles: config.includeHiddenFiles ? 0 : 1,
+        ignoreHiddenFiles: config.ignoreHiddenFiles ? 1 : 0,
         setupCompleted: config.setupCompleted ? 1 : 0,
         hideBottomScreen: config.hideBottomScreen ? 1 : 0,
         videoSound: config.videoSound ? 1 : 0,

--- a/lib/data/datasources/sqlite_database_service.dart
+++ b/lib/data/datasources/sqlite_database_service.dart
@@ -104,7 +104,7 @@ class SqliteDatabaseService {
   static Future<ScanSummary> scanSystemRoms(
     SystemModel system,
     List<String> romFolders, {
-    bool includeHiddenFiles = false,
+    bool ignoreHiddenFiles = true,
     Map<String, Map<String, String>>? rootFoldersMap,
   }) async {
     if (system.id == null) {
@@ -132,7 +132,7 @@ class SqliteDatabaseService {
         system,
         romFolders,
         validExtensionsSet,
-        includeHiddenFiles: includeHiddenFiles,
+        ignoreHiddenFiles: ignoreHiddenFiles,
         rootFoldersMap: rootFoldersMap,
       ),
       Future.delayed(const Duration(minutes: 10), () {
@@ -154,7 +154,7 @@ class SqliteDatabaseService {
     SystemModel system,
     List<String> romFolders,
     Set<String> validExtensionsSet, {
-    bool includeHiddenFiles = false,
+    bool ignoreHiddenFiles = true,
     Map<String, Map<String, String>>? rootFoldersMap,
   }) async {
     final initialCount = await SqliteService.getRomCountForSystem(system.id!);
@@ -195,14 +195,14 @@ class SqliteDatabaseService {
                   resolvedPath,
                   validExtensionsSet,
                   system.recursiveScan,
-                  includeHiddenFiles: includeHiddenFiles,
+                  ignoreHiddenFiles: ignoreHiddenFiles,
                 );
               } else {
                 entries = await _scanStandardPath(
                   resolvedPath,
                   validExtensionsSet,
                   system.recursiveScan,
-                  includeHiddenFiles: includeHiddenFiles,
+                  ignoreHiddenFiles: ignoreHiddenFiles,
                 );
               }
             } else {
@@ -215,7 +215,7 @@ class SqliteDatabaseService {
                 folderToScan,
                 validExtensionsSet,
                 system.recursiveScan,
-                includeHiddenFiles: includeHiddenFiles,
+                ignoreHiddenFiles: ignoreHiddenFiles,
               );
             } else {
               entries = await _scanStandardFolder(
@@ -223,7 +223,7 @@ class SqliteDatabaseService {
                 folderToScan,
                 validExtensionsSet,
                 system.recursiveScan,
-                includeHiddenFiles: includeHiddenFiles,
+                ignoreHiddenFiles: ignoreHiddenFiles,
               );
             }
           }
@@ -791,17 +791,14 @@ class SqliteDatabaseService {
     String folderName,
     Set<String> validExtensions,
     bool recursive, {
-    bool includeHiddenFiles = false,
+    bool ignoreHiddenFiles = true,
   }) async {
     try {
       final children = await SafDirectoryService.listFiles(romFolderUri);
       if (children.isEmpty) return [];
       String? systemTargetUri;
       for (final child in children) {
-        if (_shouldSkipSafEntry(
-          child,
-          includeHiddenFiles: includeHiddenFiles,
-        )) {
+        if (_shouldSkipSafEntry(child, ignoreHiddenFiles: ignoreHiddenFiles)) {
           continue;
         }
         if (child['isDirectory'] == true &&
@@ -816,7 +813,7 @@ class SqliteDatabaseService {
         systemTargetUri,
         validExtensions,
         recursive,
-        includeHiddenFiles: includeHiddenFiles,
+        ignoreHiddenFiles: ignoreHiddenFiles,
       );
     } catch (_) {
       return [];
@@ -828,7 +825,7 @@ class SqliteDatabaseService {
     String uri,
     Set<String> validExtensions,
     bool recursive, {
-    bool includeHiddenFiles = false,
+    bool ignoreHiddenFiles = true,
   }) async {
     final entries = <RomEntry>[];
     try {
@@ -836,7 +833,7 @@ class SqliteDatabaseService {
       for (final item in content) {
         final name = item['name'].toString();
         final itemUri = item['uri'].toString();
-        if (_shouldSkipSafEntry(item, includeHiddenFiles: includeHiddenFiles)) {
+        if (_shouldSkipSafEntry(item, ignoreHiddenFiles: ignoreHiddenFiles)) {
           continue;
         }
         if (item['isDirectory'] == true) {
@@ -846,7 +843,7 @@ class SqliteDatabaseService {
                 itemUri,
                 validExtensions,
                 recursive,
-                includeHiddenFiles: includeHiddenFiles,
+                ignoreHiddenFiles: ignoreHiddenFiles,
               ),
             );
           }
@@ -874,7 +871,7 @@ class SqliteDatabaseService {
     String folderName,
     Set<String> validExtensions,
     bool recursive, {
-    bool includeHiddenFiles = false,
+    bool ignoreHiddenFiles = true,
   }) async {
     try {
       final rootDir = Directory(romFolderPath);
@@ -885,7 +882,7 @@ class SqliteDatabaseService {
         for (final child in children) {
           if (await _shouldSkipStandardEntity(
             child,
-            includeHiddenFiles: includeHiddenFiles,
+            ignoreHiddenFiles: ignoreHiddenFiles,
           )) {
             continue;
           }
@@ -905,7 +902,7 @@ class SqliteDatabaseService {
         systemPath,
         validExtensions,
         recursive,
-        includeHiddenFiles: includeHiddenFiles,
+        ignoreHiddenFiles: ignoreHiddenFiles,
       );
     } catch (_) {
       return [];
@@ -917,7 +914,7 @@ class SqliteDatabaseService {
     String pathStr,
     Set<String> validExtensions,
     bool recursive, {
-    bool includeHiddenFiles = false,
+    bool ignoreHiddenFiles = true,
   }) async {
     final entries = <RomEntry>[];
     try {
@@ -927,7 +924,7 @@ class SqliteDatabaseService {
       for (final entity in entities) {
         if (await _shouldSkipStandardEntity(
           entity,
-          includeHiddenFiles: includeHiddenFiles,
+          ignoreHiddenFiles: ignoreHiddenFiles,
         )) {
           continue;
         }
@@ -957,9 +954,9 @@ class SqliteDatabaseService {
 
   static bool _shouldSkipSafEntry(
     Map<String, dynamic> item, {
-    required bool includeHiddenFiles,
+    required bool ignoreHiddenFiles,
   }) {
-    if (includeHiddenFiles) return false;
+    if (!ignoreHiddenFiles) return false;
     final name = item['name']?.toString() ?? '';
     if (_isDotEntryName(name)) return true;
     if (item['isHidden'] == true) return true;
@@ -968,9 +965,9 @@ class SqliteDatabaseService {
 
   static Future<bool> _shouldSkipStandardEntity(
     FileSystemEntity entity, {
-    required bool includeHiddenFiles,
+    required bool ignoreHiddenFiles,
   }) async {
-    if (includeHiddenFiles) return false;
+    if (!ignoreHiddenFiles) return false;
 
     final name = path.basename(entity.path);
     if (_isDotEntryName(name)) return true;

--- a/lib/data/datasources/sqlite_database_service.dart
+++ b/lib/data/datasources/sqlite_database_service.dart
@@ -104,6 +104,7 @@ class SqliteDatabaseService {
   static Future<ScanSummary> scanSystemRoms(
     SystemModel system,
     List<String> romFolders, {
+    bool includeHiddenFiles = false,
     Map<String, Map<String, String>>? rootFoldersMap,
   }) async {
     if (system.id == null) {
@@ -131,6 +132,7 @@ class SqliteDatabaseService {
         system,
         romFolders,
         validExtensionsSet,
+        includeHiddenFiles: includeHiddenFiles,
         rootFoldersMap: rootFoldersMap,
       ),
       Future.delayed(const Duration(minutes: 10), () {
@@ -152,6 +154,7 @@ class SqliteDatabaseService {
     SystemModel system,
     List<String> romFolders,
     Set<String> validExtensionsSet, {
+    bool includeHiddenFiles = false,
     Map<String, Map<String, String>>? rootFoldersMap,
   }) async {
     final initialCount = await SqliteService.getRomCountForSystem(system.id!);
@@ -192,12 +195,14 @@ class SqliteDatabaseService {
                   resolvedPath,
                   validExtensionsSet,
                   system.recursiveScan,
+                  includeHiddenFiles: includeHiddenFiles,
                 );
               } else {
                 entries = await _scanStandardPath(
                   resolvedPath,
                   validExtensionsSet,
                   system.recursiveScan,
+                  includeHiddenFiles: includeHiddenFiles,
                 );
               }
             } else {
@@ -210,6 +215,7 @@ class SqliteDatabaseService {
                 folderToScan,
                 validExtensionsSet,
                 system.recursiveScan,
+                includeHiddenFiles: includeHiddenFiles,
               );
             } else {
               entries = await _scanStandardFolder(
@@ -217,6 +223,7 @@ class SqliteDatabaseService {
                 folderToScan,
                 validExtensionsSet,
                 system.recursiveScan,
+                includeHiddenFiles: includeHiddenFiles,
               );
             }
           }
@@ -783,13 +790,20 @@ class SqliteDatabaseService {
     String romFolderUri,
     String folderName,
     Set<String> validExtensions,
-    bool recursive,
-  ) async {
+    bool recursive, {
+    bool includeHiddenFiles = false,
+  }) async {
     try {
       final children = await SafDirectoryService.listFiles(romFolderUri);
       if (children.isEmpty) return [];
       String? systemTargetUri;
       for (final child in children) {
+        if (_shouldSkipSafEntry(
+          child,
+          includeHiddenFiles: includeHiddenFiles,
+        )) {
+          continue;
+        }
         if (child['isDirectory'] == true &&
             child['name'].toString().toLowerCase() ==
                 folderName.toLowerCase()) {
@@ -798,7 +812,12 @@ class SqliteDatabaseService {
         }
       }
       if (systemTargetUri == null) return [];
-      return await _scanSafUri(systemTargetUri, validExtensions, recursive);
+      return await _scanSafUri(
+        systemTargetUri,
+        validExtensions,
+        recursive,
+        includeHiddenFiles: includeHiddenFiles,
+      );
     } catch (_) {
       return [];
     }
@@ -808,18 +827,27 @@ class SqliteDatabaseService {
   static Future<List<RomEntry>> _scanSafUri(
     String uri,
     Set<String> validExtensions,
-    bool recursive,
-  ) async {
+    bool recursive, {
+    bool includeHiddenFiles = false,
+  }) async {
     final entries = <RomEntry>[];
     try {
       final content = await SafDirectoryService.listFiles(uri);
       for (final item in content) {
         final name = item['name'].toString();
         final itemUri = item['uri'].toString();
+        if (_shouldSkipSafEntry(item, includeHiddenFiles: includeHiddenFiles)) {
+          continue;
+        }
         if (item['isDirectory'] == true) {
           if (recursive) {
             entries.addAll(
-              await _scanSafUri(itemUri, validExtensions, recursive),
+              await _scanSafUri(
+                itemUri,
+                validExtensions,
+                recursive,
+                includeHiddenFiles: includeHiddenFiles,
+              ),
             );
           }
         } else {
@@ -845,8 +873,9 @@ class SqliteDatabaseService {
     String romFolderPath,
     String folderName,
     Set<String> validExtensions,
-    bool recursive,
-  ) async {
+    bool recursive, {
+    bool includeHiddenFiles = false,
+  }) async {
     try {
       final rootDir = Directory(romFolderPath);
       if (!await rootDir.exists()) return [];
@@ -854,6 +883,12 @@ class SqliteDatabaseService {
       try {
         final List<FileSystemEntity> children = await rootDir.list().toList();
         for (final child in children) {
+          if (await _shouldSkipStandardEntity(
+            child,
+            includeHiddenFiles: includeHiddenFiles,
+          )) {
+            continue;
+          }
           if (child is Directory &&
               path.basename(child.path).toLowerCase() ==
                   folderName.toLowerCase()) {
@@ -866,7 +901,12 @@ class SqliteDatabaseService {
         if (await Directory(directPath).exists()) systemPath = directPath;
       }
       if (systemPath == null) return [];
-      return await _scanStandardPath(systemPath, validExtensions, recursive);
+      return await _scanStandardPath(
+        systemPath,
+        validExtensions,
+        recursive,
+        includeHiddenFiles: includeHiddenFiles,
+      );
     } catch (_) {
       return [];
     }
@@ -876,14 +916,21 @@ class SqliteDatabaseService {
   static Future<List<RomEntry>> _scanStandardPath(
     String pathStr,
     Set<String> validExtensions,
-    bool recursive,
-  ) async {
+    bool recursive, {
+    bool includeHiddenFiles = false,
+  }) async {
     final entries = <RomEntry>[];
     try {
       final entities = await Directory(
         pathStr,
       ).list(recursive: recursive, followLinks: false).toList();
       for (final entity in entities) {
+        if (await _shouldSkipStandardEntity(
+          entity,
+          includeHiddenFiles: includeHiddenFiles,
+        )) {
+          continue;
+        }
         if (entity is File) {
           final filename = path.basename(entity.path);
           final ext = path.extension(filename).toLowerCase();
@@ -901,5 +948,32 @@ class SqliteDatabaseService {
       }
     } catch (_) {}
     return entries;
+  }
+
+  static bool _isDotEntryName(String name) {
+    final trimmed = name.trim();
+    return trimmed.isNotEmpty && trimmed.startsWith('.');
+  }
+
+  static bool _shouldSkipSafEntry(
+    Map<String, dynamic> item, {
+    required bool includeHiddenFiles,
+  }) {
+    if (includeHiddenFiles) return false;
+    final name = item['name']?.toString() ?? '';
+    if (_isDotEntryName(name)) return true;
+    if (item['isHidden'] == true) return true;
+    return false;
+  }
+
+  static Future<bool> _shouldSkipStandardEntity(
+    FileSystemEntity entity, {
+    required bool includeHiddenFiles,
+  }) async {
+    if (includeHiddenFiles) return false;
+
+    final name = path.basename(entity.path);
+    if (_isDotEntryName(name)) return true;
+    return false;
   }
 }

--- a/lib/data/datasources/sqlite_migrations.dart
+++ b/lib/data/datasources/sqlite_migrations.dart
@@ -252,9 +252,6 @@ class SqliteMigrations {
       case 82:
         await _migrateToVersion82(db);
         break;
-      case 83:
-        await _migrateToVersion83(db);
-        break;
       default:
         _log.w('No migration defined for version $version');
     }
@@ -4324,32 +4321,9 @@ class SqliteMigrations {
     }
   }
 
-  /// Migration to version 82: Add include_hidden_files column to user_config.
+  /// Migration to version 82: Add ignore_hidden_files column to user_config.
   static Future<void> _migrateToVersion82(Database db) async {
-    _log.i('Migration v82: Adding include_hidden_files to user_config');
-
-    try {
-      final tableInfo = db.select('PRAGMA table_info(user_config)');
-      final columns = tableInfo.map((c) => c['name'].toString()).toList();
-
-      if (!columns.contains('include_hidden_files')) {
-        db.execute(
-          'ALTER TABLE user_config ADD COLUMN include_hidden_files INTEGER DEFAULT 0',
-        );
-        _log.i('Column include_hidden_files added');
-      } else {
-        _log.i('Column include_hidden_files already exists');
-      }
-    } catch (e, stackTrace) {
-      _log.e('Error in migration v82: $e');
-      _log.e('   StackTrace: $stackTrace');
-      rethrow;
-    }
-  }
-
-  /// Migration to version 83: Add ignore_hidden_files column to user_config.
-  static Future<void> _migrateToVersion83(Database db) async {
-    _log.i('Migration v83: Adding ignore_hidden_files to user_config');
+    _log.i('Migration v82: Adding ignore_hidden_files to user_config');
 
     try {
       final tableInfo = db.select('PRAGMA table_info(user_config)');
@@ -4364,7 +4338,7 @@ class SqliteMigrations {
         _log.i('Column ignore_hidden_files already exists');
       }
     } catch (e, stackTrace) {
-      _log.e('Error in migration v83: $e');
+      _log.e('Error in migration v82: $e');
       _log.e('   StackTrace: $stackTrace');
       rethrow;
     }

--- a/lib/data/datasources/sqlite_migrations.dart
+++ b/lib/data/datasources/sqlite_migrations.dart
@@ -249,6 +249,12 @@ class SqliteMigrations {
       case 81:
         await _migrateToVersion81(db);
         break;
+      case 82:
+        await _migrateToVersion82(db);
+        break;
+      case 83:
+        await _migrateToVersion83(db);
+        break;
       default:
         _log.w('No migration defined for version $version');
     }
@@ -4313,6 +4319,52 @@ class SqliteMigrations {
       _log.i('Migration v77 completed');
     } catch (e, stackTrace) {
       _log.e('Error in migration v77: $e');
+      _log.e('   StackTrace: $stackTrace');
+      rethrow;
+    }
+  }
+
+  /// Migration to version 82: Add include_hidden_files column to user_config.
+  static Future<void> _migrateToVersion82(Database db) async {
+    _log.i('Migration v82: Adding include_hidden_files to user_config');
+
+    try {
+      final tableInfo = db.select('PRAGMA table_info(user_config)');
+      final columns = tableInfo.map((c) => c['name'].toString()).toList();
+
+      if (!columns.contains('include_hidden_files')) {
+        db.execute(
+          'ALTER TABLE user_config ADD COLUMN include_hidden_files INTEGER DEFAULT 0',
+        );
+        _log.i('Column include_hidden_files added');
+      } else {
+        _log.i('Column include_hidden_files already exists');
+      }
+    } catch (e, stackTrace) {
+      _log.e('Error in migration v82: $e');
+      _log.e('   StackTrace: $stackTrace');
+      rethrow;
+    }
+  }
+
+  /// Migration to version 83: Add ignore_hidden_files column to user_config.
+  static Future<void> _migrateToVersion83(Database db) async {
+    _log.i('Migration v83: Adding ignore_hidden_files to user_config');
+
+    try {
+      final tableInfo = db.select('PRAGMA table_info(user_config)');
+      final columns = tableInfo.map((c) => c['name'].toString()).toList();
+
+      if (!columns.contains('ignore_hidden_files')) {
+        db.execute(
+          'ALTER TABLE user_config ADD COLUMN ignore_hidden_files INTEGER DEFAULT 1',
+        );
+        _log.i('Column ignore_hidden_files added');
+      } else {
+        _log.i('Column ignore_hidden_files already exists');
+      }
+    } catch (e, stackTrace) {
+      _log.e('Error in migration v83: $e');
       _log.e('   StackTrace: $stackTrace');
       rethrow;
     }

--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -421,7 +421,7 @@ class SqliteService {
   SqliteService._internal();
 
   // Database configuration
-  static const int _databaseVersion = 83;
+  static const int _databaseVersion = 82;
   static const String _databaseName = 'data.sqlite';
 
   DatabaseAdapter? _database;

--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -421,7 +421,7 @@ class SqliteService {
   SqliteService._internal();
 
   // Database configuration
-  static const int _databaseVersion = 81;
+  static const int _databaseVersion = 83;
   static const String _databaseName = 'data.sqlite';
 
   DatabaseAdapter? _database;
@@ -1484,6 +1484,7 @@ class SqliteService {
         is_fullscreen INTEGER DEFAULT 1,
         bartop_exit_poweroff INTEGER DEFAULT 0,
         scan_on_startup INTEGER DEFAULT 1,
+        ignore_hidden_files INTEGER DEFAULT 1,
         setup_completed INTEGER DEFAULT 0,
         hide_bottom_screen INTEGER DEFAULT 0,
         sfx_enabled INTEGER DEFAULT 1,
@@ -2182,6 +2183,7 @@ class SqliteService {
     int? isFullscreen,
     int? bartopExitPoweroff,
     int? scanOnStartup,
+    int? ignoreHiddenFiles,
     int? setupCompleted,
     int? hideBottomScreen,
     int? sfxEnabled,
@@ -2224,6 +2226,9 @@ class SqliteService {
     }
     if (scanOnStartup != null) {
       newConfig['scan_on_startup'] = scanOnStartup;
+    }
+    if (ignoreHiddenFiles != null) {
+      newConfig['ignore_hidden_files'] = ignoreHiddenFiles;
     }
     if (setupCompleted != null) {
       newConfig['setup_completed'] = setupCompleted;

--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -117,9 +117,9 @@ mixin AppLocale {
       'error_configuring_retroarch_path';
   static const String scanOnStartup = 'scan_on_startup';
   static const String scanOnStartupSubtitle = 'scan_on_startup_subtitle';
-  static const String includeHiddenFiles = 'include_hidden_files';
-  static const String includeHiddenFilesSubtitle =
-      'include_hidden_files_subtitle';
+  static const String ignoreHiddenFiles = 'ignore_hidden_files';
+  static const String ignoreHiddenFilesSubtitle =
+      'ignore_hidden_files_subtitle';
   static const String autoUpdateApp = 'auto_update_app';
   static const String autoUpdateAppSubtitle = 'auto_update_app_subtitle';
   static const String autoUpdateSystems = 'auto_update_systems';

--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -117,6 +117,9 @@ mixin AppLocale {
       'error_configuring_retroarch_path';
   static const String scanOnStartup = 'scan_on_startup';
   static const String scanOnStartupSubtitle = 'scan_on_startup_subtitle';
+  static const String includeHiddenFiles = 'include_hidden_files';
+  static const String includeHiddenFilesSubtitle =
+      'include_hidden_files_subtitle';
   static const String autoUpdateApp = 'auto_update_app';
   static const String autoUpdateAppSubtitle = 'auto_update_app_subtitle';
   static const String autoUpdateSystems = 'auto_update_systems';

--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -103,6 +103,9 @@ const Map<String, dynamic> appLocaleDe = {
   AppLocale.scanOnStartup: 'Ordner beim Start scannen',
   AppLocale.scanOnStartupSubtitle:
       'Scant ROM-Ordner automatisch beim Öffnen der App',
+  AppLocale.ignoreHiddenFiles: 'Versteckte Elemente ignorieren',
+  AppLocale.ignoreHiddenFilesSubtitle:
+      'Versteckte Dateien und Ordner beim ROM-Scan ausblenden',
   AppLocale.autoUpdateApp: 'App automatisch aktualisieren',
   AppLocale.autoUpdateAppSubtitle:
       'Beim Start nach neuen App-Versionen suchen und zum Update auffordern',

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -98,8 +98,8 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.scanOnStartup: 'Scan folders on Startup',
   AppLocale.scanOnStartupSubtitle:
       'Automatically scan ROM folders when the application starts',
-  AppLocale.includeHiddenFiles: 'Ignore hidden items',
-  AppLocale.includeHiddenFilesSubtitle:
+  AppLocale.ignoreHiddenFiles: 'Ignore hidden items',
+  AppLocale.ignoreHiddenFilesSubtitle:
       'Hide hidden files and folders during ROM scans',
   AppLocale.autoUpdateApp: 'Auto-update App',
   AppLocale.autoUpdateAppSubtitle:

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -98,6 +98,9 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.scanOnStartup: 'Scan folders on Startup',
   AppLocale.scanOnStartupSubtitle:
       'Automatically scan ROM folders when the application starts',
+  AppLocale.includeHiddenFiles: 'Ignore hidden files in scan',
+  AppLocale.includeHiddenFilesSubtitle:
+      'Hide files and folders that start with "." (including ._* AppleDouble sidecars)',
   AppLocale.autoUpdateApp: 'Auto-update App',
   AppLocale.autoUpdateAppSubtitle:
       'Check for new app versions on startup and prompt to update',

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -98,9 +98,9 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.scanOnStartup: 'Scan folders on Startup',
   AppLocale.scanOnStartupSubtitle:
       'Automatically scan ROM folders when the application starts',
-  AppLocale.includeHiddenFiles: 'Ignore hidden files in scan',
+  AppLocale.includeHiddenFiles: 'Ignore hidden items',
   AppLocale.includeHiddenFilesSubtitle:
-      'Hide files and folders that start with "." (including ._* AppleDouble sidecars)',
+      'Hide hidden files and folders during ROM scans',
   AppLocale.autoUpdateApp: 'Auto-update App',
   AppLocale.autoUpdateAppSubtitle:
       'Check for new app versions on startup and prompt to update',

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -105,6 +105,9 @@ const Map<String, dynamic> appLocaleEs = {
   AppLocale.scanOnStartup: 'Escanear al Iniciar',
   AppLocale.scanOnStartupSubtitle:
       'Escanear carpetas de ROMs automáticamente al iniciar la app',
+  AppLocale.ignoreHiddenFiles: 'Ignorar elementos ocultos',
+  AppLocale.ignoreHiddenFilesSubtitle:
+      'Ocultar archivos y carpetas ocultos durante el escaneo de ROMs',
   AppLocale.autoUpdateApp: 'Actualización automática de la App',
   AppLocale.autoUpdateAppSubtitle:
       'Verificar nuevas versiones al iniciar y notificar para actualizar',

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -107,8 +107,11 @@ const Map<String, dynamic> appLocaleFr = {
       'Erreur lors de la configuration du chemin RetroArch : {error}',
   AppLocale.scanOnStartup: 'Analyser les dossiers au démarrage',
   AppLocale.scanOnStartupSubtitle:
-      'Analyse automatiquement les dossiers de ROMs à l’ouverture de l’application',
-  AppLocale.autoUpdateApp: 'Mise à jour auto - App',
+      ‘Analyse automatiquement les dossiers de ROMs à l’ouverture de l’application’,
+  AppLocale.ignoreHiddenFiles: ‘Ignorer les éléments cachés’,
+  AppLocale.ignoreHiddenFilesSubtitle:
+      ‘Masquer les fichiers et dossiers cachés lors des analyses de ROMs’,
+  AppLocale.autoUpdateApp: ‘Mise à jour auto - App’,
   AppLocale.autoUpdateAppSubtitle:
       'Vérifier les nouvelles versions au démarrage et proposer une mise à jour',
   AppLocale.autoUpdateSystems: 'Mise à jour Systèmes & Émulateurs',

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -102,6 +102,9 @@ const Map<String, dynamic> appLocaleId = {
   AppLocale.scanOnStartup: 'Pindai folder saat mulai',
   AppLocale.scanOnStartupSubtitle:
       'Pindai folder ROM secara otomatis saat membuka aplikasi',
+  AppLocale.ignoreHiddenFiles: 'Abaikan item tersembunyi',
+  AppLocale.ignoreHiddenFilesSubtitle:
+      'Sembunyikan file dan folder tersembunyi saat pemindaian ROM',
   AppLocale.autoUpdateApp: 'Perbarui App Otomatis',
   AppLocale.autoUpdateAppSubtitle:
       'Periksa versi baru saat mulai dan tawarkan pembaruan',

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -104,8 +104,11 @@ const Map<String, dynamic> appLocaleIt = {
       'Errore durante la configurazione del percorso RetroArch: {error}',
   AppLocale.scanOnStartup: 'Scansiona cartelle all’avvio',
   AppLocale.scanOnStartupSubtitle:
-      'Scansiona automaticamente le cartelle ROM all’apertura dell’app',
-  AppLocale.autoUpdateApp: 'Aggiornamento automatico App',
+      ‘Scansiona automaticamente le cartelle ROM all’apertura dell’app’,
+  AppLocale.ignoreHiddenFiles: ‘Ignora elementi nascosti’,
+  AppLocale.ignoreHiddenFilesSubtitle:
+      ‘Nascondi file e cartelle nascosti durante la scansione delle ROM’,
+  AppLocale.autoUpdateApp: ‘Aggiornamento automatico App’,
   AppLocale.autoUpdateAppSubtitle:
       'Cerca nuove versioni all’avvio e chiedi di aggiornare',
   AppLocale.autoUpdateSystems: 'Aggiorna Sistemi ed Emulatori',

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -90,6 +90,8 @@ const Map<String, dynamic> appLocaleJa = {
       'RetroArchのパス設定中にエラーが発生しました: {error}',
   AppLocale.scanOnStartup: '起動時にフォルダをスキャン',
   AppLocale.scanOnStartupSubtitle: 'アプリ起動時にROMフォルダを自動的にスキャン',
+  AppLocale.ignoreHiddenFiles: '隠しアイテムを無視',
+  AppLocale.ignoreHiddenFilesSubtitle: 'ROMスキャン中に隠しファイルとフォルダを非表示にする',
   AppLocale.autoUpdateApp: 'アプリの自動更新',
   AppLocale.autoUpdateAppSubtitle: '起動時に新しいバージョンを確認して更新を提案',
   AppLocale.autoUpdateSystems: 'システム＆エミュレータを更新',

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -104,6 +104,9 @@ const Map<String, dynamic> appLocalePt = {
   AppLocale.scanOnStartup: 'Varrer pastas ao iniciar',
   AppLocale.scanOnStartupSubtitle:
       'Varre automaticamente as pastas de ROMs ao abrir o aplicativo',
+  AppLocale.ignoreHiddenFiles: 'Ignorar itens ocultos',
+  AppLocale.ignoreHiddenFilesSubtitle:
+      'Ocultar arquivos e pastas ocultos durante a varredura de ROMs',
   AppLocale.autoUpdateApp: 'Atualização automática do App',
   AppLocale.autoUpdateAppSubtitle:
       'Verificar novas versões ao iniciar e notificar para atualizar',

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -102,6 +102,9 @@ const Map<String, dynamic> appLocaleRu = {
   AppLocale.scanOnStartup: 'Сканировать папки при запуске',
   AppLocale.scanOnStartupSubtitle:
       'Автоматически сканировать папки ROM при запуске приложения',
+  AppLocale.ignoreHiddenFiles: 'Игнорировать скрытые элементы',
+  AppLocale.ignoreHiddenFilesSubtitle:
+      'Скрывать скрытые файлы и папки при сканировании ROM',
   AppLocale.autoUpdateApp: 'Авто-обновление приложения',
   AppLocale.autoUpdateAppSubtitle:
       'Проверять новые версии при запуске и предлагать обновление',

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -89,6 +89,8 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.errorConfiguringRetroArchPath: '配置 RetroArch 路径时出错: {error}',
   AppLocale.scanOnStartup: '启动时扫描文件夹',
   AppLocale.scanOnStartupSubtitle: '应用程序启动时自动扫描 ROM 文件夹',
+  AppLocale.ignoreHiddenFiles: '忽略隐藏项目',
+  AppLocale.ignoreHiddenFilesSubtitle: 'ROM 扫描期间隐藏隐藏文件和文件夹',
   AppLocale.autoUpdateApp: '自动更新应用',
   AppLocale.autoUpdateAppSubtitle: '启动时检查新版本并提示更新',
   AppLocale.autoUpdateSystems: '自动更新系统和模拟器',

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -89,6 +89,8 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.errorConfiguringRetroArchPath: '設定 RetroArch 路徑時發生錯誤: {error}',
   AppLocale.scanOnStartup: '啟動時掃描資料夾',
   AppLocale.scanOnStartupSubtitle: '應用程式啟動時自動掃描 ROM 資料夾',
+  AppLocale.ignoreHiddenFiles: '忽略隱藏項目',
+  AppLocale.ignoreHiddenFilesSubtitle: 'ROM 掃描期間隱藏隱藏檔案和資料夾',
   AppLocale.autoUpdateApp: '自動更新應用程式',
   AppLocale.autoUpdateAppSubtitle: '啟動時檢查新版本並提示更新',
   AppLocale.autoUpdateSystems: '自動更新系統和模擬器',

--- a/lib/models/config_model.dart
+++ b/lib/models/config_model.dart
@@ -35,8 +35,8 @@ class ConfigModel {
   /// Whether to automatically trigger a ROM scan when the application starts.
   final bool scanOnStartup;
 
-  /// Whether hidden files/folders (dot-prefixed) should be included during ROM scan.
-  final bool includeHiddenFiles;
+  /// Whether hidden files/folders (dot-prefixed) should be ignored during ROM scan.
+  final bool ignoreHiddenFiles;
 
   /// Whether the initial onboarding/setup process has been finished.
   final bool setupCompleted;
@@ -83,7 +83,7 @@ class ConfigModel {
     this.isFullscreen = true,
     this.bartopExitPoweroff = false,
     this.scanOnStartup = true,
-    this.includeHiddenFiles = false,
+    this.ignoreHiddenFiles = true,
     this.setupCompleted = false,
     this.hideBottomScreen = false,
     this.videoSound = false,
@@ -145,12 +145,12 @@ class ConfigModel {
           'true',
       scanOnStartup:
           (json['scanOnStartup'] ?? true).toString().toLowerCase() == 'true',
-      includeHiddenFiles:
-          !(((json['ignoreHiddenFiles'] ?? json['ignore_hidden_files'] ?? 1)
-                      .toString() ==
-                  '1') ||
-              (json['ignoreHiddenFiles'] ?? true).toString().toLowerCase() ==
-                  'true'),
+      ignoreHiddenFiles:
+          ((json['ignoreHiddenFiles'] ?? json['ignore_hidden_files'] ?? 1)
+                  .toString() ==
+              '1') ||
+          (json['ignoreHiddenFiles'] ?? true).toString().toLowerCase() ==
+              'true',
       setupCompleted:
           (json['setupCompleted'] ?? false).toString().toLowerCase() ==
               'true' ||
@@ -215,7 +215,7 @@ class ConfigModel {
       'isFullscreen': isFullscreen,
       'bartopExitPoweroff': bartopExitPoweroff,
       'scanOnStartup': scanOnStartup,
-      'includeHiddenFiles': includeHiddenFiles,
+      'ignoreHiddenFiles': ignoreHiddenFiles,
       'setupCompleted': setupCompleted,
       'hideBottomScreen': hideBottomScreen,
       'videoSound': videoSound,
@@ -243,7 +243,7 @@ class ConfigModel {
     bool? isFullscreen,
     bool? bartopExitPoweroff,
     bool? scanOnStartup,
-    bool? includeHiddenFiles,
+    bool? ignoreHiddenFiles,
     bool? setupCompleted,
     bool? hideBottomScreen,
     bool? videoSound,
@@ -268,7 +268,7 @@ class ConfigModel {
       isFullscreen: isFullscreen ?? this.isFullscreen,
       bartopExitPoweroff: bartopExitPoweroff ?? this.bartopExitPoweroff,
       scanOnStartup: scanOnStartup ?? this.scanOnStartup,
-      includeHiddenFiles: includeHiddenFiles ?? this.includeHiddenFiles,
+      ignoreHiddenFiles: ignoreHiddenFiles ?? this.ignoreHiddenFiles,
       setupCompleted: setupCompleted ?? this.setupCompleted,
       hideBottomScreen: hideBottomScreen ?? this.hideBottomScreen,
       videoSound: videoSound ?? this.videoSound,
@@ -288,6 +288,6 @@ class ConfigModel {
 
   @override
   String toString() {
-    return 'ConfigModel(romFolders: ${romFolders.length}, detectedSystems: ${detectedSystems.length}, emulators: ${emulators.length}, showGameInfo: $showGameInfo, isFullscreen: $isFullscreen, bartopExitPoweroff: $bartopExitPoweroff, scanOnStartup: $scanOnStartup, includeHiddenFiles: $includeHiddenFiles, setupCompleted: $setupCompleted, hideBottomScreen: $hideBottomScreen, videoSound: $videoSound)';
+    return 'ConfigModel(romFolders: ${romFolders.length}, detectedSystems: ${detectedSystems.length}, emulators: ${emulators.length}, showGameInfo: $showGameInfo, isFullscreen: $isFullscreen, bartopExitPoweroff: $bartopExitPoweroff, scanOnStartup: $scanOnStartup, ignoreHiddenFiles: $ignoreHiddenFiles, setupCompleted: $setupCompleted, hideBottomScreen: $hideBottomScreen, videoSound: $videoSound)';
   }
 }

--- a/lib/models/config_model.dart
+++ b/lib/models/config_model.dart
@@ -35,6 +35,9 @@ class ConfigModel {
   /// Whether to automatically trigger a ROM scan when the application starts.
   final bool scanOnStartup;
 
+  /// Whether hidden files/folders (dot-prefixed) should be included during ROM scan.
+  final bool includeHiddenFiles;
+
   /// Whether the initial onboarding/setup process has been finished.
   final bool setupCompleted;
 
@@ -80,6 +83,7 @@ class ConfigModel {
     this.isFullscreen = true,
     this.bartopExitPoweroff = false,
     this.scanOnStartup = true,
+    this.includeHiddenFiles = false,
     this.setupCompleted = false,
     this.hideBottomScreen = false,
     this.videoSound = false,
@@ -141,6 +145,12 @@ class ConfigModel {
           'true',
       scanOnStartup:
           (json['scanOnStartup'] ?? true).toString().toLowerCase() == 'true',
+      includeHiddenFiles:
+          !(((json['ignoreHiddenFiles'] ?? json['ignore_hidden_files'] ?? 1)
+                      .toString() ==
+                  '1') ||
+              (json['ignoreHiddenFiles'] ?? true).toString().toLowerCase() ==
+                  'true'),
       setupCompleted:
           (json['setupCompleted'] ?? false).toString().toLowerCase() ==
               'true' ||
@@ -205,6 +215,7 @@ class ConfigModel {
       'isFullscreen': isFullscreen,
       'bartopExitPoweroff': bartopExitPoweroff,
       'scanOnStartup': scanOnStartup,
+      'includeHiddenFiles': includeHiddenFiles,
       'setupCompleted': setupCompleted,
       'hideBottomScreen': hideBottomScreen,
       'videoSound': videoSound,
@@ -232,6 +243,7 @@ class ConfigModel {
     bool? isFullscreen,
     bool? bartopExitPoweroff,
     bool? scanOnStartup,
+    bool? includeHiddenFiles,
     bool? setupCompleted,
     bool? hideBottomScreen,
     bool? videoSound,
@@ -256,6 +268,7 @@ class ConfigModel {
       isFullscreen: isFullscreen ?? this.isFullscreen,
       bartopExitPoweroff: bartopExitPoweroff ?? this.bartopExitPoweroff,
       scanOnStartup: scanOnStartup ?? this.scanOnStartup,
+      includeHiddenFiles: includeHiddenFiles ?? this.includeHiddenFiles,
       setupCompleted: setupCompleted ?? this.setupCompleted,
       hideBottomScreen: hideBottomScreen ?? this.hideBottomScreen,
       videoSound: videoSound ?? this.videoSound,
@@ -275,6 +288,6 @@ class ConfigModel {
 
   @override
   String toString() {
-    return 'ConfigModel(romFolders: ${romFolders.length}, detectedSystems: ${detectedSystems.length}, emulators: ${emulators.length}, showGameInfo: $showGameInfo, isFullscreen: $isFullscreen, bartopExitPoweroff: $bartopExitPoweroff, scanOnStartup: $scanOnStartup, setupCompleted: $setupCompleted, hideBottomScreen: $hideBottomScreen, videoSound: $videoSound)';
+    return 'ConfigModel(romFolders: ${romFolders.length}, detectedSystems: ${detectedSystems.length}, emulators: ${emulators.length}, showGameInfo: $showGameInfo, isFullscreen: $isFullscreen, bartopExitPoweroff: $bartopExitPoweroff, scanOnStartup: $scanOnStartup, includeHiddenFiles: $includeHiddenFiles, setupCompleted: $setupCompleted, hideBottomScreen: $hideBottomScreen, videoSound: $videoSound)';
   }
 }

--- a/lib/providers/sqlite_config_provider.dart
+++ b/lib/providers/sqlite_config_provider.dart
@@ -715,6 +715,7 @@ class SqliteConfigProvider extends ChangeNotifier {
       final summary = await SqliteDatabaseService.scanSystemRoms(
         system,
         _config.romFolders,
+        includeHiddenFiles: _config.includeHiddenFiles,
         rootFoldersMap: rootFoldersMap,
       );
 
@@ -1139,6 +1140,18 @@ class SqliteConfigProvider extends ChangeNotifier {
     _config = _config.copyWith(scanOnStartup: value);
     await SqliteConfigService.saveConfig(_config);
     notifyListeners();
+  }
+
+  /// Updates whether hidden files/folders are included during ROM scans.
+  Future<void> updateIncludeHiddenFiles(bool value) async {
+    _config = _config.copyWith(includeHiddenFiles: value);
+    await SqliteConfigService.saveConfig(_config);
+    notifyListeners();
+  }
+
+  /// Updates whether hidden files/folders are ignored during ROM scans.
+  Future<void> updateIgnoreHiddenFiles(bool ignoreHiddenFiles) async {
+    await updateIncludeHiddenFiles(!ignoreHiddenFiles);
   }
 
   /// Updates whether UI navigation SFX sounds are enabled

--- a/lib/providers/sqlite_config_provider.dart
+++ b/lib/providers/sqlite_config_provider.dart
@@ -715,7 +715,7 @@ class SqliteConfigProvider extends ChangeNotifier {
       final summary = await SqliteDatabaseService.scanSystemRoms(
         system,
         _config.romFolders,
-        includeHiddenFiles: _config.includeHiddenFiles,
+        ignoreHiddenFiles: _config.ignoreHiddenFiles,
         rootFoldersMap: rootFoldersMap,
       );
 
@@ -1142,16 +1142,11 @@ class SqliteConfigProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Updates whether hidden files/folders are included during ROM scans.
-  Future<void> updateIncludeHiddenFiles(bool value) async {
-    _config = _config.copyWith(includeHiddenFiles: value);
-    await SqliteConfigService.saveConfig(_config);
-    notifyListeners();
-  }
-
   /// Updates whether hidden files/folders are ignored during ROM scans.
   Future<void> updateIgnoreHiddenFiles(bool ignoreHiddenFiles) async {
-    await updateIncludeHiddenFiles(!ignoreHiddenFiles);
+    _config = _config.copyWith(ignoreHiddenFiles: ignoreHiddenFiles);
+    await SqliteConfigService.saveConfig(_config);
+    notifyListeners();
   }
 
   /// Updates whether UI navigation SFX sounds are enabled

--- a/lib/screens/settings_screen/new_settings_options/directories_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/directories_settings_content.dart
@@ -593,8 +593,8 @@ class DirectoriesSettingsContentState
                 // Visual items = navigable items + 1 section header after index 1
                 itemCount: _directoryItems.length + 1,
                 itemBuilder: (context, visualIndex) {
-                  // Insert "ROM Directories" section header after user_data + rescan (nav 0,1).
-                  // Visual index 2 = section header; visual index > 2 maps to nav index - 1.
+                  // Insert "ROM Directories" section header after user_data + rescan (nav indices 0,1)
+                  // Visual index 2 = section header; visual index > 2 maps to nav index - 1
                   if (visualIndex == 2) {
                     return _buildSectionHeader(
                       theme,

--- a/lib/screens/settings_screen/new_settings_options/directories_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/directories_settings_content.dart
@@ -593,8 +593,8 @@ class DirectoriesSettingsContentState
                 // Visual items = navigable items + 1 section header after index 1
                 itemCount: _directoryItems.length + 1,
                 itemBuilder: (context, visualIndex) {
-                  // Insert "ROM Directories" section header after user_data + rescan (nav indices 0,1)
-                  // Visual index 2 = section header; visual index > 2 maps to nav index - 1
+                  // Insert "ROM Directories" section header after user_data + rescan (nav 0,1).
+                  // Visual index 2 = section header; visual index > 2 maps to nav index - 1.
                   if (visualIndex == 2) {
                     return _buildSectionHeader(
                       theme,

--- a/lib/screens/settings_screen/new_settings_options/general_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/general_settings_content.dart
@@ -461,7 +461,7 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
                     ),
                   ),
                   CustomToggleSwitch(
-                    value: !config.includeHiddenFiles,
+                    value: config.ignoreHiddenFiles,
                     onChanged: (value) {
                       context
                           .read<SqliteConfigProvider>()

--- a/lib/screens/settings_screen/new_settings_options/general_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/general_settings_content.dart
@@ -434,7 +434,7 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Text(
-                          AppLocale.includeHiddenFiles.getString(context),
+                          AppLocale.ignoreHiddenFiles.getString(context),
                           style: theme.textTheme.bodyLarge?.copyWith(
                             fontSize: 12.r,
                             fontWeight: FontWeight.w500,
@@ -447,7 +447,7 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
                         ),
                         SizedBox(height: 4.r),
                         Text(
-                          AppLocale.includeHiddenFilesSubtitle.getString(
+                          AppLocale.ignoreHiddenFilesSubtitle.getString(
                             context,
                           ),
                           style: theme.textTheme.bodyMedium?.copyWith(

--- a/lib/screens/settings_screen/new_settings_options/general_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/general_settings_content.dart
@@ -402,6 +402,78 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
             );
           }(),
 
+          // Setting: Ignore hidden files in scan.
+          SizedBox(height: 12.r),
+          () {
+            final index = currentItemIdx++;
+            return Container(
+              key: _itemKeys[index],
+              padding: EdgeInsets.only(
+                left: 12.r,
+                right: 12.r,
+                top: 6.r,
+                bottom: 6.r,
+              ),
+              decoration: BoxDecoration(
+                color: theme.cardColor.withValues(alpha: 0.25),
+                borderRadius: BorderRadius.circular(8.r),
+                border: Border.all(
+                  color:
+                      widget.isContentFocused &&
+                          widget.selectedContentIndex == index
+                      ? theme.colorScheme.primary
+                      : Colors.transparent,
+                  width: 2,
+                ),
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          AppLocale.includeHiddenFiles.getString(context),
+                          style: theme.textTheme.bodyLarge?.copyWith(
+                            fontSize: 12.r,
+                            fontWeight: FontWeight.w500,
+                            color:
+                                widget.isContentFocused &&
+                                    widget.selectedContentIndex == index
+                                ? theme.colorScheme.primary
+                                : theme.colorScheme.onSurface,
+                          ),
+                        ),
+                        SizedBox(height: 4.r),
+                        Text(
+                          AppLocale.includeHiddenFilesSubtitle.getString(
+                            context,
+                          ),
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            fontSize: 9.r,
+                            color: theme.colorScheme.onSurface.withValues(
+                              alpha: 0.6,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  CustomToggleSwitch(
+                    value: !config.includeHiddenFiles,
+                    onChanged: (value) {
+                      context
+                          .read<SqliteConfigProvider>()
+                          .updateIgnoreHiddenFiles(value);
+                    },
+                    activeColor: theme.colorScheme.primary,
+                  ),
+                ],
+              ),
+            );
+          }(),
+
           // Setting: Auto-update App.
           SizedBox(height: 12.r),
           () {

--- a/test/config_repository_test.dart
+++ b/test/config_repository_test.dart
@@ -65,5 +65,12 @@ void main() {
       expect(config, isNotNull);
       expect(config!['last_scan'], '2024-01-01');
     });
+
+    test('ignore_hidden_files defaults to enabled (1)', () async {
+      await ConfigRepository.saveUserConfig(lastScan: '2024-01-01');
+      final config = await ConfigRepository.getUserConfig();
+      expect(config, isNotNull);
+      expect(config!['ignore_hidden_files'], anyOf(1, '1'));
+    });
   });
 }

--- a/test/database_test_helper.dart
+++ b/test/database_test_helper.dart
@@ -70,6 +70,8 @@ class DatabaseTestHelper {
         is_favorite INTEGER DEFAULT 0,
         play_time INTEGER DEFAULT 0,
         last_played TEXT,
+        created_at TEXT,
+        updated_at TEXT,
         app_emulator_unique_id TEXT,
         app_emulator_os_id INTEGER
       )
@@ -88,6 +90,7 @@ class DatabaseTestHelper {
         is_fullscreen INTEGER,
         bartop_exit_poweroff INTEGER,
         scan_on_startup INTEGER,
+        ignore_hidden_files INTEGER DEFAULT 1,
         setup_completed INTEGER,
         hide_bottom_screen INTEGER,
         sfx_enabled INTEGER,

--- a/test/sqlite_database_service_hidden_files_test.dart
+++ b/test/sqlite_database_service_hidden_files_test.dart
@@ -1,0 +1,98 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/data/datasources/sqlite_database_service.dart';
+import 'package:neostation/models/system_model.dart';
+
+import 'database_test_helper.dart';
+
+void main() {
+  final dbHelper = DatabaseTestHelper();
+  late dynamic db;
+
+  setUp(() async {
+    db = await dbHelper.setUp();
+    await db.execute(
+      "INSERT INTO app_systems (id, real_name, folder_name) VALUES ('snes', 'Super Nintendo', 'snes')",
+    );
+    await db.execute(
+      "INSERT INTO app_system_extensions (system_id, extension) VALUES ('snes', 'smc')",
+    );
+  });
+
+  tearDown(() async {
+    await dbHelper.tearDown();
+  });
+
+  group('SqliteDatabaseService hidden file filtering', () {
+    test('ignores dotfiles by default (including AppleDouble ._*)', () async {
+      final root = await Directory.systemTemp.createTemp('neostation_scan_');
+      addTearDown(() async {
+        if (await root.exists()) {
+          await root.delete(recursive: true);
+        }
+      });
+
+      final snesDir = Directory('${root.path}/snes')
+        ..createSync(recursive: true);
+      File('${snesDir.path}/good.smc').writeAsStringSync('ok');
+      File('${snesDir.path}/._good.smc').writeAsStringSync('appledouble');
+      File('${snesDir.path}/.hidden.smc').writeAsStringSync('hidden');
+
+      final system = SystemModel(
+        id: 'snes',
+        realName: 'Super Nintendo',
+        folderName: 'snes',
+        iconImage: '',
+        color: '#000000',
+        recursiveScan: true,
+      );
+
+      await SqliteDatabaseService.scanSystemRoms(system, [
+        root.path,
+      ], includeHiddenFiles: false);
+
+      final rows = await db.rawQuery(
+        "SELECT filename FROM user_roms WHERE app_system_id = 'snes' ORDER BY filename",
+      );
+      final names = rows.map((r) => r['filename']).toList();
+
+      expect(names, ['good.smc']);
+    });
+
+    test('includes dotfiles when includeHiddenFiles is true', () async {
+      final root = await Directory.systemTemp.createTemp('neostation_scan_');
+      addTearDown(() async {
+        if (await root.exists()) {
+          await root.delete(recursive: true);
+        }
+      });
+
+      final snesDir = Directory('${root.path}/snes')
+        ..createSync(recursive: true);
+      File('${snesDir.path}/good.smc').writeAsStringSync('ok');
+      File('${snesDir.path}/._good.smc').writeAsStringSync('appledouble');
+      File('${snesDir.path}/.hidden.smc').writeAsStringSync('hidden');
+
+      final system = SystemModel(
+        id: 'snes',
+        realName: 'Super Nintendo',
+        folderName: 'snes',
+        iconImage: '',
+        color: '#000000',
+        recursiveScan: true,
+      );
+
+      await SqliteDatabaseService.scanSystemRoms(system, [
+        root.path,
+      ], includeHiddenFiles: true);
+
+      final rows = await db.rawQuery(
+        "SELECT filename FROM user_roms WHERE app_system_id = 'snes' ORDER BY filename",
+      );
+      final names = rows.map((r) => r['filename']).toList();
+
+      expect(names, ['._good.smc', '.hidden.smc', 'good.smc']);
+    });
+  });
+}

--- a/test/sqlite_database_service_hidden_files_test.dart
+++ b/test/sqlite_database_service_hidden_files_test.dart
@@ -50,7 +50,7 @@ void main() {
 
       await SqliteDatabaseService.scanSystemRoms(system, [
         root.path,
-      ], includeHiddenFiles: false);
+      ], ignoreHiddenFiles: true);
 
       final rows = await db.rawQuery(
         "SELECT filename FROM user_roms WHERE app_system_id = 'snes' ORDER BY filename",
@@ -60,7 +60,7 @@ void main() {
       expect(names, ['good.smc']);
     });
 
-    test('includes dotfiles when includeHiddenFiles is true', () async {
+    test('includes dotfiles when ignoreHiddenFiles is false', () async {
       final root = await Directory.systemTemp.createTemp('neostation_scan_');
       addTearDown(() async {
         if (await root.exists()) {
@@ -85,7 +85,7 @@ void main() {
 
       await SqliteDatabaseService.scanSystemRoms(system, [
         root.path,
-      ], includeHiddenFiles: true);
+      ], ignoreHiddenFiles: false);
 
       final rows = await db.rawQuery(
         "SELECT filename FROM user_roms WHERE app_system_id = 'snes' ORDER BY filename",


### PR DESCRIPTION
## Summary
- Ignore hidden files and folders by default during ROM scans
- Add a global General setting: `Ignore hidden items`
- Persist the setting in `user_config.ignore_hidden_files` (default enabled)

## Implementation Notes
- Scanner filtering is applied in both standard filesystem and SAF paths
- Hidden filtering uses dot-name checks and SAF metadata (`isHidden`) when available
- No per-directory config introduced (current design remains global)

## Validation
- `flutter analyze` (pass)
- `flutter test` full suite (pass)

Fixes #35
