### PR TITLE
fix: show console art on secondary display under the OLED palette

### DIFF
--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -355,14 +355,11 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
   }
 
   Widget _buildSystemBackground(SecondaryDisplayStateData value) {
-    if (value.isOled) {
-      return Container(
-        color: value.backgroundColor != null
-            ? Color(value.backgroundColor!)
-            : Colors.black,
-      );
-    }
-
+    // Note: OLED is intentionally NOT short-circuited here. For a highlighted
+    // system the console artwork IS the background, so blacking it out would
+    // leave only the console name on screen. The black/background-color
+    // fallback below (via _buildShaderFallback) still applies when no system
+    // image is available, preserving the OLED look in the empty case.
     final bgPath = value.systemBackground;
     final hasBg = bgPath != null && bgPath.isNotEmpty;
 


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

## Summary

On the secondary (bottom) display, highlighting a console mirrors its
artwork for every palette except OLED, where the screen went fully black
with only the console name showing. This fixes the OLED palette to render
console art like the others.

Closes #62

## Root cause

The OLED palette is meant to suppress *decorative ambient backgrounds* in
favor of pure black — not to hide content artwork. That's how it behaves
everywhere else: the `if (!isOled)` guards on the main screen drop only an
ambient fluid-gradient layer while still rendering game/console art, and the
secondary screen's game layer (screenshots/fanart) already renders under OLED.

The secondary screen has two background builders sharing the identical
`if (value.isOled) return Container(color: ...)` snippet:

- `_buildUnifiedAppBackground` — **correct**: this is the app/menu background
  (a decorative layer); content layers draw on top of it.
- `_buildSystemBackground` — **wrong**: here the "background" *is* the
  highlighted console's content artwork. The copy-pasted OLED gate returned a
  solid container immediately, so the artwork was never built — only the
  console name (a separate center layer) remained.

So this was an over-application of the OLED "pure black" rule to a function
where the background carries content.

## Fix

Remove the OLED short-circuit in `_buildSystemBackground` so the system art
renders under OLED too, realigning the secondary screen with how OLED already
behaves on the main screen and for games. The black fallback
(`_buildShaderFallback`) still applies when a system has no image, preserving
the OLED look in the empty case. `_buildUnifiedAppBackground` is left intact.

## Testing

- `flutter analyze lib/screens/secondary_screen/secondary_screen.dart` — clean.
- Built and installed on an AYN Thor; confirmed the OLED palette now shows
  console artwork on the secondary display.


## Screenshots

Before fix
<img width="400" height="452" alt="03_OLED" src="https://github.com/user-attachments/assets/d511525e-96af-430d-90e5-c6c8d584906b" />
---

After Fix
<img width="400" height="452" alt="oled-fixed" src="https://github.com/user-attachments/assets/93c97ecf-2364-4dac-b6c0-19d14017160c" />
---
