### PR TITLE
fix(android): detect installed RetroArch variant and set as default for all systems

### DIFF
--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -4141,6 +4141,45 @@ class SqliteService {
         .toList();
   }
 
+  /// Updates [is_default] across all systems so that [preferredPackage] is the
+  /// active RetroArch variant on Android. Resets all other RetroArch packages
+  /// to non-default, then sets [preferredPackage] as the default.
+  static Future<void> fixRetroArchDefaultForAndroid(
+    String preferredPackage,
+  ) async {
+    final db = await instance.database;
+
+    final osResult = await db.query(
+      'app_os',
+      where: 'name = ?',
+      whereArgs: ['android'],
+    );
+    if (osResult.isEmpty) return;
+    final osId = int.tryParse(osResult.first['id']?.toString() ?? '0') ?? 0;
+
+    await db.transaction((txn) async {
+      await txn.rawUpdate(
+        'UPDATE app_emulators SET is_default = 0 '
+        'WHERE os_id = ? AND android_package_name LIKE ?',
+        [osId, 'com.retroarch%'],
+      );
+      await txn.rawUpdate(
+        'UPDATE app_emulators SET is_default = 1 '
+        'WHERE os_id = ? AND android_package_name = ?',
+        [osId, preferredPackage],
+      );
+    });
+
+    try {
+      await db.execute('PRAGMA wal_checkpoint(FULL)');
+    } catch (e) {
+      _log.e(
+        'Failed to finalize RetroArch default fix via WAL checkpoint',
+        error: e,
+      );
+    }
+  }
+
   /// Retrieves a list of emulators for a system (legacy alias for [getCoresBySystemId]).
   static Future<List<Map<String, dynamic>>> getEmulatorsForSystem(
     String systemId,

--- a/lib/repositories/emulator_repository.dart
+++ b/lib/repositories/emulator_repository.dart
@@ -83,6 +83,9 @@ class EmulatorRepository {
   static Future<List<String>> getAndroidRetroArchPackages() =>
       SqliteService.getAndroidRetroArchPackages();
 
+  static Future<void> fixRetroArchDefaultForAndroid(String preferredPackage) =>
+      SqliteService.fixRetroArchDefaultForAndroid(preferredPackage);
+
   /// Resolves the detected RetroArch executable path for the current OS.
   static Future<String?> getRetroArchExecutablePath() async {
     final db = await SqliteService.getDatabase();

--- a/lib/screens/app_screen.dart
+++ b/lib/screens/app_screen.dart
@@ -16,7 +16,10 @@ import 'neo_sync_screen/login_screen/neo_sync_content.dart';
 import 'neo_sync_screen/neo_sync_tab.dart';
 import '../widgets/scraper_content.dart';
 import 'package:neostation/services/game_service.dart';
+import 'package:neostation/services/android_service.dart';
 import 'package:neostation/providers/palette_provider.dart';
+import 'package:neostation/repositories/emulator_repository.dart';
+import 'dart:async';
 import 'dart:io';
 
 /// The root screen of the application, managing high-level navigation tabs.
@@ -168,6 +171,45 @@ class AppScreenState extends State<AppScreen> {
         configProvider.hasRomFolder &&
         mounted) {
       configProvider.scanSystems();
+    }
+
+    unawaited(_fixRetroarchAndroidDefault());
+  }
+
+  /// Detects which RetroArch variant the user has installed on Android and sets
+  /// it as the default package for all systems. Priority order:
+  ///   com.retroarch.aarch64 > com.retroarch > com.retroarch.ra32
+  Future<void> _fixRetroarchAndroidDefault() async {
+    if (!Platform.isAndroid) return;
+
+    try {
+      final packages = await EmulatorRepository.getAndroidRetroArchPackages();
+      if (packages.isEmpty) return;
+
+      const priorityOrder = [
+        'com.retroarch.aarch64',
+        'com.retroarch',
+        'com.retroarch.ra32',
+      ];
+
+      String? chosenPackage;
+      for (final pkg in priorityOrder) {
+        if (packages.contains(pkg) &&
+            await AndroidService.isPackageInstalled(pkg)) {
+          chosenPackage = pkg;
+          break;
+        }
+      }
+
+      chosenPackage ??= priorityOrder.firstWhere(
+        (p) => packages.contains(p),
+        orElse: () => 'com.retroarch.aarch64',
+      );
+
+      await EmulatorRepository.fixRetroArchDefaultForAndroid(chosenPackage);
+      _log.i('Android: Set RetroArch default package to $chosenPackage');
+    } catch (e) {
+      _log.e('Failed to fix RetroArch default package', error: e);
     }
   }
 


### PR DESCRIPTION
﻿## Description

On Android, the default RetroArch package was hardcoded to `com.retroarch` (generic/32-bit) for all 88 systems in the `app_emulators` table. Users who only have `com.retroarch.aarch64` (64-bit) installed could not launch any game via RetroArch cores — the system would fail with *"emulator not installed or activity missing: com.retroarch"* and never fall through to try the installed variant.

This PR adds a startup check that detects which RetroArch variant is actually installed and sets it as the default for all systems.

## Changes

### `lib/data/datasources/sqlite_service.dart`
- New `fixRetroArchDefaultForAndroid(preferredPackage)` method that:
  - Resets `is_default = 0` for all RetroArch entries (`android_package_name LIKE 'com.retroarch%'`)
  - Sets `is_default = 1` for the chosen package across all systems
  - Forces a WAL checkpoint to persist the change

### `lib/repositories/emulator_repository.dart`
- Pass-through for `fixRetroArchDefaultForAndroid`

### `lib/screens/app_screen.dart`
- New `_fixRetroarchAndroidDefault()` method called at the end of the startup update sequence (non-blocking via `unawaited`)
- Checks installed packages via `AndroidService.isPackageInstalled()` (wraps `PackageManager.getPackageInfo()`)
- Priority order: `com.retroarch.aarch64` > `com.retroarch` > `com.retroarch.ra32`
- If none is installed, falls back to the same priority order (defaults to `aarch64`)

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| User has `com.retroarch.aarch64` only | Fails — tries `com.retroarch` first | Works — detects aarch64, sets it as default |
| User has `com.retroarch` only | Works (coincidence) | Works — detects generic, keeps it as default |
| User has `com.retroarch.ra32` only | Fails — tries `com.retroarch` first | Works — detects ra32, sets it as default |
| User has all 3 installed | Works with generic | Works with aarch64 (highest priority) |
| User has no RetroArch | Fails | Fails (no change, but defaults to aarch64 which is the recommended variant) |
