### PR TITLE
fix: scrape from the list view via Select, with on-screen feedback

### DIFF
--- a/lib/screens/game_screen/game_details_card/game_details_card_list.dart
+++ b/lib/screens/game_screen/game_details_card/game_details_card_list.dart
@@ -48,6 +48,12 @@ class GameDetailsCardList extends StatefulWidget {
   final RetroAchievementsProvider retroAchievementsProvider;
   final ISyncProvider syncProvider;
   final String? localizedDescription;
+
+  /// True when an external (list-level) scrape is running for this game, e.g.
+  /// triggered by the Select button. Drives the scrape button spinner so the
+  /// feedback matches a scrape started from the button itself.
+  final bool isExternallyScraping;
+
   final VoidCallback? onDeactivateNavigation;
   final VoidCallback? onReactivateNavigation;
   final void Function(VoidCallback)? onShowAchievements;
@@ -111,6 +117,7 @@ class GameDetailsCardList extends StatefulWidget {
     required this.retroAchievementsProvider,
     required this.syncProvider,
     this.localizedDescription,
+    this.isExternallyScraping = false,
     this.onDeactivateNavigation,
     this.onReactivateNavigation,
     this.onShowAchievements,
@@ -806,7 +813,7 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
               game: _game,
               isMusicSystem: _effectiveSystem.folderName == 'music',
               hasScreenScraper: _hasScreenScraper,
-              isScrapingGame: _isScrapingGame,
+              isScrapingGame: _isScrapingGame || widget.isExternallyScraping,
               localizedDescription: widget.localizedDescription,
               isSecondaryScreenActive: widget.isSecondaryScreenActive,
               isFavorite: _game.isFavorite ?? false,
@@ -841,7 +848,7 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
                         ? AppLocale.noDescription.getString(context)
                         : _game.getDescriptionForLanguage('en')),
                 screenshotPath: screenshotPath,
-                isScrapingGame: _isScrapingGame,
+                isScrapingGame: _isScrapingGame || widget.isExternallyScraping,
                 scrapeProgress: _scrapeProgress,
                 scrapeStatus: _scrapeStatus,
                 isSecondaryScreenActive: widget.isSecondaryScreenActive,

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -390,6 +390,12 @@ class _SystemGamesListState extends State<SystemGamesList> {
                   _selectedGame = updatedGame;
                 }
               });
+              // Refresh the cached localized description so the scrape button
+              // label flips from 'Scrape' to 'Rescrape' immediately (it keys
+              // off whether a description is present).
+              if (_selectedGame?.romname == romname) {
+                _loadLocalizedDescription();
+              }
             }
           }
 
@@ -2693,6 +2699,9 @@ class _SystemGamesListState extends State<SystemGamesList> {
         retroAchievementsProvider: _retroAchievementsProvider,
         syncProvider: syncManager.active!,
         localizedDescription: _localizedDescription,
+        isExternallyScraping: _scrapingGameRomnames.contains(
+          _selectedGame!.romname,
+        ),
         isNavigatingFast: _isNavigatingFast,
         isSecondaryScreenActive:
             _secondaryDisplayState?.value?.isSecondaryActive ?? false,

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -143,7 +143,6 @@ class _SystemGamesListState extends State<SystemGamesList> {
 
   // Integration callbacks for GameDetailsCardList.
   VoidCallback? _refreshAchievementsCallback;
-  VoidCallback? _toggleInfoCallback;
 
   // Overlay interaction delegates.
   bool Function()? _isAchievementsOpen;
@@ -321,15 +320,6 @@ class _SystemGamesListState extends State<SystemGamesList> {
     }
 
     _updateSecondaryDisplay(_selectedGame!);
-  }
-
-  /// Opens the detailed game information overlay.
-  void _openGameInfo() {
-    if (_selectedGame == null) return;
-
-    if (_toggleInfoCallback != null) {
-      _toggleInfoCallback!();
-    }
   }
 
   void _onScrapeCurrentGame() async {
@@ -528,12 +518,11 @@ class _SystemGamesListState extends State<SystemGamesList> {
           }
           return;
         }
-        if (_secondaryOverlayAction != null) {
-          _secondaryOverlayAction!();
-        } else {
-          _openGameInfo();
-        }
-      }, // Select - Scrape/Info.
+        // Scrape the selected game directly, matching the grid/carousel views.
+        // Routing through the details card's secondary action early-returns when
+        // the secondary display is active (e.g. AYN Thor), so scraping never ran.
+        _onScrapeCurrentGame();
+      }, // Select - Scrape.
       onLeftBumper: _handleLeftBumper,
       onRightBumper: _handleRightBumper,
       onPreviousTab: _handleLeftBumper, // Key Q.
