### PR TITLE
fix(gamepad): bind random to L3 only, not L2

### DIFF
--- a/lib/screens/game_screen/my_games_carousel.dart
+++ b/lib/screens/game_screen/my_games_carousel.dart
@@ -251,7 +251,7 @@ class _GamesCarouselState extends State<GamesCarousel> {
           GameViewModeDropdown.globalKey.currentState?.showDropdown();
         } catch (_) {}
       },
-      onLeftTrigger: widget.onRandom,
+      onLeftStickClick: widget.onRandom,
       onSelectButton: widget.onScrape,
       onSettings: widget.onSettings,
       onPreviousTab: AppNavigation.previousTab,

--- a/lib/screens/game_screen/my_games_grid.dart
+++ b/lib/screens/game_screen/my_games_grid.dart
@@ -500,7 +500,7 @@ class _GamesGridState extends State<GamesGrid> {
           GameViewModeDropdown.globalKey.currentState?.showDropdown();
         } catch (_) {}
       },
-      onLeftTrigger: widget.onRandom,
+      onLeftStickClick: widget.onRandom,
       onSelectButton: widget.onScrape,
       onSettings: widget.onSettings,
     );

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -482,7 +482,7 @@ class _SystemGamesListState extends State<SystemGamesList> {
         GameViewModeDropdown.globalKey.currentState?.showDropdown();
       }, // Button X - View mode.
       onSettings: _handleStartButton, // Button Start.
-      onLeftTrigger: () {
+      onLeftStickClick: () {
         if (widget.system.folderName == 'music') {
           final service = MusicPlayerService();
           service.toggleShuffle();
@@ -497,7 +497,7 @@ class _SystemGamesListState extends State<SystemGamesList> {
           _showRandomGameDialog();
         }
       }, // L3 - Random.
-      onRightTrigger: null,
+      onRightStickClick: null,
       onSelectButton: () {
         if (widget.system.folderName == 'music') {
           final service = MusicPlayerService();

--- a/lib/utils/gamepad_nav.dart
+++ b/lib/utils/gamepad_nav.dart
@@ -58,8 +58,8 @@ class GamepadNavigation {
   final VoidCallback? onFavorite;
   final VoidCallback? onSettings;
   final VoidCallback? onXButton;
-  final VoidCallback? onLeftTrigger;
-  final VoidCallback? onRightTrigger;
+  final VoidCallback? onLeftStickClick;
+  final VoidCallback? onRightStickClick;
   final VoidCallback? onSelectButton;
   final VoidCallback? onLeftBumper;
   final VoidCallback? onRightBumper;
@@ -128,8 +128,8 @@ class GamepadNavigation {
     this.onFavorite,
     this.onSettings,
     this.onXButton,
-    this.onLeftTrigger,
-    this.onRightTrigger,
+    this.onLeftStickClick,
+    this.onRightStickClick,
     this.onSelectButton,
     this.onLeftBumper,
     this.onRightBumper,
@@ -617,11 +617,11 @@ class GamepadNavigation {
       // icon for this action. The physical L2 trigger (buttonLT) deliberately
       // does NOT fire it.
       case GamepadInputType.leftStickButton:
-        onLeftTrigger?.call();
+        onLeftStickClick?.call();
         break;
 
       case GamepadInputType.rightStickButton:
-        onRightTrigger?.call();
+        onRightStickClick?.call();
         break;
 
       default:

--- a/lib/utils/gamepad_nav.dart
+++ b/lib/utils/gamepad_nav.dart
@@ -613,12 +613,13 @@ class GamepadNavigation {
         }
         break;
 
-      case GamepadInputType.buttonLT:
+      // L3 (left stick click) only — the UI hint shows the Left-Stick-Click
+      // icon for this action. The physical L2 trigger (buttonLT) deliberately
+      // does NOT fire it.
       case GamepadInputType.leftStickButton:
         onLeftTrigger?.call();
         break;
 
-      case GamepadInputType.buttonRT:
       case GamepadInputType.rightStickButton:
         onRightTrigger?.call();
         break;


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

## Summary

In the game views (list/grid/carousel), the "random game" action was wired to `onLeftTrigger`, which was fired by **both** the L2 trigger (`buttonLT`) **and** the left-stick click (L3, `leftStickButton`). The UI hint only advertises the **L3 (left-stick-click)** icon, so L2 was an undocumented duplicate trigger that fired random unexpectedly.

This drops the `buttonLT`/`buttonRT` cases so only L3/R3 fire those callbacks, then renames the now-misnamed callbacks to match reality.

## Commits

1. **fix(gamepad): bind random to L3 only, not L2** — remove `buttonLT`/`buttonRT` from the trigger-callback switch in `gamepad_nav.dart`.
2. **refactor(gamepad): rename `onLeftTrigger`/`onRightTrigger` → `onLeftStickClick`/`onRightStickClick`** — pure rename across `gamepad_nav.dart` + the three game-view call sites (list/grid/carousel), since the callbacks now fire only on stick-click, not the triggers. No behaviour change.

## Testing

`flutter analyze` clean. Verified on an **AYN Thor** (L2/R2 set to "both" mode):

- **L2** → does nothing (kernel capture confirmed L2 emits `KEYCODE_BUTTON_L2` → `buttonLT`, now a no-op, plus `AXIS_BRAKE` which the translator drops as unknown).
- **L3** → opens the random-game dialog as expected.

AI-Assisted: Claude:Opus-4.8