### PR TITLE
added armsx2 refresh emulator for ps2

### DIFF
--- a/assets/systems/ps2.json
+++ b/assets/systems/ps2.json
@@ -257,6 +257,18 @@
       }
     },
     {
+      "name": "Standalone ARMSX2 Refresh",
+      "unique_id": "ps2.com.armsx2",
+      "description": "Supported extensions: iso, chd, gz, mdf, bin, ciso, img.",
+      "is_retroachievements_compatible": true,
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.armsx2/.Main -a android.intent.action.VIEW -d \"{file.uri}\""
+        }
+      }
+    },
+
+    {
       "name": "Standalone PCSX2",
       "unique_id": "ps2.net.pcsx2.android",
       "description": "Supported extensions: iso, chd, gz, mdf, bin, ciso, img.",


### PR DESCRIPTION
# Description

Added ARMSX2 Refresh version as a PS2 Emulator. This emulator has been hardcore verified by RetroAchievements as they end support for NetherSX2 Hardcore achievements.

Tested on AYN Thor Max.

Fixes # 89

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [X] I have run `flutter analyze` and there are no errors.
- [X] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [X] My changes do not introduce secrets, credentials, or sensitive data.
- [X] I have verified that any new assets have compatible licenses.
- [X] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [X] Android
- [X] **Gamepad support verified** (if applicable).

## Screenshots (if applicable)

Add screenshots or GIFs showing the visual change.
