### PR TITLE
feat(secondary): mirror main-screen fanart + logo on secondary, refresh on scrape

### DIFF
--- a/lib/models/secondary_display_state.dart
+++ b/lib/models/secondary_display_state.dart
@@ -97,6 +97,13 @@ class SecondaryDisplayStateData {
   /// Whether to optimize the secondary display for OLED panels (e.g., using pure blacks).
   final bool isOled;
 
+  /// Monotonic counter bumped whenever the current game's media is rewritten in
+  /// place (e.g. a re-scrape with forceOverwrite). The image paths stay the same
+  /// but their bytes change, so the secondary engine — which has its own image
+  /// cache and keys its widgets on the path — needs this to know it must evict
+  /// and re-decode rather than show the stale cached bitmap.
+  final int mediaRevision;
+
   SecondaryDisplayStateData({
     required this.systemName,
     this.gameFanart,
@@ -127,6 +134,7 @@ class SecondaryDisplayStateData {
     this.shaderColor2,
     this.useFluidShader = false,
     this.isOled = false,
+    this.mediaRevision = 0,
   });
 
   /// Returns a new instance with the specified properties updated.
@@ -170,6 +178,7 @@ class SecondaryDisplayStateData {
     int? shaderColor2,
     bool? useFluidShader,
     bool? isOled,
+    int? mediaRevision,
   }) {
     return SecondaryDisplayStateData(
       systemName: systemName ?? this.systemName,
@@ -211,6 +220,7 @@ class SecondaryDisplayStateData {
       shaderColor2: shaderColor2 ?? this.shaderColor2,
       useFluidShader: useFluidShader ?? this.useFluidShader,
       isOled: isOled ?? this.isOled,
+      mediaRevision: mediaRevision ?? this.mediaRevision,
     );
   }
 
@@ -248,6 +258,7 @@ class SecondaryDisplayStateData {
       shaderColor2: json['shaderColor2'] as int?,
       useFluidShader: json['useFluidShader'] as bool? ?? false,
       isOled: json['isOled'] as bool? ?? false,
+      mediaRevision: json['mediaRevision'] as int? ?? 0,
     );
   }
 
@@ -285,6 +296,7 @@ class SecondaryDisplayStateData {
       'shaderColor2': shaderColor2,
       'useFluidShader': useFluidShader,
       'isOled': isOled,
+      'mediaRevision': mediaRevision,
     };
   }
 }
@@ -347,6 +359,7 @@ class SecondaryDisplayState extends SharedState<SecondaryDisplayStateData> {
     int? shaderColor2,
     bool? useFluidShader,
     bool? isOled,
+    int? mediaRevision,
   }) async {
     if (!Platform.isAndroid) return;
 
@@ -395,6 +408,7 @@ class SecondaryDisplayState extends SharedState<SecondaryDisplayStateData> {
           shaderColor2: shaderColor2,
           useFluidShader: useFluidShader,
           isOled: isOled,
+          mediaRevision: mediaRevision,
         ),
       );
     } catch (e) {

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -783,6 +783,12 @@ class _SystemGamesListState extends State<SystemGamesList> {
       _fileProvider,
     );
 
+    final wheelPath = game.getImagePath(
+      systemFolderName,
+      'wheels',
+      _fileProvider,
+    );
+
     final videoPath = _getVideoPath(game);
     final videoExists = await _fileProvider.fileExists(videoPath);
 
@@ -815,6 +821,10 @@ class _SystemGamesListState extends State<SystemGamesList> {
                       : null)) ||
         currentState.gameVideo !=
             (isMusicSystem ? null : (videoExists ? videoPath : null)) ||
+        currentState.gameWheel !=
+            (isMusicSystem
+                ? null
+                : (File(wheelPath).existsSync() ? wheelPath : null)) ||
         currentState.isVideoMuted != isVideoMuted ||
         currentState.isGameLaunching != _isGameLaunching;
 
