### PR TITLE
fix(systems): stop secondary-display recursion in the systems carousel

### DIFF
--- a/lib/screens/systems_screen/my_systems_section/my_systems_carousel.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_carousel.dart
@@ -131,10 +131,15 @@ class _MySystemsCarouselState extends State<MySystemsCarousel> {
   void _onSecondaryStateChanged() {
     if (!mounted) return;
     final isActive = _secondaryDisplayState?.value?.isSecondaryActive ?? false;
-    if (isActive && !_prevIsSecondaryActive) {
+    final wasActive = _prevIsSecondaryActive;
+    // Update the guard BEFORE calling _updateSecondaryScreenName(): that call
+    // writes secondary state synchronously, which re-enters this listener. If
+    // the flag were still false on re-entry the guard would pass again, looping
+    // until the stack overflows. Setting it first makes the re-entry a no-op.
+    _prevIsSecondaryActive = isActive;
+    if (isActive && !wasActive) {
       _updateSecondaryScreenName();
     }
-    _prevIsSecondaryActive = isActive;
   }
 
   @override


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

## Summary

`MySystemsCarousel` carried an un-patched copy of the secondary-display stack-overflow bug that #59 fixed in `MySystemsGrid`. Selecting the **All systems** carousel on a device with a secondary screen (e.g. AYN Thor) drove `_onSecondaryStateChanged` ~30,000 frames deep until Dart aborted with `Stack Overflow`, surfacing as a visible delay before the carousel rendered.

## Root cause

`_onSecondaryStateChanged` set its `_prevIsSecondaryActive` guard **after** calling `_updateSecondaryScreenName()`. That call writes secondary state synchronously (`updateState` → `SharedState.setState` → `notifyListeners`), re-entering the listener before the guard was set — so the `isActive && !_prevIsSecondaryActive` edge condition kept re-firing and recursed until the stack overflowed.

## Fix

Set the guard **before** the call (capturing the prior value in `wasActive`) so the synchronous re-entry short-circuits — mirroring the #59 fix already present in `MySystemsGrid`. One file, +7/−2.

## Testing

- Reproduced the hitch on the AYN Thor (dev channel): LB/RB onto **All systems** → multi-second stall, `Stack Overflow` in logcat with the `_onSecondaryStateChanged → _updateSecondaryScreenName → SharedState.setState → notifyListeners` cycle.
- After the fix (clean rebuild + deploy): hitch gone, no recursion in logcat. ✅
- `flutter analyze` clean; `flutter test` all passing (113).

## Related

Completes #59 — that PR fixed the grid path but missed the identical carousel copy.