### PR TITLE
chore: fix formatter drift from newer stable Dart

### DIFF
--- a/lib/services/neo_assets_service.dart
+++ b/lib/services/neo_assets_service.dart
@@ -391,11 +391,7 @@ class NeoAssetsService {
     int missing = 0;
     for (final system in systemFolderNames) {
       final bgWebp = await backgroundCachePath(themeFolder, system);
-      final bgGif = await backgroundCachePath(
-        themeFolder,
-        system,
-        ext: 'gif',
-      );
+      final bgGif = await backgroundCachePath(themeFolder, system, ext: 'gif');
       if (!await File(bgWebp).exists() && !await File(bgGif).exists()) {
         missing++;
       }
@@ -504,11 +500,7 @@ class NeoAssetsService {
     int done = 0;
     for (final system in systemFolderNames) {
       final bgWebp = await backgroundCachePath(themeFolder, system);
-      final bgGif = await backgroundCachePath(
-        themeFolder,
-        system,
-        ext: 'gif',
-      );
+      final bgGif = await backgroundCachePath(themeFolder, system, ext: 'gif');
       if (!await File(bgWebp).exists() && !await File(bgGif).exists()) {
         final bgUrl = getBackgroundUrl(themeFolder, system);
         var result = await downloadAndCacheAsset(bgUrl, bgWebp);

--- a/lib/widgets/update_dialog.dart
+++ b/lib/widgets/update_dialog.dart
@@ -296,12 +296,11 @@ class _UpdateDialogState extends State<UpdateDialog> {
       _downloadProgress = 0.0;
     });
 
-    final success = await UpdateService.downloadAndInstall(
-      widget.updateInfo,
-      (progress) {
-        if (mounted) setState(() => _downloadProgress = progress);
-      },
-    );
+    final success = await UpdateService.downloadAndInstall(widget.updateInfo, (
+      progress,
+    ) {
+      if (mounted) setState(() => _downloadProgress = progress);
+    });
 
     if (!mounted) return;
 


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

## Summary

Re-runs `dart format .` to match the output of the current stable Dart formatter. No logic changes — only whitespace reflow of three multi-line call expressions that newer stable Dart now packs differently.

This resolves format drift that fails the **Verify formatting** CI step (`dart format --output=none --set-exit-if-changed .`) on a fresh `stable` channel runner.

## Changes
- `lib/services/neo_assets_service.dart` — collapse two `backgroundCachePath(..., ext: 'gif')` calls onto one line.
- `lib/widgets/update_dialog.dart` — reflow the `downloadAndInstall` call's progress callback.

## Verification
- `dart format --output=none --set-exit-if-changed .` → clean (0 changed, 312 files).
