### PR TITLE
fix(update): restore download progress bar in UpdateDialog

### DIFF
--- a/lib/widgets/update_dialog.dart
+++ b/lib/widgets/update_dialog.dart
@@ -22,8 +22,8 @@ class UpdateDialog extends StatefulWidget {
 }
 
 class _UpdateDialogState extends State<UpdateDialog> {
-  final bool _isDownloading = false;
-  final double _downloadProgress = 0.0;
+  bool _isDownloading = false;
+  double _downloadProgress = 0.0;
   late final GamepadNavigation _gamepadNav;
 
   @override
@@ -291,14 +291,27 @@ class _UpdateDialogState extends State<UpdateDialog> {
   }
 
   Future<void> _startUpdate() async {
-    Navigator.of(context).pop(true);
+    setState(() {
+      _isDownloading = true;
+      _downloadProgress = 0.0;
+    });
 
     final success = await UpdateService.downloadAndInstall(
       widget.updateInfo,
-      (progress) {},
+      (progress) {
+        if (mounted) setState(() => _downloadProgress = progress);
+      },
     );
 
-    if (!success && mounted) {
+    if (!mounted) return;
+
+    if (success) {
+      Navigator.of(context).pop(true);
+    } else {
+      setState(() {
+        _isDownloading = false;
+        _downloadProgress = 0.0;
+      });
       AppNotification.showNotification(
         context,
         Platform.isAndroid


### PR DESCRIPTION
﻿## Description

The update download progress bar in `UpdateDialog` was broken by commit `3f90ef5`. The progress bar was never shown and progress was never reported to the user.

## Root Cause

Three issues in `_startUpdate()` in `lib/widgets/update_dialog.dart`:

1. **`final` state variables** — `_isDownloading` and `_downloadProgress` were declared `final`, making them compile-time constants that could never change
2. **Dialog popped before download** — `Navigator.of(context).pop(true)` was called immediately, closing the dialog before download began
3. **Empty progress callback** — the callback passed to `UpdateService.downloadAndInstall` was `(progress) {}`, discarding all progress updates

## Fix

- Removed `final` from `_isDownloading` and `_downloadProgress`
- Show the download progress UI via `setState(() => _isDownloading = true)` instead of popping the dialog
- Pass a real progress callback that calls `setState(() => _downloadProgress = progress)`
- On success: pop the dialog with `true` after download completes
- On failure: reset state so the user can retry, and show an error notification

## Before vs After

**Before:** User taps "Update Now" -> dialog closes -> download runs invisibly -> user sees nothing
**After:** User taps "Update Now" -> progress bar appears with live percentage -> on completion, app restarts (or error notification on failure)
