### PR TITLE
feat(settings): add 12-hour (AM/PM) clock option

### DIFF
--- a/lib/data/datasources/sqlite_config_service.dart
+++ b/lib/data/datasources/sqlite_config_service.dart
@@ -137,6 +137,12 @@ class SqliteConfigService {
             (int.tryParse(userConfig?['sfx_enabled']?.toString() ?? '1') ??
                 1) ==
             1,
+        use12HourClock:
+            (int.tryParse(
+                  userConfig?['use_12_hour_clock']?.toString() ?? '0',
+                ) ??
+                0) ==
+            1,
         systemSortBy:
             userConfig?['system_sort_by']?.toString() ?? 'alphabetical',
         systemSortOrder: userConfig?['system_sort_order']?.toString() ?? 'asc',
@@ -187,6 +193,7 @@ class SqliteConfigService {
         hideBottomScreen: config.hideBottomScreen ? 1 : 0,
         videoSound: config.videoSound ? 1 : 0,
         sfxEnabled: config.sfxEnabled ? 1 : 0,
+        use12HourClock: config.use12HourClock ? 1 : 0,
         systemSortBy: config.systemSortBy,
         systemSortOrder: config.systemSortOrder,
         appLanguage: config.appLanguage,

--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -1185,6 +1185,15 @@ class SqliteService {
     // FIX: Ensure user_screenscraper_config columns are up to date (v29).
     await _ensureScreenScraperConfigColumns(db);
 
+    // FIX: Ensure user_config includes the 12-hour clock column.
+    if (tableNames.contains('user_config')) {
+      try {
+        await _ensureUserConfigColumns(db);
+      } catch (e) {
+        _log.e('Minor fix for user_config columns failed: $e');
+      }
+    }
+
     // FIX: Resolve inconsistencies in default emulator assignments.
     if (tableNames.contains('app_systems') &&
         tableNames.contains('app_emulators')) {
@@ -1237,6 +1246,17 @@ class SqliteService {
       CREATE INDEX IF NOT EXISTS idx_neo_sync_state_file_path 
       ON app_neo_sync_state(file_path);
     ''');
+  }
+
+  /// Ensures the user_config table has columns added after its initial schema.
+  Future<void> _ensureUserConfigColumns(DatabaseAdapter db) async {
+    final tableInfo = await db.rawQuery('PRAGMA table_info(user_config)');
+    final columns = tableInfo.map((c) => c['name'].toString()).toList();
+    if (!columns.contains('use_12_hour_clock')) {
+      await db.execute(
+        'ALTER TABLE user_config ADD COLUMN use_12_hour_clock INTEGER DEFAULT 0',
+      );
+    }
   }
 
   /// Ensures the unique_identifier column exists in app_emulators.
@@ -1565,7 +1585,8 @@ class SqliteService {
         auto_update_app INTEGER DEFAULT 1,
         auto_update_systems INTEGER DEFAULT 1,
         system_grid_columns TEXT DEFAULT 'M',
-        game_grid_columns TEXT DEFAULT 'M'
+        game_grid_columns TEXT DEFAULT 'M',
+        use_12_hour_clock INTEGER DEFAULT 0
       );
       ''',
       '''
@@ -2258,6 +2279,7 @@ class SqliteService {
     int? setupCompleted,
     int? hideBottomScreen,
     int? sfxEnabled,
+    int? use12HourClock,
     String? systemSortBy,
     String? systemSortOrder,
     String? appLanguage,
@@ -2311,6 +2333,9 @@ class SqliteService {
     }
     if (sfxEnabled != null) {
       newConfig['sfx_enabled'] = sfxEnabled;
+    }
+    if (use12HourClock != null) {
+      newConfig['use_12_hour_clock'] = use12HourClock;
     }
     if (systemSortBy != null) {
       newConfig['system_sort_by'] = systemSortBy;

--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -127,6 +127,8 @@ mixin AppLocale {
       'auto_update_systems_subtitle';
   static const String sfxSounds = 'sfx_sounds';
   static const String sfxSoundsSubtitle = 'sfx_sounds_subtitle';
+  static const String use12HourClock = 'use_12_hour_clock';
+  static const String use12HourClockSubtitle = 'use_12_hour_clock_subtitle';
   static const String fullscreenMode = 'fullscreen_mode';
   static const String fullscreenModeSubtitle = 'fullscreen_mode_subtitle';
   static const String allFilesAccess = 'all_files_access';

--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -115,6 +115,9 @@ const Map<String, dynamic> appLocaleDe = {
   AppLocale.sfxSounds: 'Benutzeroberflächen-Sounds',
   AppLocale.sfxSoundsSubtitle:
       'Spielt Sounds für die Navigation mit Controller, Tastatur und Touch ab',
+  AppLocale.use12HourClock: '12-Stunden-Format',
+  AppLocale.use12HourClockSubtitle:
+      'Uhrzeit im 12-Stunden-Format mit AM/PM statt im 24-Stunden-Format anzeigen',
   AppLocale.fullscreenMode: 'Vollbildmodus',
   AppLocale.fullscreenModeSubtitle: 'Zeigt die App im Vollbildmodus an',
   AppLocale.allFilesAccess: 'Zugriff auf alle Dateien',

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -110,6 +110,9 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.sfxSounds: 'UI Navigation Sounds',
   AppLocale.sfxSoundsSubtitle:
       'Play sound effects for gamepad, keyboard and touch navigation',
+  AppLocale.use12HourClock: 'Use 12-Hour Clock',
+  AppLocale.use12HourClockSubtitle:
+      'Show the clock in 12-hour format with AM/PM instead of 24-hour',
   AppLocale.fullscreenMode: 'Fullscreen Mode',
   AppLocale.fullscreenModeSubtitle: 'Display the app in fullscreen mode',
   AppLocale.allFilesAccess: 'All Files Access',

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -116,6 +116,9 @@ const Map<String, dynamic> appLocaleEs = {
       'Verificar actualizaciones de sistemas y emuladores al iniciar',
   AppLocale.sfxSounds: 'Sonidos de Navegación',
   AppLocale.sfxSoundsSubtitle: 'Reproducir efectos de sonido al navegar',
+  AppLocale.use12HourClock: 'Reloj de 12 horas',
+  AppLocale.use12HourClockSubtitle:
+      'Mostrar la hora en formato de 12 horas con AM/PM en lugar de 24 horas',
   AppLocale.fullscreenMode: 'Modo Pantalla Completa',
   AppLocale.fullscreenModeSubtitle:
       'Mostrar la aplicación en pantalla completa',

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -120,6 +120,9 @@ const Map<String, dynamic> appLocaleFr = {
   AppLocale.sfxSounds: 'Sons de l’Interface',
   AppLocale.sfxSoundsSubtitle:
       'Joue des sons pour la navigation à la manette, au clavier et au tactile',
+  AppLocale.use12HourClock: 'Horloge 12 heures',
+  AppLocale.use12HourClockSubtitle:
+      'Afficher l\'heure au format 12 heures avec AM/PM au lieu de 24 heures',
   AppLocale.fullscreenMode: 'Mode Plein Écran',
   AppLocale.fullscreenModeSubtitle: 'Affiche l’application en plein écran',
   AppLocale.allFilesAccess: 'Accès à Tous les Fichiers',

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -114,6 +114,9 @@ const Map<String, dynamic> appLocaleId = {
   AppLocale.sfxSounds: 'Suara Antarmuka',
   AppLocale.sfxSoundsSubtitle:
       'Putar suara untuk navigasi dengan kontroler, keyboard, dan sentuhan',
+  AppLocale.use12HourClock: 'Format 12 Jam',
+  AppLocale.use12HourClockSubtitle:
+      'Tampilkan jam dalam format 12 jam dengan AM/PM, bukan 24 jam',
   AppLocale.fullscreenMode: 'Mode Layar Penuh',
   AppLocale.fullscreenModeSubtitle: 'Tampilkan aplikasi dalam mode layar penuh',
   AppLocale.allFilesAccess: 'Akses Semua File',

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -117,6 +117,9 @@ const Map<String, dynamic> appLocaleIt = {
   AppLocale.sfxSounds: 'Suoni Interfaccia',
   AppLocale.sfxSoundsSubtitle:
       'Riproduce suoni per la navigazione con controller, tastiera e touch',
+  AppLocale.use12HourClock: 'Orologio a 12 ore',
+  AppLocale.use12HourClockSubtitle:
+      'Mostra l\'ora nel formato a 12 ore con AM/PM invece di 24 ore',
   AppLocale.fullscreenMode: 'Modalità Schermo Intero',
   AppLocale.fullscreenModeSubtitle: 'Visualizza l’app a schermo intero',
   AppLocale.allFilesAccess: 'Accesso a Tutti i File',

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -98,6 +98,8 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.autoUpdateSystemsSubtitle: '起動時にシステムとエミュレータの設定更新を確認',
   AppLocale.sfxSounds: 'インターフェース音',
   AppLocale.sfxSoundsSubtitle: 'コントローラ、キーボード、タッチ操作時の音を再生',
+  AppLocale.use12HourClock: '12時間表示',
+  AppLocale.use12HourClockSubtitle: '24時間表示ではなく、AM/PM付きの12時間表示で時刻を表示します',
   AppLocale.fullscreenMode: 'フルスクリーンモード',
   AppLocale.fullscreenModeSubtitle: 'アプリをフルスクリーンで表示',
   AppLocale.allFilesAccess: 'すべてのファイルへのアクセス',

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -116,6 +116,9 @@ const Map<String, dynamic> appLocalePt = {
   AppLocale.sfxSounds: 'Sons de Interface',
   AppLocale.sfxSoundsSubtitle:
       'Reproduz sons para navegação por controle, teclado e toque',
+  AppLocale.use12HourClock: 'Relógio de 12 horas',
+  AppLocale.use12HourClockSubtitle:
+      'Mostrar o relógio no formato de 12 horas com AM/PM em vez de 24 horas',
   AppLocale.fullscreenMode: 'Modo Tela Cheia',
   AppLocale.fullscreenModeSubtitle: 'Exibe o aplicativo em tela cheia',
   AppLocale.allFilesAccess: 'Acesso a Todos os Arquivos',

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -114,6 +114,9 @@ const Map<String, dynamic> appLocaleRu = {
   AppLocale.sfxSounds: 'Звуки навигации UI',
   AppLocale.sfxSoundsSubtitle:
       'Воспроизводить звуковые эффекты для геймпада, клавиатуры и сенсорной навигации',
+  AppLocale.use12HourClock: '12-часовой формат',
+  AppLocale.use12HourClockSubtitle:
+      'Показывать время в 12-часовом формате с AM/PM вместо 24-часового',
   AppLocale.fullscreenMode: 'Полноэкранный режим',
   AppLocale.fullscreenModeSubtitle:
       'Отображать приложение в полноэкранном режиме',

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -97,6 +97,8 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.autoUpdateSystemsSubtitle: '启动时检查系统和模拟器配置更新',
   AppLocale.sfxSounds: '界面导航音效',
   AppLocale.sfxSoundsSubtitle: '播放手柄、键盘和触摸导航的音效',
+  AppLocale.use12HourClock: '12小时制',
+  AppLocale.use12HourClockSubtitle: '以 12 小时制（AM/PM）显示时间，而非 24 小时制',
   AppLocale.fullscreenMode: '全屏模式',
   AppLocale.fullscreenModeSubtitle: '以全屏模式显示应用',
   AppLocale.allFilesAccess: '所有文件访问权限',

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -97,6 +97,8 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.autoUpdateSystemsSubtitle: '啟動時檢查系統和模擬器設定更新',
   AppLocale.sfxSounds: '介面導航音效',
   AppLocale.sfxSoundsSubtitle: '播放手把、鍵盤和觸控導航的音效',
+  AppLocale.use12HourClock: '12小時制',
+  AppLocale.use12HourClockSubtitle: '以 12 小時制（AM/PM）顯示時間，而非 24 小時制',
   AppLocale.fullscreenMode: '全螢幕模式',
   AppLocale.fullscreenModeSubtitle: '以全螢幕模式顯示應用程式',
   AppLocale.allFilesAccess: '所有檔案存取權限',

--- a/lib/models/config_model.dart
+++ b/lib/models/config_model.dart
@@ -50,6 +50,9 @@ class ConfigModel {
   /// Whether UI sound effects (navigation, clicks) are enabled.
   final bool sfxEnabled;
 
+  /// Whether the header clock should use a 12-hour format with AM/PM (false = 24-hour).
+  final bool use12HourClock;
+
   /// The property used to sort the system list (e.g., 'alphabetical', 'release_year').
   final String systemSortBy;
 
@@ -97,6 +100,7 @@ class ConfigModel {
     this.hideBottomScreen = false,
     this.videoSound = false,
     this.sfxEnabled = true,
+    this.use12HourClock = false,
     this.systemSortBy = 'alphabetical',
     this.systemSortOrder = 'asc',
     this.appLanguage = 'es',
@@ -177,6 +181,11 @@ class ConfigModel {
       sfxEnabled:
           (json['sfxEnabled'] ?? true).toString().toLowerCase() == 'true' ||
           (json['sfx_enabled'] ?? 1).toString() == '1',
+      use12HourClock:
+          (json['use12HourClock'] ?? json['use_12_hour_clock'] ?? 0)
+                  .toString() ==
+              '1' ||
+          (json['use12HourClock'] ?? false).toString().toLowerCase() == 'true',
       systemSortBy:
           (json['systemSortBy'] ?? json['system_sort_by'] ?? 'alphabetical')
               .toString(),
@@ -243,6 +252,7 @@ class ConfigModel {
       'hideBottomScreen': hideBottomScreen,
       'videoSound': videoSound,
       'sfxEnabled': sfxEnabled,
+      'use12HourClock': use12HourClock,
       'systemSortBy': systemSortBy,
       'systemSortOrder': systemSortOrder,
       'appLanguage': appLanguage,
@@ -274,6 +284,7 @@ class ConfigModel {
     bool? hideBottomScreen,
     bool? videoSound,
     bool? sfxEnabled,
+    bool? use12HourClock,
     String? systemSortBy,
     String? systemSortOrder,
     String? appLanguage,
@@ -302,6 +313,7 @@ class ConfigModel {
       hideBottomScreen: hideBottomScreen ?? this.hideBottomScreen,
       videoSound: videoSound ?? this.videoSound,
       sfxEnabled: sfxEnabled ?? this.sfxEnabled,
+      use12HourClock: use12HourClock ?? this.use12HourClock,
       systemSortBy: systemSortBy ?? this.systemSortBy,
       systemSortOrder: systemSortOrder ?? this.systemSortOrder,
       appLanguage: appLanguage ?? this.appLanguage,

--- a/lib/providers/sqlite_config_provider.dart
+++ b/lib/providers/sqlite_config_provider.dart
@@ -1218,6 +1218,13 @@ class SqliteConfigProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Updates whether the header clock uses a 12-hour (AM/PM) format.
+  Future<void> updateUse12HourClock(bool value) async {
+    _config = _config.copyWith(use12HourClock: value);
+    await SqliteConfigService.saveConfig(_config);
+    notifyListeners();
+  }
+
   /// Updates whether UI navigation SFX sounds are enabled
   Future<void> updateSfxEnabled(bool value) async {
     _config = _config.copyWith(sfxEnabled: value);

--- a/lib/screens/settings_screen/new_settings_options/general_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/general_settings_content.dart
@@ -169,6 +169,7 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
     count++; // Auto-update App
     count++; // Auto-update Systems
     count++; // SFX Sounds
+    count++; // 12-Hour Clock
     count++; // Language
     if (!kIsWeb &&
         (Platform.isWindows || Platform.isLinux || Platform.isMacOS)) {
@@ -226,6 +227,15 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
     if (index == currentItemIndex) {
       final sfxEnabled = configProvider.config.sfxEnabled;
       configProvider.updateSfxEnabled(!sfxEnabled);
+      return;
+    }
+    currentItemIndex++;
+
+    // Protocol: 12-Hour Clock Format.
+    if (index == currentItemIndex) {
+      configProvider.updateUse12HourClock(
+        !configProvider.config.use12HourClock,
+      );
       return;
     }
     currentItemIndex++;
@@ -659,6 +669,76 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
                     value: config.sfxEnabled,
                     onChanged: (value) {
                       context.read<SqliteConfigProvider>().updateSfxEnabled(
+                        value,
+                      );
+                    },
+                    activeColor: theme.colorScheme.primary,
+                  ),
+                ],
+              ),
+            );
+          }(),
+
+          // Setting: 12-Hour Clock Format.
+          SizedBox(height: 12.r),
+          () {
+            final index = currentItemIdx++;
+            return Container(
+              key: _itemKeys[index],
+              padding: EdgeInsets.only(
+                left: 12.r,
+                right: 12.r,
+                top: 6.r,
+                bottom: 6.r,
+              ),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surface.withValues(alpha: 0.5),
+                borderRadius: BorderRadius.circular(8.r),
+                border: Border.all(
+                  color:
+                      widget.isContentFocused &&
+                          widget.selectedContentIndex == index
+                      ? theme.colorScheme.primary
+                      : Colors.transparent,
+                  width: 2,
+                ),
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          AppLocale.use12HourClock.getString(context),
+                          style: theme.textTheme.bodyLarge?.copyWith(
+                            fontSize: 12.r,
+                            fontWeight: FontWeight.w500,
+                            color:
+                                widget.isContentFocused &&
+                                    widget.selectedContentIndex == index
+                                ? theme.colorScheme.primary
+                                : theme.colorScheme.onSurface,
+                          ),
+                        ),
+                        SizedBox(height: 4.r),
+                        Text(
+                          AppLocale.use12HourClockSubtitle.getString(context),
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            fontSize: 9.r,
+                            color: theme.colorScheme.onSurface.withValues(
+                              alpha: 0.6,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  CustomToggleSwitch(
+                    value: config.use12HourClock,
+                    onChanged: (value) {
+                      context.read<SqliteConfigProvider>().updateUse12HourClock(
                         value,
                       );
                     },

--- a/lib/utils/time_format.dart
+++ b/lib/utils/time_format.dart
@@ -1,0 +1,16 @@
+/// Formats the [time] for the header clock, honoring the user's
+/// 12/24-hour clock preference.
+///
+/// When [use12Hour] is false (default), returns 24-hour format (e.g. `14:09`).
+/// When true, returns 12-hour format with an AM/PM suffix (e.g. `2:09 PM`),
+/// mapping midnight to `12:00 AM` and noon to `12:00 PM`.
+String formatClockTime(DateTime time, {required bool use12Hour}) {
+  final minute = time.minute.toString().padLeft(2, '0');
+  if (!use12Hour) {
+    return '${time.hour}:$minute';
+  }
+  final period = time.hour < 12 ? 'AM' : 'PM';
+  int hour12 = time.hour % 12;
+  if (hour12 == 0) hour12 = 12;
+  return '$hour12:$minute $period';
+}

--- a/lib/widgets/header.dart
+++ b/lib/widgets/header.dart
@@ -12,6 +12,7 @@ import 'package:neostation/services/permission_service.dart';
 import 'package:neostation/providers/sqlite_config_provider.dart';
 import 'package:neostation/widgets/header_sort_dropdown.dart';
 import 'package:neostation/l10n/app_locale.dart';
+import 'package:neostation/utils/time_format.dart';
 import 'package:flutter_localization/flutter_localization.dart';
 
 class Header extends StatefulWidget {
@@ -32,7 +33,7 @@ class HeaderState extends State<Header> {
   final Battery _battery = Battery();
   int _batteryLevel = 100;
   bool _isTelevision = false;
-  String _currentTime = '';
+  DateTime _now = DateTime.now();
   Timer? _timeUpdateTimer;
   late final List<FocusNode> _tabFocusNodes;
 
@@ -60,10 +61,9 @@ class HeaderState extends State<Header> {
   }
 
   void _updateTime() {
-    final now = DateTime.now();
     if (mounted) {
       setState(() {
-        _currentTime = "${now.hour}:${now.minute.toString().padLeft(2, '0')}";
+        _now = DateTime.now();
       });
       // Also update battery every minute
       _getBatteryLevel();
@@ -298,7 +298,10 @@ class HeaderState extends State<Header> {
                       ),
                       SizedBox(width: 4.r),
                       Text(
-                        _currentTime,
+                        formatClockTime(
+                          _now,
+                          use12Hour: configProvider.config.use12HourClock,
+                        ),
                         style: TextStyle(
                           color: Theme.of(context).colorScheme.onSurface,
                           fontSize: 12.r,

--- a/test/database_test_helper.dart
+++ b/test/database_test_helper.dart
@@ -115,7 +115,8 @@ class DatabaseTestHelper {
         neostation_app_version TEXT,
         auto_update_app INTEGER,
         auto_update_systems INTEGER,
-        system_grid_columns TEXT DEFAULT 'M'
+        system_grid_columns TEXT DEFAULT 'M',
+        use_12_hour_clock INTEGER DEFAULT 0
       )
     ''');
 

--- a/test/time_format_test.dart
+++ b/test/time_format_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/utils/time_format.dart';
+
+void main() {
+  DateTime at(int hour, int minute) => DateTime(2026, 6, 21, hour, minute);
+
+  group('formatClockTime - 24-hour', () {
+    test('keeps the raw hour without padding', () {
+      expect(formatClockTime(at(0, 0), use12Hour: false), '0:00');
+      expect(formatClockTime(at(9, 5), use12Hour: false), '9:05');
+      expect(formatClockTime(at(14, 59), use12Hour: false), '14:59');
+      expect(formatClockTime(at(23, 0), use12Hour: false), '23:00');
+    });
+
+    test('zero-pads the minutes', () {
+      expect(formatClockTime(at(13, 1), use12Hour: false), '13:01');
+      expect(formatClockTime(at(13, 10), use12Hour: false), '13:10');
+    });
+  });
+
+  group('formatClockTime - 12-hour', () {
+    test('midnight maps to 12:xx AM', () {
+      expect(formatClockTime(at(0, 0), use12Hour: true), '12:00 AM');
+      expect(formatClockTime(at(0, 30), use12Hour: true), '12:30 AM');
+    });
+
+    test('noon maps to 12:xx PM', () {
+      expect(formatClockTime(at(12, 0), use12Hour: true), '12:00 PM');
+      expect(formatClockTime(at(12, 45), use12Hour: true), '12:45 PM');
+    });
+
+    test('morning hours are AM', () {
+      expect(formatClockTime(at(1, 9), use12Hour: true), '1:09 AM');
+      expect(formatClockTime(at(11, 59), use12Hour: true), '11:59 AM');
+    });
+
+    test('afternoon/evening hours are PM and wrap past 12', () {
+      expect(formatClockTime(at(13, 0), use12Hour: true), '1:00 PM');
+      expect(formatClockTime(at(23, 5), use12Hour: true), '11:05 PM');
+    });
+
+    test('zero-pads the minutes', () {
+      expect(formatClockTime(at(3, 7), use12Hour: true), '3:07 AM');
+    });
+  });
+
+  group('formatClockTime - exhaustive AM/PM boundary across all 24 hours', () {
+    test('every hour maps to the correct 12-hour value and period', () {
+      // Expected 12-hour display hour for each 24-hour input (index = hour).
+      const expectedHour = [
+        12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, // 0..11
+        12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, // 12..23
+      ];
+      for (var h = 0; h < 24; h++) {
+        final period = h < 12 ? 'AM' : 'PM';
+        expect(
+          formatClockTime(at(h, 0), use12Hour: true),
+          '${expectedHour[h]}:00 $period',
+          reason: 'hour $h should format as ${expectedHour[h]}:00 $period',
+        );
+      }
+    });
+  });
+}

--- a/test/use_12_hour_clock_test.dart
+++ b/test/use_12_hour_clock_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/models/config_model.dart';
+import 'package:neostation/data/datasources/sqlite_service.dart';
+
+import 'database_test_helper.dart';
+
+void main() {
+  group('ConfigModel.use12HourClock serialization', () {
+    test('defaults to false (24-hour)', () {
+      expect(const ConfigModel().use12HourClock, isFalse);
+    });
+
+    test('copyWith updates the flag', () {
+      const base = ConfigModel();
+      expect(base.copyWith(use12HourClock: true).use12HourClock, isTrue);
+      // Omitting the field preserves the previous value.
+      final enabled = base.copyWith(use12HourClock: true);
+      expect(enabled.copyWith().use12HourClock, isTrue);
+    });
+
+    test('round-trips through toJson/fromJson', () {
+      const enabled = ConfigModel(use12HourClock: true);
+      final restored = ConfigModel.fromJson(enabled.toJson());
+      expect(restored.use12HourClock, isTrue);
+    });
+
+    test('fromJson parses bool, legacy int, and snake_case keys', () {
+      expect(
+        ConfigModel.fromJson({'use12HourClock': true}).use12HourClock,
+        isTrue,
+      );
+      expect(
+        ConfigModel.fromJson({'use_12_hour_clock': 1}).use12HourClock,
+        isTrue,
+      );
+      expect(
+        ConfigModel.fromJson({'use_12_hour_clock': 0}).use12HourClock,
+        isFalse,
+      );
+      // Absent key falls back to the 24-hour default.
+      expect(ConfigModel.fromJson({}).use12HourClock, isFalse);
+    });
+  });
+
+  group('use_12_hour_clock persistence (SQLite)', () {
+    final dbHelper = DatabaseTestHelper();
+
+    setUp(() async => dbHelper.setUp());
+    tearDown(() async => dbHelper.tearDown());
+
+    test('defaults to 0 when never set', () async {
+      await SqliteService.saveUserConfig(appLanguage: 'en');
+      final config = await SqliteService.getUserConfig();
+      final value =
+          int.tryParse(config?['use_12_hour_clock']?.toString() ?? '0') ?? 0;
+      expect(value, 0);
+    });
+
+    test('persists an enabled value across save/load', () async {
+      await SqliteService.saveUserConfig(use12HourClock: 1);
+      final config = await SqliteService.getUserConfig();
+      expect(config?['use_12_hour_clock'].toString(), '1');
+    });
+
+    test('can be toggled back off', () async {
+      await SqliteService.saveUserConfig(use12HourClock: 1);
+      await SqliteService.saveUserConfig(use12HourClock: 0);
+      final config = await SqliteService.getUserConfig();
+      expect(config?['use_12_hour_clock'].toString(), '0');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds a **Use 12-Hour Clock** toggle under **Settings → General** so the header clock can be shown in 12-hour AM/PM format instead of the hard-coded 24-hour format. Default is unchanged (24-hour); the preference persists and applies immediately without a restart.

Fixes #56.

## Type of Change

- [x] New feature (non-breaking change which adds capability)

## What changed

- **Model:** `use12HourClock` added to `ConfigModel` (defaults to `false` = 24-hour) and threaded through `fromJson`/`toJson`/`copyWith`.
- **Persistence:** new `user_config.use_12_hour_clock` column. Added to the `CREATE TABLE` schema plus a defensive `_ensureUserConfigColumns()` migration so existing installs gain the column on launch (no DB version bump needed).
- **Provider:** `updateUse12HourClock()` on `SqliteConfigProvider`.
- **UI:** toggle row in General settings (wired into the gamepad-nav item count + dispatcher), placed between *UI Navigation Sounds* and *Language*.
- **Clock:** header formatting extracted into a pure `formatClockTime()` util (`lib/utils/time_format.dart`) and rendered in `build()` so toggling reformats instantly. Handles midnight → `12:00 AM`, noon → `12:00 PM`, and zero-padded minutes.
- **i18n:** new strings localized across all 11 supported languages.

## Test plan

- `flutter analyze` on all touched files: **no issues**.
- New unit tests (**15**, all passing):
  - `test/time_format_test.dart` — exhaustive formatting across all 24 hours in both modes, plus midnight/noon edges and minute padding.
  - `test/use_12_hour_clock_test.dart` — `ConfigModel` serialization and SQLite save/load/toggle persistence.
- Manually verified on an Android device (AYN Thor):
  - Toggling flips the header `3:14` ↔ `3:14 AM` instantly (no restart).
  - **Persistence across a true cold restart:** set 12-hour, then `am force-stop` the app and relaunch it as a fresh process (PID confirmed `none` → new) — the header still shows AM, so the value round-trips through SQLite (incl. the migration on an existing DB). See demo below.
- Note: two favorites-related tests (`game_repository_test`, `game_service_test`) fail on `main` independently of this change (pre-existing) — this PR neither touches that code nor introduces new failures.

<details>
<summary><b>Verification output</b> (flutter analyze + flutter test)</summary>

```text
$ flutter analyze <touched files>
Analyzing 7 items...
No issues found! (ran in 11.8s)

$ flutter test test/time_format_test.dart test/use_12_hour_clock_test.dart
00:00 +0: formatClockTime - 24-hour keeps the raw hour without padding
00:00 +1: formatClockTime - 24-hour zero-pads the minutes
00:00 +2: formatClockTime - 12-hour midnight maps to 12:xx AM
00:00 +3: formatClockTime - 12-hour noon maps to 12:xx PM
00:00 +4: formatClockTime - 12-hour morning hours are AM
00:00 +5: formatClockTime - 12-hour afternoon/evening hours are PM and wrap past 12
00:00 +6: formatClockTime - 12-hour zero-pads the minutes
00:00 +7: formatClockTime - exhaustive AM/PM boundary across all 24 hours
00:01 +8: ConfigModel.use12HourClock serialization defaults to false (24-hour)
00:01 +9: ConfigModel.use12HourClock serialization copyWith updates the flag
00:01 +10: ConfigModel.use12HourClock serialization round-trips through toJson/fromJson
00:01 +11: ConfigModel.use12HourClock serialization fromJson parses bool, legacy int, and snake_case keys
00:01 +12: use_12_hour_clock persistence (SQLite) defaults to 0 when never set
00:01 +13: use_12_hour_clock persistence (SQLite) persists an enabled value across save/load
00:01 +14: use_12_hour_clock persistence (SQLite) can be toggled back off
00:01 +15: All tests passed!
```

</details>

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation. _(N/A — no user-facing docs affected)_
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. _(no new assets added)_
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [ ] **Gamepad support verified** — toggle is wired into the gamepad-nav list; verified via touch on device, physical-controller pass still pending.

## Screenshots

**Header clock**

| 12-hour (ON) | 24-hour (OFF) |
| --- | --- |
| <img width="420" alt="header 12-hour" src="https://github.com/user-attachments/assets/d83e4790-35a8-4602-94ce-3f3566116e5b" /> | <img width="420" alt="header 24-hour" src="https://github.com/user-attachments/assets/fb38e19f-3145-4427-8bf6-b214687f62e8" /> |

**Settings toggle**

| Toggle ON | Toggle OFF |
| --- | --- |
| <img width="420" alt="settings toggle on" src="https://github.com/user-attachments/assets/2480ad5c-6a3d-4f3b-834b-8b760358f1b4" /> | <img width="420" alt="settings toggle off" src="https://github.com/user-attachments/assets/3aa0fcb7-e0ea-4386-89cc-cd505ae615d4" /> |

---
*Posted by Claude Code on behalf of @androosio.*

