### PR TITLE
fix(systems): stop secondary-display update from recursing into a stack overflow

### DIFF
--- a/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
@@ -815,10 +815,16 @@ class _SystemCardGridViewState extends State<SystemCardGridView> {
   void _onSecondaryStateChanged() {
     if (!mounted) return;
     final isActive = _secondaryDisplayState?.value?.isSecondaryActive ?? false;
-    if (isActive && !_prevIsSecondaryActive) {
+    // Update the guard BEFORE pushing state. _updateSecondaryScreenName() calls
+    // updateState(), which synchronously re-enters this listener via
+    // notifyListeners(); if _prevIsSecondaryActive were still false the
+    // edge-condition below would stay true and recurse until the stack
+    // overflows (a CPU spike per tab switch on devices with a secondary screen).
+    final wasActive = _prevIsSecondaryActive;
+    _prevIsSecondaryActive = isActive;
+    if (isActive && !wasActive) {
       _updateSecondaryScreenName();
     }
-    _prevIsSecondaryActive = isActive;
   }
 
   void _loadThemeAssetsForSystems() {


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

# Description

Fixes an infinite recursion / stack overflow in the secondary-display update path
on the systems screen.

`_SystemCardGridViewState._onSecondaryStateChanged` only pushes secondary-display
state on the inactive→active edge (`isActive && !_prevIsSecondaryActive`), but it
updated `_prevIsSecondaryActive` *after* calling `_updateSecondaryScreenName()`.
That call runs `SecondaryDisplayState.updateState()` → `notifyListeners()`, which
synchronously re-enters `_onSecondaryStateChanged` while the guard flag is still
`false`, so the edge condition stays true and the listener recurses until the Dart
stack overflows.

It self-recovers (the `Stack Overflow` exception unwinds the stack) so it isn't
visibly fatal, but on a dual-screen device it fires every time the systems grid is
re-mounted while the secondary display is active — e.g. rapidly switching the
top-nav sections with the L/R bumpers. Each event spins the deep recursion and
floods the log with a stack trace plus "setState() called after dispose" warnings.

**Fix:** capture the previous value and set `_prevIsSecondaryActive = isActive`
*before* calling `_updateSecondaryScreenName()`, so the synchronous re-entrant call
sees the guard already set and does not recurse.

Fixes #58

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works. _(verified on-device instead — the recursion is behind a `Platform.isAndroid` guard and a cross-engine notifier, which is impractical to unit-test)_
- [ ] I have updated the corresponding documentation. _(N/A)_
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. _(no new assets)_
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [ ] **Gamepad support verified** _(N/A — not input-related; though the repro is driven via the gamepad L/R bumpers)_

## Reproduction

1. Run on a device with a secondary display active (e.g. AYN Thor, both screens on).
2. On the systems screen, rapidly switch the top-nav sections with the L/R bumpers.
3. Each return to the systems grid re-mounts it while the secondary is active →
   `flutter: Another exception was thrown: Stack Overflow` (note: logged with a
   space, not `StackOverflowError`), plus a flood of dispose-related warnings.

## Verification

Measured on an AYN Thor (Android 13), identical 40s of L/R hammering on each build
(both runs did ~113 nav-layer switches, so the load is matched):

| | Stack Overflow exceptions | "setState after dispose" warnings | App CPU (mean) | App CPU (peak) |
| --- | --- | --- | --- | --- |
| Before (`141e16c`) | 16 | 64 | 117% | 251% |
| After (this fix) | 0 | 0 | 44% | 244% |

Sustained CPU more than halves and the recursion is eliminated; the residual peaks
are ordinary per-frame render cost during navigation, not the bug.


<img width="770" alt="cpu_comparison" src="https://github.com/user-attachments/assets/bc4b20f2-49de-449d-8d45-a580789f7d09" />