@@ -822,6 +832,7 @@ class _SystemGamesListState extends State<SystemGamesList> {
       final bool hasFanart = !isMusicSystem && File(fanartPath).existsSync();
       final bool hasScreenshot =
           !isMusicSystem && File(screenshotPath).existsSync();
+      final bool hasWheel = !isMusicSystem && File(wheelPath).existsSync();
 
       // ignore: unawaited_futures
       _secondaryDisplayState?.updateState(
@@ -830,8 +841,8 @@ class _SystemGamesListState extends State<SystemGamesList> {
         gameScreenshot: hasScreenshot ? screenshotPath : null,
         clearFanart: !hasFanart,
         clearScreenshot: !hasScreenshot,
-        gameWheel: null,
-        clearWheel: true,
+        gameWheel: hasWheel ? wheelPath : null,
+        clearWheel: !hasWheel,
         gameVideo: null, // Reset video state during active scrolling.
         clearVideo: true,
         gameImageBytes: null,

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -404,6 +404,14 @@ class _SystemGamesListState extends State<SystemGamesList> {
               // off whether a description is present).
               if (_selectedGame?.romname == romname) {
                 _loadLocalizedDescription();
+                // Push the freshly-scraped media to the secondary screen and
+                // the main background right away. The main list rebuilds from
+                // _selectedGame via setState, but the secondary window is a
+                // separate engine fed only through _updateSecondaryDisplay —
+                // without this it stays stale until the selection changes.
+                _updateBackground(updatedGame);
+                _updateSecondaryDisplay(updatedGame, forceMediaRefresh: true);
+                _updateSecondaryDisplayVideo(updatedGame);
               }
             }
           }
@@ -761,7 +769,16 @@ class _SystemGamesListState extends State<SystemGamesList> {
   }
 
   /// Synchronizes selection metadata and assets with secondary hardware displays.
-  void _updateSecondaryDisplay(GameModel game) async {
+  ///
+  /// [forceMediaRefresh] forces a push even when every media path is unchanged
+  /// and bumps [SecondaryDisplayStateData.mediaRevision]. Use it after a
+  /// re-scrape (forceOverwrite) rewrites the art in place: the paths stay the
+  /// same, so the dedup below would otherwise skip the update and the secondary
+  /// engine would keep showing the stale cached bitmap.
+  void _updateSecondaryDisplay(
+    GameModel game, {
+    bool forceMediaRefresh = false,
+  }) async {
     if (_secondaryDisplayState == null || _isNavigatingBack) return;
 
     final systemFolderName =
@@ -800,9 +817,12 @@ class _SystemGamesListState extends State<SystemGamesList> {
 
     final isMusicSystem = widget.system.folderName == 'music';
 
-    // State optimization: Skip updates if metadata remains identical.
+    // State optimization: Skip updates if metadata remains identical. A forced
+    // media refresh (post re-scrape) always pushes — the paths are unchanged
+    // but their bytes are not, so the secondary engine must be told to re-decode.
     final currentState = _secondaryDisplayState?.value;
     final bool shouldUpdate =
+        forceMediaRefresh ||
         currentState == null ||
         currentState.systemName != widget.system.realName ||
         currentState.gameId !=
@@ -859,6 +879,11 @@ class _SystemGamesListState extends State<SystemGamesList> {
             ? MusicPlayerService().activeTrack?.romPath
             : game.romPath,
         isScraperLoggedIn: isScraperLoggedIn,
+        // Bump the revision on a forced refresh so the secondary engine evicts
+        // its now-stale cached bitmaps and re-decodes the same paths from disk.
+        mediaRevision: forceMediaRefresh
+            ? (currentState?.mediaRevision ?? 0) + 1
+            : null,
       );
     }
 

--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -214,7 +214,8 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                                             fit: BoxFit
                                                 .contain, // "se debe ver completo"
                                           )
-                                        else if (value.gameFanart != null)
+                                        else if (value.gameFanart != null ||
+                                            value.gameWheel != null)
                                           _buildFanartWithLogo(value),
                                       ] else ...[
                                         if (value.gameImageBytes != null)
@@ -229,7 +230,8 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                                             fit: BoxFit
                                                 .contain, // "se debe ver completo"
                                           )
-                                        else if (value.gameFanart != null)
+                                        else if (value.gameFanart != null ||
+                                            value.gameWheel != null)
                                           _buildFanartWithLogo(value),
                                       ],
                                     ],
@@ -343,12 +345,15 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
 
   /// Mirrors the main screen's game art as a fallback when no screenshot or
   /// video is available: fanart filling the screen (cover) with the game's