@@ -2709,7 +2698,6 @@ class _SystemGamesListState extends State<SystemGamesList> {
             _secondaryDisplayState?.value?.isSecondaryActive ?? false,
         onDeactivateNavigation: () => _gamepadNav.deactivate(),
         onReactivateNavigation: () => _gamepadNav.activate(),
-        onToggleInfo: (callback) => _toggleInfoCallback = callback,
         onRegisterOverlayState: (isOverlayOpen, isAchievementsOpen) {
           _isAchievementsOpen = isAchievementsOpen;
         },

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -330,6 +330,13 @@ class _SystemGamesListState extends State<SystemGamesList> {
     if (romPath == null) return;
     if (_scrapingGameRomnames.contains(romname)) return;
 
+    // Claim the lock synchronously, before any await, so rapid repeated
+    // presses (the scrape button or the Select shortcut) can't slip past the
+    // guard above and queue duplicate scrapes for the same game.
+    _scrapingGameRomnames.add(romname);
+    _scrapeProgress[romname] = 0.0;
+    setState(() {});
+
     // Resolve the actual system (not favorites virtual system).
     SystemModel targetSystem = widget.system;
     if ((widget.system.folderName == SystemFolderNames.all ||
@@ -344,11 +351,12 @@ class _SystemGamesListState extends State<SystemGamesList> {
     }
 
     final systemId = targetSystem.id;
-    if (systemId == null) return;
-
-    _scrapingGameRomnames.add(romname);
-    _scrapeProgress[romname] = 0.0;
-    setState(() {});
+    if (systemId == null) {
+      _scrapingGameRomnames.remove(romname);
+      _scrapeProgress.remove(romname);
+      if (mounted) setState(() {});
+      return;
+    }
 
     ScreenScraperService.scrapeSingleGame(
           appSystemId: systemId,


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

## Summary

In the **list view**, pressing **Select** to scrape a game now works on devices with an active secondary display, and gives the same visual feedback as tapping the scrape button.

## Commits

1. **fix: scrape from the game list view via the Select button**
   Select routed through the details card's secondary action, which early-returns when the secondary display is active and the bottom screen is visible (`_isGameInfoHidden == true`). On such devices (e.g. AYN Thor) Select never scraped, despite the footer hint showing the Select icon next to "Scrape". Now calls `_onScrapeCurrentGame()` directly, matching the grid/carousel views, and removes the now-unused `_openGameInfo` / `_toggleInfoCallback` / `onToggleInfo` wiring.

2. **feat: show scrape feedback for Select-triggered scrape**
   A Select-triggered scrape runs the list-level `_onScrapeCurrentGame` path, which previously gave no visual feedback (the scrape button's spinner is driven by the card's own `_isScrapingGame`, and the Scrape/Rescrape label keyed off a cached description that wasn't refreshed). Now:
   - Threads an `isExternallyScraping` flag from the list into `GameDetailsCardList`, OR-ed into the footer's `isScrapingGame`, so the scrape button shows its spinner for a Select-triggered scrape just like a tap.
   - Reloads the cached localized description on completion, so the button label flips from "Scrape" to "Rescrape" immediately.

3. **fix: lock scrape per game until it completes**
   The scrape guard checked `_scrapingGameRomnames` before claiming the lock, but the lock was only added *after* the all/favorites virtual-system `await`. Rapid presses of the scrape button or the Select shortcut all passed the guard before any claimed the lock, queueing duplicate scrapes for the same game. The lock is now claimed synchronously right after the guard (before any await), and released on the `systemId == null` early-return path.

## Testing

`flutter analyze` clean, all 113 tests pass. Verified on an **AYN Thor**:
- Select in list view scrapes the selected game.
- The scrape button shows its spinner during the scrape and relabels to "Rescrape" immediately on completion.
- Spamming the scrape button / Select while a scrape is in flight no longer queues duplicate scrapes, including on the All/Favorites views.

AI-Assisted: Claude:Opus-4.8