### PR TITLE
fix(theme): support animated GIF backgrounds from theme store

### DIFF
--- a/lib/providers/neo_assets_provider.dart
+++ b/lib/providers/neo_assets_provider.dart
@@ -148,10 +148,11 @@ class NeoAssetsProvider extends ChangeNotifier {
     );
   }
 
-  /// Synchronous variant for resolving background paths without checking cache integrity.
+  /// Synchronous variant for resolving background paths.
+  /// Checks the cache for both .webp and .gif formats.
   String? getBackgroundForSystemSync(String systemFolderName) {
     if (!hasActiveTheme) return null;
-    return NeoAssetsService.backgroundCachePathSync(
+    return NeoAssetsService.resolveBackgroundPathSync(
       _activeThemeFolder,
       systemFolderName,
     );

--- a/lib/screens/systems_screen/my_systems_section/my_systems_carousel.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_carousel.dart
@@ -654,8 +654,8 @@ class _MySystemsCarouselState extends State<MySystemsCarousel> {
     final customBgPath = system.customBackgroundPath;
     final hasCustomBg = customBgPath != null && customBgPath.isNotEmpty;
 
-    // SCENARIO A: Animated GIF background.
-    if (hasCustomBg && ImageUtils.isGif(customBgPath)) {
+    // SCENARIO A: Animated GIF (custom or theme-provided).
+    if (ImageUtils.isGif(customBgPath)) {
       return Positioned.fill(
         child: Container(
           color: Theme.of(context).colorScheme.surface,
@@ -667,9 +667,22 @@ class _MySystemsCarouselState extends State<MySystemsCarousel> {
       );
     }
 
-    // SCENARIO B: Static Asset resolution (Priority: custom > theme > color).
+    // SCENARIO B: Animated GIF from theme.
     final folderKey = system.primaryFolderName ?? system.folderName ?? '';
     final themeBgPath = hasCustomBg ? null : _themeBackgrounds[folderKey];
+    if (!hasCustomBg && ImageUtils.isGif(themeBgPath)) {
+      return Positioned.fill(
+        child: Container(
+          color: Theme.of(context).colorScheme.surface,
+          child: ShaderGifWidget(
+            imagePath: themeBgPath!,
+            key: ValueKey('${themeBgPath}_${system.imageVersion}'),
+          ),
+        ),
+      );
+    }
+
+    // SCENARIO C: Static Asset resolution (Priority: custom > theme > color).
     final activeBgPath = hasCustomBg ? customBgPath : themeBgPath;
     final hasActiveBg = activeBgPath != null && activeBgPath.isNotEmpty;
 

--- a/lib/screens/systems_screen/my_systems_section/my_systems_carousel.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_carousel.dart
@@ -655,7 +655,7 @@ class _MySystemsCarouselState extends State<MySystemsCarousel> {
     final hasCustomBg = customBgPath != null && customBgPath.isNotEmpty;
 
     // SCENARIO A: Animated GIF (custom or theme-provided).
-    if (ImageUtils.isGif(customBgPath)) {
+    if (hasCustomBg && ImageUtils.isGif(customBgPath)) {
       return Positioned.fill(
         child: Container(
           color: Theme.of(context).colorScheme.surface,

--- a/lib/screens/systems_screen/my_systems_section/system_card.dart
+++ b/lib/screens/systems_screen/my_systems_section/system_card.dart
@@ -283,8 +283,8 @@ class _SystemCardState extends State<SystemCard> {
     final customBgPath = widget.info.customBackgroundPath;
     final hasCustomBg = customBgPath != null && customBgPath.isNotEmpty;
 
-    // SCENARIO A: Animated GIF background.
-    if (hasCustomBg && ImageUtils.isGif(customBgPath)) {
+    // SCENARIO A: Animated GIF (custom or theme-provided).
+    if (ImageUtils.isGif(customBgPath)) {
       return Positioned.fill(
         child: ClipRRect(
           borderRadius: BorderRadius.circular(12.r),
@@ -299,7 +299,25 @@ class _SystemCardState extends State<SystemCard> {
       );
     }
 
-    // SCENARIO B: Static image (Custom or Theme-provided).
+    // SCENARIO B: Animated GIF from theme.
+    if (!hasCustomBg && ImageUtils.isGif(_themeBackgroundPath)) {
+      return Positioned.fill(
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(12.r),
+          child: Container(
+            color: Theme.of(context).colorScheme.surface,
+            child: ShaderGifWidget(
+              imagePath: _themeBackgroundPath!,
+              key: ValueKey(
+                '${_themeBackgroundPath}_${widget.info.imageVersion}',
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    // SCENARIO C: Static image (Custom or Theme-provided).
     final activeBgPath = hasCustomBg ? customBgPath : _themeBackgroundPath;
     final hasActiveBg = activeBgPath != null && activeBgPath.isNotEmpty;
 

--- a/lib/screens/systems_screen/my_systems_section/system_card.dart
+++ b/lib/screens/systems_screen/my_systems_section/system_card.dart
@@ -284,7 +284,7 @@ class _SystemCardState extends State<SystemCard> {
     final hasCustomBg = customBgPath != null && customBgPath.isNotEmpty;
 
     // SCENARIO A: Animated GIF (custom or theme-provided).
-    if (ImageUtils.isGif(customBgPath)) {
+    if (hasCustomBg && ImageUtils.isGif(customBgPath)) {
       return Positioned.fill(
         child: ClipRRect(
           borderRadius: BorderRadius.circular(12.r),

--- a/lib/services/neo_assets_service.dart
+++ b/lib/services/neo_assets_service.dart
@@ -196,13 +196,21 @@ class NeoAssetsService {
   }
 
   /// Returns the remote URL for a specific system background within a theme.
-  static String getBackgroundUrl(String themeFolder, String systemFolderName) {
-    return '$_baseRaw/themes/$themeFolder/backgrounds/$systemFolderName.webp';
+  static String getBackgroundUrl(
+    String themeFolder,
+    String systemFolderName, {
+    String ext = 'webp',
+  }) {
+    return '$_baseRaw/themes/$themeFolder/backgrounds/$systemFolderName.$ext';
   }
 
   /// Returns the remote URL for a specific system logo within a theme.
-  static String getLogoUrl(String themeFolder, String systemFolderName) {
-    return '$_baseRaw/themes/$themeFolder/logos/$systemFolderName.webp';
+  static String getLogoUrl(
+    String themeFolder,
+    String systemFolderName, {
+    String ext = 'webp',
+  }) {
+    return '$_baseRaw/themes/$themeFolder/logos/$systemFolderName.$ext';
   }
 
   /// Returns the remote URL for a theme's metadata JSON file.
@@ -247,39 +255,72 @@ class NeoAssetsService {
   /// Synchronous variant of background path resolution, requires previous initialization.
   static String? backgroundCachePathSync(
     String themeFolder,
-    String systemFolderName,
-  ) {
+    String systemFolderName, {
+    String ext = 'webp',
+  }) {
     final dir = _cachedThemeDir;
     if (dir == null) return null;
-    return path.join(dir, themeFolder, 'backgrounds', '$systemFolderName.webp');
+    return path.join(dir, themeFolder, 'backgrounds', '$systemFolderName.$ext');
   }
 
   /// Synchronous variant of logo path resolution, requires previous initialization.
   static String? logoCachePathSync(
     String themeFolder,
+    String systemFolderName, {
+    String ext = 'webp',
+  }) {
+    final dir = _cachedThemeDir;
+    if (dir == null) return null;
+    return path.join(dir, themeFolder, 'logos', '$systemFolderName.$ext');
+  }
+
+  /// Resolves the cached background path checking both .webp and .gif formats.
+  /// Returns the path to the existing file, preferring .webp over .gif.
+  /// If neither exists, returns the .webp path as default.
+  static String? resolveBackgroundPathSync(
+    String themeFolder,
     String systemFolderName,
   ) {
     final dir = _cachedThemeDir;
     if (dir == null) return null;
-    return path.join(dir, themeFolder, 'logos', '$systemFolderName.webp');
+
+    final webpPath = path.join(
+      dir,
+      themeFolder,
+      'backgrounds',
+      '$systemFolderName.webp',
+    );
+    if (File(webpPath).existsSync()) return webpPath;
+
+    final gifPath = path.join(
+      dir,
+      themeFolder,
+      'backgrounds',
+      '$systemFolderName.gif',
+    );
+    if (File(gifPath).existsSync()) return gifPath;
+
+    return webpPath;
   }
 
   /// Returns the local cache path for a specific background.
   static Future<String> backgroundCachePath(
     String themeFolder,
-    String systemFolderName,
-  ) async {
+    String systemFolderName, {
+    String ext = 'webp',
+  }) async {
     final dir = await _cacheDir();
-    return path.join(dir, themeFolder, 'backgrounds', '$systemFolderName.webp');
+    return path.join(dir, themeFolder, 'backgrounds', '$systemFolderName.$ext');
   }
 
   /// Returns the local cache path for a specific logo.
   static Future<String> logoCachePath(
     String themeFolder,
-    String systemFolderName,
-  ) async {
+    String systemFolderName, {
+    String ext = 'webp',
+  }) async {
     final dir = await _cacheDir();
-    return path.join(dir, themeFolder, 'logos', '$systemFolderName.webp');
+    return path.join(dir, themeFolder, 'logos', '$systemFolderName.$ext');
   }
 
   /// Returns the local cache path for a theme's metadata file.
@@ -349,8 +390,15 @@ class NeoAssetsService {
   ) async {
     int missing = 0;
     for (final system in systemFolderNames) {
-      final bgPath = await backgroundCachePath(themeFolder, system);
-      if (!await File(bgPath).exists()) missing++;
+      final bgWebp = await backgroundCachePath(themeFolder, system);
+      final bgGif = await backgroundCachePath(
+        themeFolder,
+        system,
+        ext: 'gif',
+      );
+      if (!await File(bgWebp).exists() && !await File(bgGif).exists()) {
+        missing++;
+      }
 
       final logoPath = await logoCachePath(themeFolder, system);
       if (!await File(logoPath).exists()) missing++;
@@ -388,13 +436,26 @@ class NeoAssetsService {
   }
 
   /// Retrieves a cached background image, downloading it if necessary.
+  /// Tries .webp first, then falls back to .gif.
   static Future<String?> getCachedBackground(
     String themeFolder,
     String systemFolderName,
   ) async {
-    final localPath = await backgroundCachePath(themeFolder, systemFolderName);
-    final url = getBackgroundUrl(themeFolder, systemFolderName);
-    return downloadAndCacheAsset(url, localPath);
+    final webpPath = await backgroundCachePath(themeFolder, systemFolderName);
+    final webpUrl = getBackgroundUrl(themeFolder, systemFolderName);
+    var result = await downloadAndCacheAsset(webpUrl, webpPath);
+    if (result != null) return result;
+
+    final gifPath = await backgroundCachePath(
+      themeFolder,
+      systemFolderName,
+      ext: 'gif',
+    );
+    final gifUrl = getBackgroundUrl(themeFolder, systemFolderName, ext: 'gif');
+    result = await downloadAndCacheAsset(gifUrl, gifPath);
+    if (result != null) return result;
+
+    return null;
   }
 
   /// Retrieves a cached system logo image, downloading it if necessary.
@@ -442,10 +503,19 @@ class NeoAssetsService {
 
     int done = 0;
     for (final system in systemFolderNames) {
-      final bgPath = await backgroundCachePath(themeFolder, system);
-      if (!await File(bgPath).exists()) {
+      final bgWebp = await backgroundCachePath(themeFolder, system);
+      final bgGif = await backgroundCachePath(
+        themeFolder,
+        system,
+        ext: 'gif',
+      );
+      if (!await File(bgWebp).exists() && !await File(bgGif).exists()) {
         final bgUrl = getBackgroundUrl(themeFolder, system);
-        await downloadAndCacheAsset(bgUrl, bgPath);
+        var result = await downloadAndCacheAsset(bgUrl, bgWebp);
+        if (result == null) {
+          final gifUrl = getBackgroundUrl(themeFolder, system, ext: 'gif');
+          await downloadAndCacheAsset(gifUrl, bgGif);
+        }
         done++;
         onProgress?.call(done, missingTotal);
       }


### PR DESCRIPTION
﻿## Description

When downloading themes from the remote store, the system only looked for `.webp` background files. The theme store now also provides `.gif` backgrounds (animated), but they were never downloaded or rendered with the shader.

This PR adds fallback support: if a `.webp` background is not available (404 or not cached), the system tries `.gif`. If a `.gif` is found, it's rendered with `ShaderGifWidget` for proper animation — the same way custom uploaded GIFs already work.

## Changes

### `lib/services/neo_assets_service.dart`
- `getBackgroundUrl()`, `backgroundCachePathSync()`, `backgroundCachePath()` now accept an optional `ext` parameter (default `'webp'`) to request a specific format
- New `resolveBackgroundPathSync()` — checks cache for `.webp` first, falls back to `.gif`, returns the `.webp` path as default if neither exists
- `getCachedBackground()` — tries to download `.webp` first, then falls back to `.gif` on 404
- `downloadMissingThemeAssets()` — same `.webp` → `.gif` fallback for incremental downloads
- `countMissingThemeAssets()` — counts a background as missing only when both `.webp` and `.gif` are absent

### `lib/providers/neo_assets_provider.dart`
- `getBackgroundForSystemSync()` uses `resolveBackgroundPathSync()` instead of `backgroundCachePathSync()` so the returned path can be a `.gif` file

### `lib/screens/systems_screen/my_systems_section/system_card.dart`
- New SCENARIO B: if no custom background is set and the theme background path ends in `.gif`, renders it with `ShaderGifWidget` (same animated shader used for custom GIF uploads)

### `lib/screens/systems_screen/my_systems_section/my_systems_carousel.dart`
- Same GIF rendering support as system_card for the carousel view

## Behavior
- **Before:** Only `.webp` theme backgrounds were ever considered; GIF files in the theme store were silently ignored
- **After:** `.webp` is preferred (static), `.gif` is used as fallback and rendered with the GPU shader for smooth animation
