### PR TITLE
fix: change retroachievement game name fuzzy search to prefer main game ov…

### DIFF
--- a/lib/repositories/retro_achievements_repository.dart
+++ b/lib/repositories/retro_achievements_repository.dart
@@ -160,8 +160,14 @@ class RetroAchievementsRepository {
       SELECT g.game_id
       FROM app_ra_game_list g
       WHERE g.console_id = ($consoleSubquery)
-        AND g.title LIKE ?
-      ORDER BY g.title DESC
+        AND g.title LIKE ? 
+      ORDER BY
+        CASE
+          WHEN g.title LIKE '~Hack~%' THEN 1
+          WHEN g.title LIKE '%Subset%' THEN 1
+          ELSE 0
+        END,
+        g.title ASC
       LIMIT 1
       ''',
       [systemFolderName, searchPattern],


### PR DESCRIPTION
…er hacks and subsets. This fixes the issue with, for example, Castlevania: SOTN. Added Conker's Bad Fur Day to the local ra db.

# Description

Briefly describe the changes you are introducing.

I've made a small tweak to the query used to retrieve the Game ID from the internal database. There are several legitimate scenarios where hash matching will not succeed and the lookup will fall back to name-based searches (e.g. multiple supported hashes on RA, disc-based games, CHD usage).

Where multiple entries in the database match the search, the previous query the previous query sorted results alphabetically (descending) and returned the first entry. The issue with this is that ~Hack~ entries will rank before the main game. This can cause games like Castlevania: SOTN on PS1 to display the associated ~Hack~ achievements, and not those for the main game. I think generally this tweak to deprioritise the ~Hack~ and subset achievements is the correct choice to ensure the right achievement sets display for the majority of users.

Whilst I was in there, I also added Conker's Bad Fur Day to the ra_inserts.sql because it was missing (only the subset was in there). 

Fixes # (issue)

## Type of Change

- [*] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [*] I have run `flutter analyze` and there are no errors.
- [NA] I have added tests demonstrating that my fix or feature works. -- No new tests required. Simple SQL tweak. Fix validated on debug app deployed locally. All query does is order query results so that hacks and subsets are moved to the bottom of returned results. 
- [NA] I have updated the corresponding documentation.
- [*] My changes do not introduce secrets, credentials, or sensitive data.
- [NA] I have verified that any new assets have compatible licenses.
- [*] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [*] Android
- [NA] **Gamepad support verified** (if applicable).

## Screenshots (if applicable)

Add screenshots or GIFs showing the visual change.
