### PR TITLE
fix(secondary): keep correct system art on the secondary display when returning from a system

### DIFF
--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -7,6 +7,7 @@ import 'package:neostation/l10n/app_locale.dart';
 import 'package:neostation/services/logger_service.dart';
 import 'package:neostation/sync/sync_manager.dart';
 import 'package:neostation/providers/palette_provider.dart';
+import 'package:neostation/providers/neo_assets_provider.dart';
 import 'package:neostation/services/sfx_service.dart';
 import 'package:neostation/widgets/custom_notification.dart';
 import 'package:neostation/providers/retro_achievements_provider.dart';
@@ -1074,13 +1075,30 @@ class _SystemGamesListState extends State<SystemGamesList> {
     GamepadNavigationManager.popLayer('games_grid');
     GamepadNavigationManager.popLayer('system_games_list');
 
-    // Restore secondary display to original system branding.
+    // Restore secondary display to original system branding. Resolve the logo
+    // and background the same way the systems grid does (custom → active-theme
+    // → bundled asset, themed background when present) so themed systems don't
+    // flash the default logo here before the grid re-asserts its state on pop.
     final configProvider = context.read<SqliteConfigProvider>();
+    final neoAssets = context.read<NeoAssetsProvider>();
     final folder = widget.system.primaryFolderName;
-    final systemLogo = 'assets/images/systems/logos/$folder.webp';
+
+    final String? customLogo = widget.system.customLogoPath?.isNotEmpty == true
+        ? widget.system.customLogoPath
+        : null;
+    final String? themeLogo = customLogo == null
+        ? neoAssets.getLogoForSystemSync(folder)
+        : null;
+    final systemLogo =
+        customLogo ?? themeLogo ?? 'assets/images/systems/logos/$folder.webp';
+    final bool isLogoAsset = customLogo == null && themeLogo == null;
+
     final String? customBg = widget.system.customBackgroundPath;
     final bool hasCustomBg = customBg != null && customBg.isNotEmpty;
-    final String? systemBackground = hasCustomBg ? customBg : null;
+    final String? themeBg = hasCustomBg
+        ? null
+        : neoAssets.getBackgroundForSystemSync(folder);
+    final String? systemBackground = hasCustomBg ? customBg : themeBg;
 
     final paletteProvider = Provider.of<PaletteProvider>(
       context,
@@ -1095,11 +1113,11 @@ class _SystemGamesListState extends State<SystemGamesList> {
       isVideoMuted: !configProvider.config.videoSound,
       backgroundColor: Theme.of(context).scaffoldBackgroundColor.toARGB32(),
       systemLogo: systemLogo,
-      isLogoAsset: true,
+      isLogoAsset: isLogoAsset,
       systemBackground: systemBackground,
       clearSystemBackground: systemBackground == null,
       isBackgroundAsset: false,
-      useShader: !hasCustomBg,
+      useShader: systemBackground == null,
       shaderColor1: widget.system.color1AsColor?.toARGB32(),
       shaderColor2: widget.system.color2AsColor?.toARGB32(),
       useFluidShader: false,

--- a/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
@@ -631,15 +631,35 @@ class MySystems extends StatelessWidget {
     if (secondaryState == null) return;
     final folder = system.primaryFolderName ?? system.folderName ?? 'all';
 
-    // UI Asset Mapping logic.
+    // UI Asset Mapping logic — resolve the same way as the hover path
+    // (_updateSecondaryScreenName): prefer a custom logo, then the active
+    // theme's logo, then the bundled asset. Resolving the theme asset here
+    // (instead of always falling back to the bundled asset) is what keeps the
+    // correct system art on the secondary display when returning from a
+    // system, rather than reverting to the default logo until the user hovers
+    // another system. See NeoAssetsProvider (returns null when no theme).
+    final neoAssets = Provider.of<NeoAssetsProvider>(context, listen: false);
+
+    final String? customLogo = system.customLogoPath?.isNotEmpty == true
+        ? system.customLogoPath
+        : null;
+    final String? themeLogo = customLogo == null
+        ? neoAssets.getLogoForSystemSync(folder)
+        : null;
     final String? systemLogo = system.isGame
         ? system.customWheelImage
-        : 'assets/images/systems/logos/$folder.webp';
-    final bool isLogoAsset = !system.isGame;
+        : (customLogo ??
+              themeLogo ??
+              'assets/images/systems/logos/$folder.webp');
+    final bool isLogoAsset =
+        !system.isGame && customLogo == null && themeLogo == null;
 
     final String? customBg = system.customBackgroundPath;
     final bool hasCustomBg = customBg != null && customBg.isNotEmpty;
-    final String? systemBackground = hasCustomBg ? customBg : null;
+    final String? themeBg = hasCustomBg
+        ? null
+        : neoAssets.getBackgroundForSystemSync(folder);
+    final String? systemBackground = hasCustomBg ? customBg : themeBg;
     final bool isBackgroundAsset = false;
 
     final paletteProvider = Provider.of<PaletteProvider>(
@@ -656,7 +676,7 @@ class MySystems extends StatelessWidget {
       systemBackground: systemBackground,
       clearSystemBackground: systemBackground == null,
       isBackgroundAsset: isBackgroundAsset,
-      useShader: !hasCustomBg,
+      useShader: systemBackground == null,
       shaderColor1: system.color1AsColor?.toARGB32(),
       shaderColor2: system.color2AsColor?.toARGB32(),
       isGameSelected: false,


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device (AYN Thor) before posting.

## Summary

On the systems **grid**, the secondary display lost the correct system art after entering a system and returning to the systems view — it reverted to the default (bundled-asset) logo with no themed background until the user hovered another system and came back. Returning also showed a brief default-logo **flash** before the art settled.

Root cause: two secondary-display update paths had diverged from the canonical hover resolver (`_updateSecondaryScreenName`).

## Fix

Both fixes make the divergent paths resolve the logo/background exactly like the hover path: **custom logo → active-theme logo → bundled asset**, themed background when present, and shader only when there is no background (`useShader: systemBackground == null`). Theme assets resolve via `NeoAssetsProvider` (which returns `null` when no theme is active, preserving the existing bundled-asset fallback for non-themed setups).

1. **`MySystems._updateSecondaryScreenForSystem`** (systems grid, static return-path) previously hardcoded `assets/images/systems/logos/<folder>.webp` and ignored themed backgrounds entirely — so returning reverted to default art. It now mirrors the hover resolver field-for-field.

2. **`_SystemGamesListState._goBack`** (game list, back handler) re-asserted system branding on exit with the same hardcoded-asset logic, painting the default logo for a frame before the grid re-asserted state on pop — the visible flash. It now resolves the same way, so the correct themed art shows immediately.

The carousel's return path was already correct (it calls its instance hover resolver), so no change was needed there.

## No regression for non-themed setups

When no theme is active, `getLogoForSystemSync`/`getBackgroundForSystemSync` return `null`, falling back to the bundled asset with `isLogoAsset: true` and `useShader: true` — identical to the previous behaviour. The change only adds correct behaviour when a theme **is** active.

## Testing

- `dart format` clean, `flutter analyze` clean, all 113 tests pass.
- Verified on an **AYN Thor** with an active theme:
  - Enter a system and return → the original system's themed art stays on the secondary display (previously needed hovering another system and back).
  - No default-logo flash on return.

AI-Assisted: Claude:Opus-4.8