-  /// wheel/logo centered on top.
+  /// wheel/logo centered on top. Either asset is optional — a logo-only game
+  /// shows just the centered logo over the app background, and a fanart-only
+  /// game shows just the fanart.
   Widget _buildFanartWithLogo(SecondaryDisplayStateData value) {
     return Stack(
       fit: StackFit.expand,
       children: [
-        _buildBackground(value.gameFanart!, fit: BoxFit.cover),
+        if (value.gameFanart != null)
+          _buildBackground(value.gameFanart!, fit: BoxFit.cover),
         if (value.gameWheel != null)
           Center(
             child: Padding(

--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -353,12 +353,33 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
           Center(
             child: Padding(
               padding: EdgeInsets.all(48.r),
-              child: Image.file(
-                File(value.gameWheel!),
-                fit: BoxFit.contain,
-                width: 600.r,
-                errorBuilder: (context, error, stackTrace) =>
-                    const SizedBox.shrink(),
+              child: Stack(
+                alignment: Alignment.center,
+                children: [
+                  // Drop shadow: black-tinted copy offset behind the logo,
+                  // mirroring the main screen's wheel shadow treatment.
+                  Transform.translate(
+                    offset: Offset(4.r, 4.r),
+                    child: Image.file(
+                      File(value.gameWheel!),
+                      fit: BoxFit.contain,
+                      width: 600.r,
+                      filterQuality: FilterQuality.low,
+                      cacheWidth: 32,
+                      color: Colors.black.withValues(alpha: 0.7),
+                      errorBuilder: (context, error, stackTrace) =>
+                          const SizedBox.shrink(),
+                    ),
+                  ),
+                  Image.file(
+                    File(value.gameWheel!),
+                    fit: BoxFit.contain,
+                    width: 600.r,
+                    cacheWidth: 640,
+                    errorBuilder: (context, error, stackTrace) =>
+                        const SizedBox.shrink(),
+                  ),
+                ],
               ),
             ),
           ),

--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -195,7 +195,7 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                                     ),
                                 child: Stack(
                                   key: ValueKey(
-                                    'game_content_${value.systemName}_${value.gameId}_${value.gameScreenshot ?? 'none'}_${value.gameImageBytes != null ? value.gameImageBytes.hashCode : 'none'}',
+                                    'game_content_${value.systemName}_${value.gameId}_${value.gameScreenshot ?? 'none'}_${value.gameFanart ?? 'none'}_${value.gameWheel ?? 'none'}_${value.gameImageBytes != null ? value.gameImageBytes.hashCode : 'none'}',
                                   ),
                                   fit: StackFit.expand,
                                   children: [
@@ -213,7 +213,9 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                                             value.gameScreenshot!,
                                             fit: BoxFit
                                                 .contain, // "se debe ver completo"
-                                          ),
+                                          )
+                                        else if (value.gameFanart != null)
+                                          _buildFanartWithLogo(value),
                                       ] else ...[
                                         if (value.gameImageBytes != null)
                                           _buildBackgroundBytes(
@@ -226,7 +228,9 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                                             value.gameScreenshot!,
                                             fit: BoxFit
                                                 .contain, // "se debe ver completo"
-                                          ),
+                                          )
+                                        else if (value.gameFanart != null)
+                                          _buildFanartWithLogo(value),
                                       ],
                                     ],
                                   ],
@@ -335,6 +339,31 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
 
   Widget _buildDefaultBackground() {
     return const SizedBox.shrink();
+  }
+
+  /// Mirrors the main screen's game art as a fallback when no screenshot or
+  /// video is available: fanart filling the screen (cover) with the game's
+  /// wheel/logo centered on top.
+  Widget _buildFanartWithLogo(SecondaryDisplayStateData value) {
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        _buildBackground(value.gameFanart!, fit: BoxFit.cover),
+        if (value.gameWheel != null)
+          Center(
+            child: Padding(
+              padding: EdgeInsets.all(48.r),
+              child: Image.file(
+                File(value.gameWheel!),
+                fit: BoxFit.contain,
+                width: 600.r,
+                errorBuilder: (context, error, stackTrace) =>
+                    const SizedBox.shrink(),
+              ),
+            ),
+          ),
+      ],
+    );
   }
 
   Widget _buildUnifiedAppBackground(SecondaryDisplayStateData value) {

--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -23,6 +23,7 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
   Timer? _videoTimer;
   bool _showVideo = false;
   String? _currentVideoPath;
+  int _lastMediaRevision = 0;
 
   @override
   void initState() {
@@ -42,6 +43,20 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
   void _onStateChanged() {
     final state = _secondaryDisplayState?.value;
     if (state == null) return;
+
+    // A re-scrape rewrites the art at the same path, so this engine's image
+    // cache still holds the old bitmap. When the producer bumps mediaRevision,
+    // clear the cache so the rebuild (its ValueKey also carries the revision)
+    // re-decodes the fresh bytes from disk. The secondary engine only ever
+    // shows one game's art, so a full clear is cheap — and it correctly drops
+    // the wheel's ResizeImage-wrapped entries, which a bare FileImage.evict
+    // would miss.
+    if (state.mediaRevision != _lastMediaRevision) {
+      _lastMediaRevision = state.mediaRevision;
+      final imageCache = PaintingBinding.instance.imageCache;
+      imageCache.clear();
+      imageCache.clearLiveImages();
+    }
 
     if (state.isGameLaunching) {
       _stopVideo();
@@ -195,7 +210,7 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                                     ),
                                 child: Stack(
                                   key: ValueKey(
-                                    'game_content_${value.systemName}_${value.gameId}_${value.gameScreenshot ?? 'none'}_${value.gameFanart ?? 'none'}_${value.gameWheel ?? 'none'}_${value.gameImageBytes != null ? value.gameImageBytes.hashCode : 'none'}',
+                                    'game_content_${value.systemName}_${value.gameId}_${value.gameScreenshot ?? 'none'}_${value.gameFanart ?? 'none'}_${value.gameWheel ?? 'none'}_${value.gameImageBytes != null ? value.gameImageBytes.hashCode : 'none'}_${value.mediaRevision}',
                                   ),
                                   fit: StackFit.expand,
                                   children: [

--- a/lib/services/neo_assets_service.dart
+++ b/lib/services/neo_assets_service.dart
@@ -391,11 +391,7 @@ class NeoAssetsService {
     int missing = 0;
     for (final system in systemFolderNames) {
       final bgWebp = await backgroundCachePath(themeFolder, system);
-      final bgGif = await backgroundCachePath(
-        themeFolder,
-        system,
-        ext: 'gif',
-      );
+      final bgGif = await backgroundCachePath(themeFolder, system, ext: 'gif');
       if (!await File(bgWebp).exists() && !await File(bgGif).exists()) {
         missing++;
       }
@@ -504,11 +500,7 @@ class NeoAssetsService {
     int done = 0;
     for (final system in systemFolderNames) {
       final bgWebp = await backgroundCachePath(themeFolder, system);
-      final bgGif = await backgroundCachePath(
-        themeFolder,
-        system,
-        ext: 'gif',
-      );
+      final bgGif = await backgroundCachePath(themeFolder, system, ext: 'gif');
       if (!await File(bgWebp).exists() && !await File(bgGif).exists()) {
         final bgUrl = getBackgroundUrl(themeFolder, system);
         var result = await downloadAndCacheAsset(bgUrl, bgWebp);

--- a/lib/widgets/update_dialog.dart
+++ b/lib/widgets/update_dialog.dart
@@ -296,12 +296,11 @@ class _UpdateDialogState extends State<UpdateDialog> {
       _downloadProgress = 0.0;
     });
 
-    final success = await UpdateService.downloadAndInstall(
-      widget.updateInfo,
-      (progress) {
-        if (mounted) setState(() => _downloadProgress = progress);
-      },
-    );
+    final success = await UpdateService.downloadAndInstall(widget.updateInfo, (
+      progress,
+    ) {
+      if (mounted) setState(() => _downloadProgress = progress);
+    });
 
     if (!mounted) return;
 


### PR DESCRIPTION
> 🤖 This PR was developed with the assistance of [Claude Code](https://claude.com/claude-code).

## What

When the main screen has no screenshot/video for a game, the secondary display now mirrors the main-screen fanart + logo (with a drop shadow), and shows logo-only games on the fallback. This PR also fixes two issues found while testing the fallback on-device:

- **Secondary screen didn't refresh after a scrape.** A scrape updated the selected game and rebuilt the main list, but never re-pushed to the secondary window (a separate Flutter engine fed only through `_updateSecondaryDisplay`). The art only appeared after changing selection and coming back. The scrape-completion handler now refreshes the background, secondary display, and secondary video for the selected game immediately.
- **Re-scrape (forceOverwrite) didn't update in place.** When art is rewritten at the same path, the path-equality dedup guard skipped the push and the secondary engine kept its cached bitmap. A new `mediaRevision` token is threaded through `SecondaryDisplayStateData` so a forced refresh bypasses the dedup and tells the secondary engine to clear its image cache and re-decode (its widget `ValueKey` carries the revision so the `AnimatedSwitcher` swaps to fresh bytes). A full cache clear is used rather than per-path `FileImage.evict()` because the wheel renders via `ResizeImage` (`cacheWidth`), whose entry a bare evict would miss.

## Note on the formatting commit

This branch includes a small formatting-only commit for `neo_assets_service.dart` and `update_dialog.dart`. These have formatter drift from a newer stable Dart and would fail the repo-wide `dart format --set-exit-if-changed .` CI check, even though they're unrelated to this feature. The changes are pulled verbatim from #80, so they're byte-identical — whichever PR merges first, the other's formatting commit becomes a no-op. No conflict expected.

## Testing

- `flutter analyze` clean, all 113 tests pass.
- Verified on an AYN Thor (Android, dev channel): fanart/logo fallback on the secondary screen, immediate refresh on first scrape, and immediate refresh on re-scrape of art that already existed.
