### PR TITLE
feat: replace old default flag with default_core and default_standalone

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,3 +1,3 @@
 {
-  "latest_version": "0.3.2"
+  "latest_version": "0.3.3"
 }

--- a/assets/systems/2600.json
+++ b/assets/systems/2600.json
@@ -34,7 +34,7 @@
   "emulators": [
     {
       "name": "RetroArch Stella",
-      "default": true,
+      "default_core": true,
       "unique_id": "2600.ra.stella",
       "is_retroachievements_compatible": true,
       "description": "Supported extensions: a26, bin, zip",
@@ -80,6 +80,7 @@
     },
     {
       "name": "RetroArch64 Stella",
+      "default_core": true,
       "unique_id": "2600.ra64.stella",
       "is_retroachievements_compatible": true,
       "description": "Supported extensions: a26, bin, zip",
@@ -113,6 +114,7 @@
     },
     {
       "name": "RetroArch32 Stella",
+      "default_core": true,
       "unique_id": "2600.ra32.stella",
       "is_retroachievements_compatible": true,
       "description": "Supported extensions: a26, bin, zip",

--- a/assets/systems/32x.json
+++ b/assets/systems/32x.json
@@ -47,7 +47,7 @@
   "emulators": [
     {
       "name": "RetroArch PicoDrive",
-      "default": true,
+      "default_core": true,
       "unique_id": "32x.ra.picodrive",
       "is_retroachievements_compatible": true,
       "description": "Supported extensions: 32x, 68k, bin, chd, cue, gen, gg, iso, m3u, md, pco, sgd, smd, sms, 7z, zip.",
@@ -71,6 +71,7 @@
     },
     {
       "name": "RetroArch64 PicoDrive",
+      "default_core": true,
       "unique_id": "32x.ra64.picodrive",
       "is_retroachievements_compatible": true,
       "description": "Supported extensions: 32x, 68k, bin, chd, cue, gen, gg, iso, m3u, md, pco, sgd, smd, sms, 7z, zip.",
@@ -82,6 +83,7 @@
     },
     {
       "name": "RetroArch32 PicoDrive",
+      "default_core": true,
       "unique_id": "32x.ra32.picodrive",
       "is_retroachievements_compatible": true,
       "description": "Supported extensions: 32x, 68k, bin, chd, cue, gen, gg, iso, m3u, md, pco, sgd, smd, sms, 7z, zip.",

--- a/assets/systems/3do.json
+++ b/assets/systems/3do.json
@@ -34,7 +34,7 @@
   "emulators": [
     {
       "name": "RetroArch Opera",
-      "default": true,
+      "default_core": true,
       "unique_id": "3do.ra.opera",
       "is_retroachievements_compatible": true,
       "description": "Supported extensions: bin, chd, cue, iso, zip.",
@@ -58,6 +58,7 @@
     },
     {
       "name": "RetroArch64 Opera",
+      "default_core": true,
       "unique_id": "3do.ra64.opera",
       "is_retroachievements_compatible": true,
       "description": "Supported extensions: bin, chd, cue, iso, zip.",
@@ -69,6 +70,7 @@
     },
     {
       "name": "RetroArch32 Opera",
+      "default_core": true,
       "unique_id": "3do.ra32.opera",
       "is_retroachievements_compatible": true,
       "description": "Supported extensions: bin, chd, cue, iso, zip.",

--- a/assets/systems/3ds.json
+++ b/assets/systems/3ds.json
@@ -37,7 +37,7 @@
   "emulators": [
     {
       "name": "RetroArch Citra",
-      "default": true,
+      "default_core": true,
       "unique_id": "3ds.ra.citra",
       "is_retroachievements_compatible": false,
       "description": "Supported extensions: 3ds, 3dsx, app, axf, cci, cxi, elf.",
@@ -107,6 +107,7 @@
     },
     {
       "name": "RetroArch64 Citra",
+      "default_core": true,
       "unique_id": "3ds.ra64.citra",
       "is_retroachievements_compatible": false,
       "description": "Supported extensions: 3ds, 3dsx, app, axf, cci, cxi, elf.",
@@ -140,6 +141,7 @@
     },
     {
       "name": "RetroArch32 Citra",
+      "default_core": true,
       "unique_id": "3ds.ra32.citra",
       "is_retroachievements_compatible": false,
       "description": "Supported extensions: 3ds, 3dsx, app, axf, cci, cxi, elf.",

--- a/assets/systems/5200.json
+++ b/assets/systems/5200.json
@@ -54,6 +54,7 @@
     },
     {
       "name": "RetroArch64 a5200",
+      "default_core": true,
       "unique_id": "5200.atari5200.ra64.a5200",
       "description": "Supported extensions: a52, bin.",
       "is_retroachievements_compatible": false,
@@ -76,6 +77,7 @@
     },
     {
       "name": "RetroArch32 a5200",
+      "default_core": true,
       "unique_id": "5200.atari5200.ra32.a5200",
       "description": "Supported extensions: a52, bin.",
       "is_retroachievements_compatible": false,
@@ -87,7 +89,6 @@
     },
     {
       "name": "RetroArch atari800",
-      "default": true,
       "unique_id": "5200.atari5200.ra.atari800",
       "description": "Supported extensions: a52, atr, atx, bin, car, cas, cdm, com, rom, xex, xfd, zip.",
       "is_retroachievements_compatible": false,
@@ -111,6 +112,7 @@
     },
     {
       "name": "RetroArch a5200",
+      "default_core": true,
       "unique_id": "5200.atari5200.ra.a5200",
       "description": "Supported extensions: a52, bin.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/7800.json
+++ b/assets/systems/7800.json
@@ -34,7 +34,7 @@
   "emulators": [
     {
       "name": "RetroArch ProSystem",
-      "default": true,
+      "default_core": true,
       "unique_id": "7800.ra.prosystem",
       "is_retroachievements_compatible": true,
       "description": "Supported extensions: a78, bin, zip, 7z.",
@@ -58,6 +58,7 @@
     },
     {
       "name": "RetroArch64 ProSystem",
+      "default_core": true,
       "unique_id": "7800.ra64.prosystem",
       "is_retroachievements_compatible": true,
       "description": "Supported extensions: a78, bin, zip, 7z.",
@@ -69,6 +70,7 @@
     },
     {
       "name": "RetroArch32 ProSystem",
+      "default_core": true,
       "unique_id": "7800.ra32.prosystem",
       "is_retroachievements_compatible": true,
       "description": "Supported extensions: a78, bin, zip, 7z.",

--- a/assets/systems/a2.json
+++ b/assets/systems/a2.json
@@ -45,7 +45,7 @@
   "emulators": [
     {
       "name": "RetroArch AppleWin",
-      "default": true,
+      "default_core": true,
       "unique_id": "a2.ra.applewin",
       "is_retroachievements_compatible": false,
       "description": "Supported extensions: cmd.",
@@ -91,6 +91,30 @@
       }
     },
     {
+      "name": "RetroArch64 AppleWin",
+      "default_core": true,
+      "unique_id": "a2.ra64.applewin",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: cmd.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.retroarch.aarch64/com.retroarch.browser.retroactivity.RetroActivityFuture --es ROM \"{file.path}\" --es LIBRETRO \"applewin\""
+        },
+        "windows": {
+          "executable": "retroarch.exe",
+          "args": "-L applewin_libretro.dll \"{file.path}\""
+        },
+        "linux": {
+          "executable": "retroarch",
+          "args": "-L applewin_libretro.so \"{file.path}\""
+        },
+        "macos": {
+          "executable": "RetroArch.App",
+          "args": "-L applewin_libretro.dylib \"{file.path}\""
+        }
+      }
+    },
+    {
       "name": "RetroArch64 MAME/MESS",
       "unique_id": "a2.ra64.mess",
       "is_retroachievements_compatible": false,
@@ -98,6 +122,30 @@
       "platforms": {
         "android": {
           "launch_arguments": "-n com.retroarch.aarch64/com.retroarch.browser.retroactivity.RetroActivityFuture --es ROM \"{file.path}\" --es LIBRETRO \"mamemess\""
+        }
+      }
+    },
+    {
+      "name": "RetroArch32 AppleWin",
+      "default_core": true,
+      "unique_id": "a2.ra32.applewin",
+      "is_retroachievements_compatible": false,
+      "description": "Supported extensions: cmd.",
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.retroarch.ra32/com.retroarch.browser.retroactivity.RetroActivityFuture --es ROM \"{file.path}\" --es LIBRETRO \"applewin\""
+        },
+        "windows": {
+          "executable": "retroarch.exe",
+          "args": "-L applewin_libretro.dll \"{file.path}\""
+        },
+        "linux": {
+          "executable": "retroarch",
+          "args": "-L applewin_libretro.so \"{file.path}\""
+        },
+        "macos": {
+          "executable": "RetroArch.App",
+          "args": "-L applewin_libretro.dylib \"{file.path}\""
         }
       }
     },

--- a/assets/systems/a2001.json
+++ b/assets/systems/a2001.json
@@ -32,7 +32,7 @@
   "emulators": [
     {
       "name": "RetroArch MAME/MESS",
-      "default": true,
+      "default_core": true,
       "unique_id": "a2001.ra.mess",
       "is_retroachievements_compatible": false,
       "description": "Supported extensions: bin, zip.",
@@ -56,6 +56,7 @@
     },
     {
       "name": "RetroArch64 MAME/MESS",
+      "default_core": true,
       "unique_id": "a2001.ra64.mess",
       "is_retroachievements_compatible": false,
       "description": "Supported extensions: bin, zip.",
@@ -67,6 +68,7 @@
     },
     {
       "name": "RetroArch32 MAME/MESS",
+      "default_core": true,
       "unique_id": "a2001.ra32.mess",
       "is_retroachievements_compatible": false,
       "description": "Supported extensions: bin, zip.",

--- a/assets/systems/amazon.json
+++ b/assets/systems/amazon.json
@@ -32,7 +32,7 @@
     {
       "name": "Standalone GameNative (Amazon)",
       "unique_id": "amazon.app.gamenative.amazon",
-      "default": true,
+      "default_standalone": true,
       "is_retroachievements_compatible": false,
       "description": "Supported extensions: amazon.",
       "platforms": {

--- a/assets/systems/amiga.json
+++ b/assets/systems/amiga.json
@@ -54,6 +54,7 @@
   "emulators": [
     {
       "name": "RetroArch64 puae",
+      "default_core": true,
       "unique_id": "amiga.ra64.puae",
       "description": "Supported extensions: 7z, adf, adz, ccd, chd, cue, dms, fdi, hdf, hdz, info, ipf, iso, lha, m3u, mds, nrg, rp9, slave, uae, zip.",
       "is_retroachievements_compatible": false,
@@ -76,6 +77,7 @@
     },
     {
       "name": "RetroArch32 puae",
+      "default_core": true,
       "unique_id": "amiga.ra32.puae",
       "description": "Supported extensions: 7z, adf, adz, ccd, chd, cue, dms, fdi, hdf, hdz, info, ipf, iso, lha, m3u, mds, nrg, rp9, slave, uae, zip.",
       "is_retroachievements_compatible": false,
@@ -98,7 +100,7 @@
     },
     {
       "name": "RetroArch puae",
-      "default": true,
+      "default_core": true,
       "unique_id": "amiga.ra.puae",
       "description": "Supported extensions: 7z, adf, adz, ccd, chd, cue, dms, fdi, hdf, hdz, info, ipf, iso, lha, m3u, mds, nrg, rp9, slave, uae, zip.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/arc.json
+++ b/assets/systems/arc.json
@@ -32,7 +32,7 @@
   "emulators": [
     {
       "name": "RetroArch FBNeo",
-      "default": true,
+      "default_core": true,
       "unique_id": "arc.ra.fbneo",
       "description": "Supported extensions: 7z, ccd, cue, zip.",
       "is_retroachievements_compatible": true,
@@ -79,6 +79,7 @@
     },
     {
       "name": "RetroArch64 FBNeo",
+      "default_core": true,
       "unique_id": "arc.ra64.fbneo",
       "description": "Supported extensions: 7z, ccd, cue, zip.",
       "is_retroachievements_compatible": true,
@@ -101,6 +102,7 @@
     },
     {
       "name": "RetroArch32 FBNeo",
+      "default_core": true,
       "unique_id": "arc.ra32.fbneo",
       "description": "Supported extensions: 7z, ccd, cue, zip.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/ard.json
+++ b/assets/systems/ard.json
@@ -52,7 +52,7 @@
     },
     {
       "name": "RetroArch Ardens",
-      "default": true,
+      "default_core": true,
       "unique_id": "ard.ra.ardens",
       "description": "Supported extensions: hex, arduboy.",
       "is_retroachievements_compatible": true,
@@ -87,6 +87,7 @@
     },
     {
       "name": "RetroArch64 Ardens",
+      "default_core": true,
       "unique_id": "ard.ra64.ardens",
       "description": "Supported extensions: hex, arduboy.",
       "is_retroachievements_compatible": true,
@@ -109,6 +110,7 @@
     },
     {
       "name": "RetroArch32 Ardens",
+      "default_core": true,
       "unique_id": "ard.ra32.ardens",
       "description": "Supported extensions: hex, arduboy.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/ast.json
+++ b/assets/systems/ast.json
@@ -36,6 +36,7 @@
   "emulators": [
     {
       "name": "RetroArch64 hatari",
+      "default_core": true,
       "unique_id": "ast.atarist.ra64.hatari",
       "description": "Supported extensions: dim, ipf, m3u, msa, st, stx, zip.",
       "is_retroachievements_compatible": false,
@@ -47,6 +48,7 @@
     },
     {
       "name": "RetroArch32 hatari",
+      "default_core": true,
       "unique_id": "ast.atarist.ra32.hatari",
       "description": "Supported extensions: dim, ipf, m3u, msa, st, stx, zip.",
       "is_retroachievements_compatible": false,
@@ -58,7 +60,7 @@
     },
     {
       "name": "RetroArch hatari",
-      "default": true,
+      "default_core": true,
       "unique_id": "ast.atarist.ra.hatari",
       "description": "Supported extensions: dim, ipf, m3u, msa, st, stx, zip.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/aw.json
+++ b/assets/systems/aw.json
@@ -67,6 +67,7 @@
     },
     {
       "name": "RetroArch64 Flycast",
+      "default_core": true,
       "unique_id": "aw.ra64.flycast",
       "description": "Supported extensions: 7z, chd, dat, lst, zip.",
       "is_retroachievements_compatible": true,
@@ -78,6 +79,7 @@
     },
     {
       "name": "RetroArch32 Flycast",
+      "default_core": true,
       "unique_id": "aw.ra32.flycast",
       "description": "Supported extensions: 7z, chd, dat, lst, zip.",
       "is_retroachievements_compatible": true,
@@ -89,7 +91,7 @@
     },
     {
       "name": "RetroArch Flycast",
-      "default": true,
+      "default_core": true,
       "unique_id": "aw.ra.flycast",
       "description": "Supported extensions: cdi, gdi, chd, cue, bin, elf, zip, 7z, lst, dat, m3u, zip.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/bbcmicro.json
+++ b/assets/systems/bbcmicro.json
@@ -30,6 +30,7 @@
   "emulators": [
     {
       "name": "RetroArch64 b2",
+      "default_core": true,
       "unique_id": "bbcmicro.ra64.b2",
       "description": "Supported extensions: ssd, dsd.",
       "is_retroachievements_compatible": false,
@@ -41,6 +42,7 @@
     },
     {
       "name": "RetroArch32 b2",
+      "default_core": true,
       "unique_id": "bbcmicro.ra32.b2",
       "description": "Supported extensions: ssd, dsd.",
       "is_retroachievements_compatible": false,
@@ -52,7 +54,7 @@
     },
     {
       "name": "RetroArch b2",
-      "default": true,
+      "default_core": true,
       "unique_id": "bbcmicro.ra.b2",
       "description": "Supported extensions: ssd, dsd.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/c64.json
+++ b/assets/systems/c64.json
@@ -74,6 +74,7 @@
     },
     {
       "name": "RetroArch64 vice_x64",
+      "default_core": true,
       "unique_id": "c64.ra64.vice_x64",
       "description": "Supported extensions: bin, cmd, crt, d2m, d4m, d64, d6z, d71, d7z, d80, d81, d82, d8z, g41, g4z, g64, g6z, gz, m3u, nbz, nib, p00, prg, t64, tap, vfl, vsf, x64, x6z, zip.",
       "is_retroachievements_compatible": false,
@@ -107,6 +108,7 @@
     },
     {
       "name": "RetroArch32 vice_x64",
+      "default_core": true,
       "unique_id": "c64.ra32.vice_x64",
       "description": "Supported extensions: bin, cmd, crt, d2m, d4m, d64, d6z, d71, d7z, d80, d81, d82, d8z, g41, g4z, g64, g6z, gz, m3u, nbz, nib, p00, prg, t64, tap, vfl, vsf, x64, x6z, zip.",
       "is_retroachievements_compatible": false,
@@ -152,7 +154,7 @@
     },
     {
       "name": "RetroArch vice_x64",
-      "default": true,
+      "default_core": true,
       "unique_id": "c64.ra.vice_x64",
       "description": "Supported extensions: bin, cmd, crt, d2m, d4m, d64, d6z, d71, d7z, d80, d81, d82, d8z, g41, g4z, g64, g6z, gz, m3u, nbz, nib, p00, prg, t64, tap, vfl, vsf, x64, x6z, zip.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/cdi.json
+++ b/assets/systems/cdi.json
@@ -32,6 +32,7 @@
   "emulators": [
     {
       "name": "Retroarch 64 same_cdi",
+      "default_core": true,
       "unique_id": "cdi.ra64.same_cdi",
       "description": "Supported extensions: cue, chd, iso",
       "is_retroachievements_compatible": false,
@@ -43,6 +44,7 @@
     },
     {
       "name": "Retroarch32 same_cdi",
+      "default_core": true,
       "unique_id": "cdi.ra32.same_cdi",
       "description": "Supported extensions: cue, chd, iso",
       "is_retroachievements_compatible": false,
@@ -54,6 +56,7 @@
     },
     {
       "name": "Retroarch same_cdi",
+      "default_core": true,
       "unique_id": "cdi.ra.same_cdi",
       "description": "Supported extensions: cue, chd, iso",
       "is_retroachievements_compatible": false,

--- a/assets/systems/chf.json
+++ b/assets/systems/chf.json
@@ -33,6 +33,7 @@
   "emulators": [
     {
       "name": "RetroArch64 FreeChaF",
+      "default_core": true,
       "unique_id": "chf.ra64.freechaf",
       "description": "Supported extensions: chf, bin, zip.",
       "is_retroachievements_compatible": true,
@@ -44,6 +45,7 @@
     },
     {
       "name": "RetroArch32 FreeChaF",
+      "default_core": true,
       "unique_id": "chf.ra32.freechaf",
       "description": "Supported extensions: chf, bin, zip.",
       "is_retroachievements_compatible": true,
@@ -55,7 +57,7 @@
     },
     {
       "name": "RetroArch FreeChaF",
-      "default": true,
+      "default_core": true,
       "unique_id": "chf.ra.freechaf",
       "description": "Supported extensions: chf, bin, zip.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/cpc.json
+++ b/assets/systems/cpc.json
@@ -50,6 +50,7 @@
     },
     {
       "name": "RetroArch64 Caprice32",
+      "default_core": true,
       "unique_id": "cpc.ra64.cap32",
       "description": "Supported extensions: cdt, cpr, dsk, m3u, sna, tap, voc, zip.",
       "is_retroachievements_compatible": true,
@@ -72,6 +73,7 @@
     },
     {
       "name": "RetroArch32 Caprice32",
+      "default_core": true,
       "unique_id": "cpc.ra32.cap32",
       "description": "Supported extensions: cdt, cpr, dsk, m3u, sna, tap, voc, zip.",
       "is_retroachievements_compatible": true,
@@ -106,7 +108,7 @@
     },
     {
       "name": "RetroArch Caprice32",
-      "default": true,
+      "default_core": true,
       "unique_id": "cpc.ra.cap32",
       "description": "Supported extensions: cdt, cpr, dsk, m3u, sna, tap, voc, zip.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/cps1.json
+++ b/assets/systems/cps1.json
@@ -37,6 +37,7 @@
   "emulators": [
     {
       "name": "RetroArch64 FBNeo",
+      "default_core": true,
       "unique_id": "cps1.ra64.fbneo",
       "description": "Supported extensions: 7z, zip.",
       "is_retroachievements_compatible": true,
@@ -70,6 +71,7 @@
     },
     {
       "name": "RetroArch32 FBNeo",
+      "default_core": true,
       "unique_id": "cps1.ra32.fbneo",
       "description": "Supported extensions: 7z, zip.",
       "is_retroachievements_compatible": true,
@@ -103,7 +105,7 @@
     },
     {
       "name": "RetroArch FBNeo",
-      "default": true,
+      "default_core": true,
       "unique_id": "cps1.ra.fbneo",
       "description": "Supported extensions: 7z, zip.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/cps2.json
+++ b/assets/systems/cps2.json
@@ -34,6 +34,7 @@
   "emulators": [
     {
       "name": "RetroArch64 FBNeo",
+      "default_core": true,
       "unique_id": "cps2.ra64.fbneo",
       "description": "Supported extensions: 7z, zip.",
       "is_retroachievements_compatible": true,
@@ -67,6 +68,7 @@
     },
     {
       "name": "RetroArch32 FBNeo",
+      "default_core": true,
       "unique_id": "cps2.ra32.fbneo",
       "description": "Supported extensions: 7z, zip.",
       "is_retroachievements_compatible": true,
@@ -100,7 +102,7 @@
     },
     {
       "name": "RetroArch FBNeo",
-      "default": true,
+      "default_core": true,
       "unique_id": "cps2.ra.fbneo",
       "description": "Supported extensions: 7z, zip.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/cps3.json
+++ b/assets/systems/cps3.json
@@ -34,6 +34,7 @@
   "emulators": [
     {
       "name": "RetroArch64 FBNeo",
+      "default_core": true,
       "unique_id": "cps3.ra64.fbneo",
       "description": "Supported extensions: 7z, zip.",
       "is_retroachievements_compatible": true,
@@ -67,6 +68,7 @@
     },
     {
       "name": "RetroArch32 FBNeo",
+      "default_core": true,
       "unique_id": "cps3.ra32.fbneo",
       "description": "Supported extensions: 7z, zip.",
       "is_retroachievements_compatible": true,
@@ -100,7 +102,7 @@
     },
     {
       "name": "RetroArch FBNeo",
-      "default": true,
+      "default_core": true,
       "unique_id": "cps3.ra.fbneo",
       "description": "Supported extensions: 7z, zip.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/cv.json
+++ b/assets/systems/cv.json
@@ -42,6 +42,7 @@
   "emulators": [
     {
       "name": "RetroArch64 BlueMSX",
+      "default_core": true,
       "unique_id": "cv.ra64.bluemsx",
       "description": "Supported extensions: cas, col, dsk, m3u, mx1, mx2, ri, rom, sc, sg, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -64,6 +65,7 @@
     },
     {
       "name": "RetroArch32 BlueMSX",
+      "default_core": true,
       "unique_id": "cv.ra32.bluemsx",
       "description": "Supported extensions: cas, col, dsk, m3u, mx1, mx2, ri, rom, sc, sg, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -86,7 +88,7 @@
     },
     {
       "name": "RetroArch BlueMSX",
-      "default": true,
+      "default_core": true,
       "unique_id": "cv.ra.bluemsx",
       "description": "Supported extensions: cas, col, dsk, m3u, mx1, mx2, ri, rom, sc, sg, zip, 7z.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/dc.json
+++ b/assets/systems/dc.json
@@ -72,6 +72,7 @@
     },
     {
       "name": "RetroArch64 Flycast",
+      "default_core": true,
       "unique_id": "dc.ra64.flycast",
       "description": "Supported extensions: cdi, gdi, chd, cue, bin, elf, zip, 7z, lst, m3u, zip.",
       "is_retroachievements_compatible": true,
@@ -83,6 +84,7 @@
     },
     {
       "name": "RetroArch32 Flycast",
+      "default_core": true,
       "unique_id": "dc.ra32.flycast",
       "description": "Supported extensions: cdi, gdi, chd, cue, bin, elf, zip, 7z, lst, m3u, zip.",
       "is_retroachievements_compatible": true,
@@ -94,7 +96,7 @@
     },
     {
       "name": "RetroArch Flycast",
-      "default": true,
+      "default_core": true,
       "unique_id": "dc.ra.flycast",
       "description": "Supported extensions: cdi, gdi, chd, cue, bin, elf, zip, 7z, lst, m3u, zip.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/dos.json
+++ b/assets/systems/dos.json
@@ -44,6 +44,7 @@
   "emulators": [
     {
       "name": "RetroArch64 dosbox_pure",
+      "default_core": true,
       "unique_id": "dos.ra64.dosbox_pure",
       "description": "Supported extensions: bat, com, cue, dosz, exe, ima, img, ins, iso, m3u, m3u8, vhd, zip.",
       "is_retroachievements_compatible": false,
@@ -77,6 +78,7 @@
     },
     {
       "name": "RetroArch32 dosbox_pure",
+      "default_core": true,
       "unique_id": "dos.ra32.dosbox_pure",
       "description": "Supported extensions: bat, com, cue, dosz, exe, ima, img, ins, iso, m3u, m3u8, vhd, zip.",
       "is_retroachievements_compatible": false,
@@ -110,7 +112,7 @@
     },
     {
       "name": "RetroArch dosbox_pure",
-      "default": true,
+      "default_core": true,
       "unique_id": "dos.ra.dosbox_pure",
       "description": "Supported extensions: bat, com, cue, dosz, exe, ima, img, ins, iso, m3u, m3u8, vhd, zip.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/ds.json
+++ b/assets/systems/ds.json
@@ -33,7 +33,7 @@
   "emulators": [
     {
       "name": "RetroArch MelonDS",
-      "default": true,
+      "default_core": true,
       "unique_id": "ds.ra.melonds",
       "is_retroachievements_compatible": true,
       "description": "MelonDS core for RetroArch.",
@@ -103,6 +103,7 @@
     },
     {
       "name": "RetroArch64 MelonDS",
+      "default_core": true,
       "unique_id": "ds.ra64.melonds",
       "is_retroachievements_compatible": true,
       "description": "MelonDS core for RetroArch 64.",
@@ -125,6 +126,7 @@
     },
     {
       "name": "RetroArch32 MelonDS",
+      "default_core": true,
       "unique_id": "ds.ra32.melonds",
       "is_retroachievements_compatible": true,
       "description": "MelonDS core for RetroArch 32.",

--- a/assets/systems/duck.json
+++ b/assets/systems/duck.json
@@ -30,6 +30,7 @@
   "emulators": [
     {
       "name": "RetroArch64 SameDuck",
+      "default_core": true,
       "unique_id": "duck.ra64.sameduck",
       "description": "Supported extensions: bin.",
       "is_retroachievements_compatible": true,
@@ -41,6 +42,7 @@
     },
     {
       "name": "RetroArch32 SameDuck",
+      "default_core": true,
       "unique_id": "duck.ra32.sameduck",
       "description": "Supported extensions: bin.",
       "is_retroachievements_compatible": true,
@@ -52,7 +54,7 @@
     },
     {
       "name": "RetroArch SameDuck",
-      "default": true,
+      "default_core": true,
       "unique_id": "duck.ra.sameduck",
       "description": "Supported extensions: bin.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/epic.json
+++ b/assets/systems/epic.json
@@ -32,7 +32,7 @@
     {
       "name": "Standalone GameNative (Epic Games)",
       "unique_id": "epic.app.gamenative.epic",
-      "default": true,
+      "default_standalone": true,
       "is_retroachievements_compatible": false,
       "description": "Supported extensions: epicgame.",
       "platforms": {

--- a/assets/systems/fbneo.json
+++ b/assets/systems/fbneo.json
@@ -38,7 +38,7 @@
   "emulators": [
     {
       "name": "RetroArch FBNeo",
-      "default": true,
+      "default_core": true,
       "unique_id": "fbneo.ra.fbneo",
       "description": "Supported extensions: 7z, ccd, cue, zip.",
       "is_retroachievements_compatible": true,
@@ -85,6 +85,7 @@
     },
     {
       "name": "RetroArch64 FBNeo",
+      "default_core": true,
       "unique_id": "fbneo.ra64.fbneo",
       "description": "Supported extensions: 7z, ccd, cue, zip.",
       "is_retroachievements_compatible": true,
@@ -107,6 +108,7 @@
     },
     {
       "name": "RetroArch32 FBNeo",
+      "default_core": true,
       "unique_id": "fbneo.ra32.fbneo",
       "description": "Supported extensions: 7z, ccd, cue, zip.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/fc.json
+++ b/assets/systems/fc.json
@@ -68,6 +68,7 @@
     },
     {
       "name": "RetroArch64 FCEUmm",
+      "default_core": true,
       "unique_id": "fc.ra64.fceumm",
       "description": "Supported extensions: fds, nes, unf, unif.",
       "is_retroachievements_compatible": true,
@@ -123,6 +124,7 @@
     },
     {
       "name": "RetroArch32 FCEUmm",
+      "default_core": true,
       "unique_id": "fc.ra32.fceumm",
       "description": "Supported extensions: fds, nes, unf, unif.",
       "is_retroachievements_compatible": true,
@@ -190,7 +192,7 @@
     },
     {
       "name": "RetroArch FCEUmm",
-      "default": true,
+      "default_core": true,
       "unique_id": "fc.ra.fceumm",
       "description": "Supported extensions: fds, nes, unf, unif.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/fds.json
+++ b/assets/systems/fds.json
@@ -78,6 +78,7 @@
     },
     {
       "name": "RetroArch64 FCEUmm",
+      "default_core": true,
       "unique_id": "fds.ra64.fceumm",
       "description": "Supported extensions: fds, nes, unf, unif.",
       "is_retroachievements_compatible": true,
@@ -111,6 +112,7 @@
     },
     {
       "name": "RetroArch32 FCEUmm",
+      "default_core": true,
       "unique_id": "fds.ra32.fceumm",
       "description": "Supported extensions: fds, nes, unf, unif.",
       "is_retroachievements_compatible": true,
@@ -156,6 +158,7 @@
     },
     {
       "name": "RetroArch FCEUmm",
+      "default_core": true,
       "unique_id": "fds.ra.fceumm",
       "description": "Supported extensions: fds, nes, unf, unif.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/gb-hacks.json
+++ b/assets/systems/gb-hacks.json
@@ -105,6 +105,7 @@
     },
     {
       "name": "RetroArch64 Gambatte",
+      "default_core": true,
       "unique_id": "gb-hacks.ra64.gambatte",
       "description": "Supported extensions: dmg, gb, gbc, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -193,6 +194,7 @@
     },
     {
       "name": "RetroArch32 Gambatte",
+      "default_core": true,
       "unique_id": "gb-hacks.ra32.gambatte",
       "description": "Supported extensions: dmg, gb, gbc, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -281,7 +283,7 @@
     },
     {
       "name": "RetroArch Gambatte",
-      "default": true,
+      "default_core": true,
       "unique_id": "gb-hacks.ra.gambatte",
       "description": "Supported extensions: dmg, gb, gbc, zip, 7z.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/gb.json
+++ b/assets/systems/gb.json
@@ -106,6 +106,7 @@
     },
     {
       "name": "RetroArch64 Gambatte",
+      "default_core": true,
       "unique_id": "gb.ra64.gambatte",
       "description": "Supported extensions: dmg, gb, gbc, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -194,6 +195,7 @@
     },
     {
       "name": "RetroArch32 Gambatte",
+      "default_core": true,
       "unique_id": "gb.ra32.gambatte",
       "description": "Supported extensions: dmg, gb, gbc, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -282,7 +284,7 @@
     },
     {
       "name": "RetroArch Gambatte",
-      "default": true,
+      "default_core": true,
       "unique_id": "gb.ra.gambatte",
       "description": "Supported extensions: dmg, gb, gbc, zip, 7z.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/gba-hacks.json
+++ b/assets/systems/gba-hacks.json
@@ -139,6 +139,7 @@
     },
     {
       "name": "RetroArch64 mGBA",
+      "default_core": true,
       "unique_id": "gba-hacks.ra64.mgba",
       "description": "Supported extensions: gb, gba, gbc, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -205,6 +206,7 @@
     },
     {
       "name": "RetroArch32 mGBA",
+      "default_core": true,
       "unique_id": "gba-hacks.ra32.mgba",
       "description": "Supported extensions: gb, gba, gbc, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -295,7 +297,7 @@
     },
     {
       "name": "RetroArch mGBA",
-      "default": true,
+      "default_core": true,
       "unique_id": "gba-hacks.ra.mgba",
       "description": "Supported extensions: gb, gba, gbc, zip, 7z.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/gba.json
+++ b/assets/systems/gba.json
@@ -138,6 +138,7 @@
     },
     {
       "name": "RetroArch64 mGBA",
+      "default_core": true,
       "unique_id": "gba.ra64.mgba",
       "description": "Supported extensions: gb, gba, gbc, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -204,6 +205,7 @@
     },
     {
       "name": "RetroArch32 mGBA",
+      "default_core": true,
       "unique_id": "gba.ra32.mgba",
       "description": "Supported extensions: gb, gba, gbc, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -294,7 +296,7 @@
     },
     {
       "name": "RetroArch mGBA",
-      "default": true,
+      "default_core": true,
       "unique_id": "gba.ra.mgba",
       "description": "Supported extensions: gb, gba, gbc, zip, 7z.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/gbc-hacks.json
+++ b/assets/systems/gbc-hacks.json
@@ -116,6 +116,7 @@
     },
     {
       "name": "RetroArch64 Gambatte",
+      "default_core": true,
       "unique_id": "gbc-hacks.ra64.gambatte",
       "description": "Supported extensions: dmg, gb, gbc, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -204,6 +205,7 @@
     },
     {
       "name": "RetroArch32 Gambatte",
+      "default_core": true,
       "unique_id": "gbc-hacks.ra32.gambatte",
       "description": "Supported extensions: dmg, gb, gbc, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -292,7 +294,7 @@
     },
     {
       "name": "RetroArch Gambatte",
-      "default": true,
+      "default_core": true,
       "unique_id": "gbc-hacks.ra.gambatte",
       "description": "Supported extensions: dmg, gb, gbc, zip, 7z.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/gbc.json
+++ b/assets/systems/gbc.json
@@ -115,6 +115,7 @@
     },
     {
       "name": "RetroArch64 Gambatte",
+      "default_core": true,
       "unique_id": "gbc.ra64.gambatte",
       "description": "Supported extensions: dmg, gb, gbc, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -203,6 +204,7 @@
     },
     {
       "name": "RetroArch32 Gambatte",
+      "default_core": true,
       "unique_id": "gbc.ra32.gambatte",
       "description": "Supported extensions: dmg, gb, gbc, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -291,7 +293,7 @@
     },
     {
       "name": "RetroArch Gambatte",
-      "default": true,
+      "default_core": true,
       "unique_id": "gbc.ra.gambatte",
       "description": "Supported extensions: dmg, gb, gbc, zip, 7z.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/gc.json
+++ b/assets/systems/gc.json
@@ -119,6 +119,7 @@
     },
     {
       "name": "RetroArch64 Dolphin",
+      "default_core": true,
       "unique_id": "gc.ra64.dolphin",
       "description": "Supported extensions: ciso, dff, dol, elf, gcm, gcz, iso, m3u, rvz, tgc, wad, wbfs, wia",
       "is_retroachievements_compatible": false,
@@ -130,7 +131,7 @@
     },
     {
       "name": "RetroArch Dolphin",
-      "default": true,
+      "default_core": true,
       "unique_id": "gc.ra.dolphin",
       "description": "Supported extensions: ciso, dff, dol, elf, gcm, gcz, iso, m3u, rvz, tgc, wad, wbfs, wia",
       "is_retroachievements_compatible": false,

--- a/assets/systems/genesis-hacks.json
+++ b/assets/systems/genesis-hacks.json
@@ -81,6 +81,7 @@
     },
     {
       "name": "RetroArch64 Genesis Plus GX",
+      "default_core": true,
       "unique_id": "genesis-hacks.ra64.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -114,6 +115,7 @@
     },
     {
       "name": "RetroArch32 Genesis Plus GX",
+      "default_core": true,
       "unique_id": "genesis-hacks.ra32.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -147,7 +149,7 @@
     },
     {
       "name": "RetroArch Genesis Plus GX",
-      "default": true,
+      "default_core": true,
       "unique_id": "genesis-hacks.ra.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/genesis.json
+++ b/assets/systems/genesis.json
@@ -79,6 +79,7 @@
     },
     {
       "name": "RetroArch64 Genesis Plus GX",
+      "default_core": true,
       "unique_id": "genesis.ra64.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -112,6 +113,7 @@
     },
     {
       "name": "RetroArch32 Genesis Plus GX",
+      "default_core": true,
       "unique_id": "genesis.ra32.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -145,7 +147,7 @@
     },
     {
       "name": "RetroArch Genesis Plus GX",
-      "default": true,
+      "default_core": true,
       "unique_id": "genesis.ra.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/gg-hacks.json
+++ b/assets/systems/gg-hacks.json
@@ -82,6 +82,7 @@
     },
     {
       "name": "RetroArch64 Genesis Plus GX",
+      "default_core": true,
       "unique_id": "gg-hacks.ra64.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -137,6 +138,7 @@
     },
     {
       "name": "RetroArch32 Genesis Plus GX",
+      "default_core": true,
       "unique_id": "gg-hacks.ra32.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -192,7 +194,7 @@
     },
     {
       "name": "RetroArch Genesis Plus GX",
-      "default": true,
+      "default_core": true,
       "unique_id": "gg-hacks.ra.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/gg.json
+++ b/assets/systems/gg.json
@@ -81,6 +81,7 @@
     },
     {
       "name": "RetroArch64 Genesis Plus GX",
+      "default_core": true,
       "unique_id": "gg.ra64.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -136,6 +137,7 @@
     },
     {
       "name": "RetroArch32 Genesis Plus GX",
+      "default_core": true,
       "unique_id": "gg.ra32.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -191,7 +193,7 @@
     },
     {
       "name": "RetroArch Genesis Plus GX",
-      "default": true,
+      "default_core": true,
       "unique_id": "gg.ra.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/gog.json
+++ b/assets/systems/gog.json
@@ -32,7 +32,7 @@
     {
       "name": "Standalone GameNative (GOG)",
       "unique_id": "gog.app.gamenative.gog",
-      "default": true,
+      "default_standalone": true,
       "is_retroachievements_compatible": false,
       "description": "Supported extensions: gog.",
       "platforms": {

--- a/assets/systems/gw.json
+++ b/assets/systems/gw.json
@@ -31,6 +31,7 @@
   "emulators": [
     {
       "name": "RetroArch64 GW",
+      "default_core": true,
       "unique_id": "gw.ra64.gw",
       "description": "Supported extensions: mgw.",
       "is_retroachievements_compatible": false,
@@ -53,6 +54,7 @@
     },
     {
       "name": "RetroArch32 GW",
+      "default_core": true,
       "unique_id": "gw.ra32.gw",
       "description": "Supported extensions: mgw.",
       "is_retroachievements_compatible": false,
@@ -64,7 +66,7 @@
     },
     {
       "name": "RetroArch GW",
-      "default": true,
+      "default_core": true,
       "unique_id": "gw.ra.gw",
       "description": "Supported extensions: mgw.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/intv.json
+++ b/assets/systems/intv.json
@@ -33,6 +33,7 @@
   "emulators": [
     {
       "name": "RetroArch64 FreeIntv",
+      "default_core": true,
       "unique_id": "intellivision.ra64.freeintv",
       "description": "Supported extensions: bin, int, rom, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -44,6 +45,7 @@
     },
     {
       "name": "RetroArch32 FreeIntv",
+      "default_core": true,
       "unique_id": "intellivision.ra32.freeintv",
       "description": "Supported extensions: bin, int, rom, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -55,7 +57,7 @@
     },
     {
       "name": "RetroArch FreeIntv",
-      "default": true,
+      "default_core": true,
       "unique_id": "intellivision.ra.freeintv",
       "description": "Supported extensions: bin, int, rom, zip, 7z.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/jag.json
+++ b/assets/systems/jag.json
@@ -65,6 +65,7 @@
     },
     {
       "name": "RetroArch64 Virtual Jaguar",
+      "default_core": true,
       "unique_id": "jag.ra64.virtualjaguar",
       "description": "Supported extensions: j64, jag, rom, abs, cof, bin, prg, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -76,6 +77,7 @@
     },
     {
       "name": "RetroArch32 Virtual Jaguar",
+      "default_core": true,
       "unique_id": "jag.ra32.virtualjaguar",
       "description": "Supported extensions: j64, jag, rom, abs, cof, bin, prg, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -87,7 +89,7 @@
     },
     {
       "name": "RetroArch Virtual Jaguar",
-      "default": true,
+      "default_core": true,
       "unique_id": "jag.ra.virtualjaguar",
       "description": "Supported extensions: j64, jag, rom, abs, cof, bin, prg, zip, 7z.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/jagcd.json
+++ b/assets/systems/jagcd.json
@@ -30,7 +30,7 @@
   "emulators": [
     {
       "name": "Standalone BigPEmu",
-      "default": true,
+      "default_standalone": true,
       "unique_id": "jagcd.jaguarcd.bigpe.bigpemu",
       "description": "Supported extensions: cue, cdi.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/lynx.json
+++ b/assets/systems/lynx.json
@@ -54,6 +54,7 @@
     },
     {
       "name": "RetroArch64 Handy",
+      "default_core": true,
       "unique_id": "lynx.ra64.handy",
       "description": "Supported extensions: lnx, o, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -87,6 +88,7 @@
     },
     {
       "name": "RetroArch32 Handy",
+      "default_core": true,
       "unique_id": "lynx.ra32.handy",
       "description": "Supported extensions: lnx, o, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -132,7 +134,7 @@
     },
     {
       "name": "RetroArch Handy",
-      "default": true,
+      "default_core": true,
       "unique_id": "lynx.ra.handy",
       "description": "Supported extensions: lnx, o, zip, 7z.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/mame.json
+++ b/assets/systems/mame.json
@@ -87,6 +87,7 @@
     },
     {
       "name": "RetroArch64 MAME",
+      "default_core": true,
       "unique_id": "mame.ra64.mamearcade",
       "description": "Supported extensions: 7z, chd, cmd, zip.",
       "is_retroachievements_compatible": false,
@@ -153,6 +154,7 @@
     },
     {
       "name": "RetroArch32 MAME",
+      "default_core": true,
       "unique_id": "mame.ra32.mamearcade",
       "description": "Supported extensions: 7z, chd, cmd, zip.",
       "is_retroachievements_compatible": false,
@@ -255,7 +257,7 @@
     },
     {
       "name": "RetroArch MAME",
-      "default": true,
+      "default_core": true,
       "unique_id": "mame.ra.mamearcade",
       "description": "Supported extensions: 7z, chd, cmd, zip.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/mark3.json
+++ b/assets/systems/mark3.json
@@ -68,6 +68,7 @@
     },
     {
       "name": "RetroArch64 Genesis Plus GX",
+      "default_core": true,
       "unique_id": "mark3.ra64.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -123,6 +124,7 @@
     },
     {
       "name": "RetroArch32 Genesis Plus GX",
+      "default_core": true,
       "unique_id": "mark3.ra32.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -178,7 +180,7 @@
     },
     {
       "name": "RetroArch Genesis Plus GX",
-      "default": true,
+      "default_core": true,
       "unique_id": "mark3.ra.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/mcd.json
+++ b/assets/systems/mcd.json
@@ -59,6 +59,7 @@
     },
     {
       "name": "RetroArch64 Genesis Plus GX",
+      "default_core": true,
       "unique_id": "mcd.ra64.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -92,6 +93,7 @@
     },
     {
       "name": "RetroArch32 Genesis Plus GX",
+      "default_core": true,
       "unique_id": "mcd.ra32.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -125,7 +127,7 @@
     },
     {
       "name": "RetroArch Genesis Plus GX",
-      "default": true,
+      "default_core": true,
       "unique_id": "mcd.ra.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/md-hacks.json
+++ b/assets/systems/md-hacks.json
@@ -84,6 +84,7 @@
     },
     {
       "name": "RetroArch64 Genesis Plus GX",
+      "default_core": true,
       "unique_id": "md-hacks.ra64.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -117,6 +118,7 @@
     },
     {
       "name": "RetroArch32 Genesis Plus GX",
+      "default_core": true,
       "unique_id": "md-hacks.ra32.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -150,7 +152,7 @@
     },
     {
       "name": "RetroArch Genesis Plus GX",
-      "default": true,
+      "default_core": true,
       "unique_id": "md-hacks.ra.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/md.json
+++ b/assets/systems/md.json
@@ -83,6 +83,7 @@
     },
     {
       "name": "RetroArch64 Genesis Plus GX",
+      "default_core": true,
       "unique_id": "md.ra64.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -116,6 +117,7 @@
     },
     {
       "name": "RetroArch32 Genesis Plus GX",
+      "default_core": true,
       "unique_id": "md.ra32.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -149,7 +151,7 @@
     },
     {
       "name": "RetroArch Genesis Plus GX",
-      "default": true,
+      "default_core": true,
       "unique_id": "md.ra.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/mini.json
+++ b/assets/systems/mini.json
@@ -33,6 +33,7 @@
   "emulators": [
     {
       "name": "RetroArch64 Pokémini",
+      "default_core": true,
       "unique_id": "mini.ra64.pokemini",
       "description": "Supported extensions: min.",
       "is_retroachievements_compatible": true,
@@ -44,6 +45,7 @@
     },
     {
       "name": "RetroArch32 Pokémini",
+      "default_core": true,
       "unique_id": "mini.ra32.pokemini",
       "description": "Supported extensions: min.",
       "is_retroachievements_compatible": true,
@@ -55,7 +57,7 @@
     },
     {
       "name": "RetroArch Pokémini",
-      "default": true,
+      "default_core": true,
       "unique_id": "mini.ra.pokemini",
       "description": "Supported extensions: min.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/mo2.json
+++ b/assets/systems/mo2.json
@@ -32,6 +32,7 @@
   "emulators": [
     {
       "name": "RetroArch64 O2EM",
+      "default_core": true,
       "unique_id": "mo2.ra64.o2em",
       "description": "Supported extensions: bin.",
       "is_retroachievements_compatible": true,
@@ -43,6 +44,7 @@
     },
     {
       "name": "RetroArch32 O2EM",
+      "default_core": true,
       "unique_id": "mo2.ra32.o2em",
       "description": "Supported extensions: bin.",
       "is_retroachievements_compatible": true,
@@ -54,7 +56,7 @@
     },
     {
       "name": "RetroArch O2EM",
-      "default": true,
+      "default_core": true,
       "unique_id": "mo2.ra.o2em",
       "description": "Supported extensions: bin.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/msx.json
+++ b/assets/systems/msx.json
@@ -64,6 +64,7 @@
     },
     {
       "name": "RetroArch64 blueMSX",
+      "default_core": true,
       "unique_id": "msx.ra64.bluemsx",
       "description": "Supported extensions: cas, col, dsk, m3u, mx1, mx2, ri, rom, sc, sg",
       "is_retroachievements_compatible": true,
@@ -86,6 +87,7 @@
     },
     {
       "name": "RetroArch32 blueMSX",
+      "default_core": true,
       "unique_id": "msx.ra32.bluemsx",
       "description": "Supported extensions: cas, col, dsk, m3u, mx1, mx2, ri, rom, sc, sg",
       "is_retroachievements_compatible": true,
@@ -120,7 +122,7 @@
     },
     {
       "name": "RetroArch blueMSX",
-      "default": true,
+      "default_core": true,
       "unique_id": "msx.ra.bluemsx",
       "description": "Supported extensions: cas, col, dsk, m3u, mx1, mx2, ri, rom, sc, sg",
       "is_retroachievements_compatible": true,

--- a/assets/systems/n64.json
+++ b/assets/systems/n64.json
@@ -80,6 +80,7 @@
     },
     {
       "name": "RetroArch64 Mupen64Plus-Next GLES3",
+      "default_core": true,
       "unique_id": "n64.ra64.mupen64plus_next_gles3",
       "description": "Supported extensions: bin, n64, u1, v64, z64, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -113,6 +114,7 @@
     },
     {
       "name": "RetroArch32 Mupen64Plus-Next GLES3",
+      "default_core": true,
       "unique_id": "n64.ra32.mupen64plus_next_gles3",
       "description": "Supported extensions: bin, n64, u1, v64, z64, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -166,7 +168,7 @@
     },
     {
       "name": "RetroArch Mupen64Plus-Next GLES3",
-      "default": true,
+      "default_core": true,
       "unique_id": "n64.ra.mupen64plus_next_gles3",
       "description": "Supported extensions: bin, n64, u1, v64, z64, zip, 7z.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/naomi.json
+++ b/assets/systems/naomi.json
@@ -44,6 +44,7 @@
     },
     {
       "name": "RetroArch64 Flycast",
+      "default_core": true,
       "unique_id": "naomi.ra64.flycast",
       "description": "Supported extensions: 7z, chd, dat, lst, zip.",
       "is_retroachievements_compatible": true,
@@ -55,6 +56,7 @@
     },
     {
       "name": "RetroArch32 Flycast",
+      "default_core": true,
       "unique_id": "naomi.ra32.flycast",
       "description": "Supported extensions: 7z, chd, dat, lst, zip.",
       "is_retroachievements_compatible": true,
@@ -66,7 +68,7 @@
     },
     {
       "name": "RetroArch Flycast",
-      "default": true,
+      "default_core": true,
       "unique_id": "naomi.ra.flycast",
       "description": "Supported extensions: cdi, gdi, chd, cue, bin, elf, zip, 7z, lst, dat, m3u, zip.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/naomi2.json
+++ b/assets/systems/naomi2.json
@@ -44,6 +44,7 @@
     },
     {
       "name": "RetroArch64 Flycast",
+      "default_core": true,
       "unique_id": "naomi2.ra64.flycast",
       "description": "Supported extensions: 7z, chd, dat, lst, zip.",
       "is_retroachievements_compatible": true,
@@ -55,6 +56,7 @@
     },
     {
       "name": "RetroArch32 Flycast",
+      "default_core": true,
       "unique_id": "naomi2.ra32.flycast",
       "description": "Supported extensions: 7z, chd, dat, lst, zip.",
       "is_retroachievements_compatible": true,
@@ -66,7 +68,7 @@
     },
     {
       "name": "RetroArch Flycast",
-      "default": true,
+      "default_core": true,
       "unique_id": "naomi2.ra.flycast",
       "description": "Supported extensions: cdi, gdi, chd, cue, bin, elf, zip, 7z, lst, dat, m3u, zip.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/naomigd.json
+++ b/assets/systems/naomigd.json
@@ -44,6 +44,7 @@
     },
     {
       "name": "RetroArch64 Flycast",
+      "default_core": true,
       "unique_id": "naomigd.ra64.flycast",
       "description": "Supported extensions: 7z, chd, dat, lst, zip.",
       "is_retroachievements_compatible": true,
@@ -55,6 +56,7 @@
     },
     {
       "name": "RetroArch32 Flycast",
+      "default_core": true,
       "unique_id": "naomigd.ra32.flycast",
       "description": "Supported extensions: 7z, chd, dat, lst, zip.",
       "is_retroachievements_compatible": true,
@@ -66,7 +68,7 @@
     },
     {
       "name": "RetroArch Flycast",
-      "default": true,
+      "default_core": true,
       "unique_id": "naomigd.ra.flycast",
       "description": "Supported extensions: cdi, gdi, chd, cue, bin, elf, zip, 7z, lst, dat, m3u, zip.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/neogeo.json
+++ b/assets/systems/neogeo.json
@@ -42,6 +42,7 @@
     },
     {
       "name": "RetroArch64 FBNeo",
+      "default_core": true,
       "unique_id": "neogeo.ra64.fbneo",
       "description": "Supported extensions: zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -86,6 +87,7 @@
     },
     {
       "name": "RetroArch32 FBNeo",
+      "default_core": true,
       "unique_id": "neogeo.ra32.fbneo",
       "description": "Supported extensions: zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -130,7 +132,7 @@
     },
     {
       "name": "RetroArch FBNeo",
-      "default": true,
+      "default_core": true,
       "unique_id": "neogeo.ra.fbneo",
       "description": "Supported extensions: zip, 7z.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/nes-hacks.json
+++ b/assets/systems/nes-hacks.json
@@ -72,6 +72,7 @@
     },
     {
       "name": "RetroArch64 FCEUmm",
+      "default_core": true,
       "unique_id": "nes-hacks.ra64.fceumm",
       "description": "Supported extensions: fds, nes, unf, unif.",
       "is_retroachievements_compatible": true,
@@ -127,6 +128,7 @@
     },
     {
       "name": "RetroArch32 FCEUmm",
+      "default_core": true,
       "unique_id": "nes-hacks.ra32.fceumm",
       "description": "Supported extensions: fds, nes, unf, unif.",
       "is_retroachievements_compatible": true,
@@ -194,7 +196,7 @@
     },
     {
       "name": "RetroArch FCEUmm",
-      "default": true,
+      "default_core": true,
       "unique_id": "nes-hacks.ra.fceumm",
       "description": "Supported extensions: fds, nes, unf, unif.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/nes.json
+++ b/assets/systems/nes.json
@@ -71,6 +71,7 @@
     },
     {
       "name": "RetroArch64 FCEUmm",
+      "default_core": true,
       "unique_id": "nes.ra64.fceumm",
       "description": "Supported extensions: fds, nes, unf, unif.",
       "is_retroachievements_compatible": true,
@@ -126,6 +127,7 @@
     },
     {
       "name": "RetroArch32 FCEUmm",
+      "default_core": true,
       "unique_id": "nes.ra32.fceumm",
       "description": "Supported extensions: fds, nes, unf, unif.",
       "is_retroachievements_compatible": true,
@@ -193,7 +195,7 @@
     },
     {
       "name": "RetroArch FCEUmm",
-      "default": true,
+      "default_core": true,
       "unique_id": "nes.ra.fceumm",
       "description": "Supported extensions: fds, nes, unf, unif.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/ngcd.json
+++ b/assets/systems/ngcd.json
@@ -31,6 +31,7 @@
   "emulators": [
     {
       "name": "RetroArch64 NeoCD",
+      "default_core": true,
       "unique_id": "ngcd.ra64.neocd",
       "description": "Supported extensions: chd, cue.",
       "is_retroachievements_compatible": true,
@@ -42,6 +43,7 @@
     },
     {
       "name": "RetroArch32 NeoCD",
+      "default_core": true,
       "unique_id": "ngcd.ra32.neocd",
       "description": "Supported extensions: chd, cue.",
       "is_retroachievements_compatible": true,
@@ -53,7 +55,7 @@
     },
     {
       "name": "RetroArch NeoCD",
-      "default": true,
+      "default_core": true,
       "unique_id": "ngcd.ra.neocd",
       "description": "Supported extensions: chd, cue.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/ngp.json
+++ b/assets/systems/ngp.json
@@ -45,6 +45,7 @@
     },
     {
       "name": "RetroArch64 Beetle NeoPop",
+      "default_core": true,
       "unique_id": "ngp.ra64.mednafen_ngp",
       "description": "Supported extensions: zip, ngp, ngc, 7z.",
       "is_retroachievements_compatible": true,
@@ -67,6 +68,7 @@
     },
     {
       "name": "RetroArch32 Beetle NeoPop",
+      "default_core": true,
       "unique_id": "ngp.ra32.mednafen_ngp",
       "description": "Supported extensions: zip, ngp, ngc, 7z.",
       "is_retroachievements_compatible": true,
@@ -89,7 +91,7 @@
     },
     {
       "name": "RetroArch Beetle NeoPop",
-      "default": true,
+      "default_core": true,
       "unique_id": "ngp.ra.mednafen_ngp",
       "description": "Supported extensions: zip, ngp, ngc, 7z.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/ngpc.json
+++ b/assets/systems/ngpc.json
@@ -33,7 +33,7 @@
   },
   "emulators": [
     {
-      "name": "ngpc - NGP.EMU",
+      "name": "NGP.EMU",
       "unique_id": "ngpc.com.explusalpha.NgpEmu",
       "description": "Supported extensions: zip, ngp, ngc, 7z.",
       "is_retroachievements_compatible": false,
@@ -44,7 +44,8 @@
       }
     },
     {
-      "name": "ngpc - RetroArch 64 - Beetle NeoPop",
+      "name": "RetroArch64 Beetle NeoPop",
+      "default_core": true,
       "unique_id": "ngpc.ra64.mednafen_ngp",
       "description": "Supported extensions: zip, ngp, ngc, 7z.",
       "is_retroachievements_compatible": true,
@@ -55,7 +56,7 @@
       }
     },
     {
-      "name": "ngpc - RetroArch 64 - RACE",
+      "name": "RetroArch64 RACE",
       "unique_id": "ngpc.ra64.race",
       "description": "Supported extensions: zip, ngp, ngc, 7z.",
       "is_retroachievements_compatible": false,
@@ -66,7 +67,8 @@
       }
     },
     {
-      "name": "ngpc - RetroArch 32 - Beetle NeoPop",
+      "name": "RetroArch32 Beetle NeoPop",
+      "default_core": true,
       "unique_id": "ngpc.ra32.mednafen_ngp",
       "description": "Supported extensions: zip, ngp, ngc, 7z.",
       "is_retroachievements_compatible": true,
@@ -77,7 +79,7 @@
       }
     },
     {
-      "name": "ngpc - RetroArch 32 - RACE",
+      "name": "RetroArch32 RACE",
       "unique_id": "ngpc.ra32.race",
       "description": "Supported extensions: zip, ngp, ngc, 7z.",
       "is_retroachievements_compatible": false,
@@ -88,7 +90,8 @@
       }
     },
     {
-      "name": "ngpc - RetroArch - Beetle NeoPop",
+      "name": "RetroArch Beetle NeoPop",
+      "default_core": true,
       "unique_id": "ngpc.ra.mednafen_ngp",
       "description": "Supported extensions: zip, ngp, ngc, 7z.",
       "is_retroachievements_compatible": true,
@@ -111,7 +114,7 @@
       }
     },
     {
-      "name": "ngpc - RetroArch - RACE",
+      "name": "RetroArch RACE",
       "unique_id": "ngpc.ra.race",
       "description": "Supported extensions: zip, ngp, ngc, 7z.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/palm.json
+++ b/assets/systems/palm.json
@@ -31,6 +31,7 @@
   "emulators": [
     {
       "name": "RetroArch64 MU",
+      "default_core": true,
       "unique_id": "palm.ra64.mu",
       "description": "Supported extensions: img, pdb, pqa, prc.",
       "is_retroachievements_compatible": false,
@@ -42,6 +43,7 @@
     },
     {
       "name": "RetroArch32 MU",
+      "default_core": true,
       "unique_id": "palm.ra32.mu",
       "description": "Supported extensions: img, pdb, pqa, prc.",
       "is_retroachievements_compatible": false,
@@ -53,6 +55,7 @@
     },
     {
       "name": "RetroArch MU",
+      "default_core": true,
       "unique_id": "palm.ra.mu",
       "description": "Supported extensions: img, pdb, pqa, prc.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/pc88.json
+++ b/assets/systems/pc88.json
@@ -34,7 +34,7 @@
   "emulators": [
     {
       "name": "RetroArch QUASI88",
-      "default": true,
+      "default_core": true,
       "unique_id": "8088.ra.quasi88",
       "is_retroachievements_compatible": true,
       "description": "Supported extensions: d88, m3u, u88.",
@@ -58,6 +58,7 @@
     },
     {
       "name": "RetroArch64 QUASI88",
+      "default_core": true,
       "unique_id": "8088.ra64.quasi88",
       "is_retroachievements_compatible": true,
       "description": "Supported extensions: d88, m3u, u88.",
@@ -69,6 +70,7 @@
     },
     {
       "name": "RetroArch32 QUASI88",
+      "default_core": true,
       "unique_id": "8088.ra32.quasi88",
       "is_retroachievements_compatible": true,
       "description": "Supported extensions: d88, m3u, u88.",

--- a/assets/systems/pc98.json
+++ b/assets/systems/pc98.json
@@ -48,6 +48,7 @@
   "emulators": [
     {
       "name": "Retroarch64 NP2kai",
+      "default_core": true,
       "unique_id": "pc98.ra64.np2kai",
       "description": "Supported extensions: 2hd, 88d, 98d, cmd, d88, d98, dup, fdd, fdi, hdd, hdi, hdm, hdn, nhd, tfd, thd, xdf, zip.",
       "is_retroachievements_compatible": false,
@@ -70,6 +71,7 @@
     },
     {
       "name": "Retroarch32 NP2kai",
+      "default_core": true,
       "unique_id": "pc98.ra32.np2kai",
       "description": "Supported extensions: 2hd, 88d, 98d, cmd, d88, d98, dup, fdd, fdi, hdd, hdi, hdm, hdn, nhd, tfd, thd, xdf, zip.",
       "is_retroachievements_compatible": false,
@@ -92,6 +94,7 @@
     },
     {
       "name": "Retroarch NP2kai",
+      "default_core": true,
       "unique_id": "pc98.ra.np2kai",
       "description": "Supported extensions: 2hd, 88d, 98d, cmd, d88, d98, dup, fdd, fdi, hdd, hdi, hdm, hdn, nhd, tfd, thd, xdf, zip.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/pccd.json
+++ b/assets/systems/pccd.json
@@ -49,6 +49,18 @@
       }
     },
     {
+      "name": "RetroArch64 Beetle SuperGrafx",
+      "default_core": true,
+      "unique_id": "pccd.ra64.mednafen_supergrafx",
+      "description": "Supported extensions: pce, sgx, cue, ccd, chd, pce.",
+      "is_retroachievements_compatible": true,
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.retroarch.aarch64/com.retroarch.browser.retroactivity.RetroActivityFuture --es ROM \"{file.path}\" --es LIBRETRO \"mednafen_supergrafx\""
+        }
+      }
+    },
+    {
       "name": "RetroArch64 Beetle PCE Fast",
       "unique_id": "pccd.ra64.mednafen_pce_fast",
       "description": "Supported extensions: ccd, chd, cue, m3u, pce, toc.",
@@ -71,6 +83,18 @@
       }
     },
     {
+      "name": "RetroArch32 Beetle SuperGrafx",
+      "default_core": true,
+      "unique_id": "pccd.ra32.mednafen_supergrafx",
+      "description": "Supported extensions: pce, sgx, cue, ccd, chd, pce.",
+      "is_retroachievements_compatible": true,
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.retroarch.ra32/com.retroarch.browser.retroactivity.RetroActivityFuture --es ROM \"{file.path}\" --es LIBRETRO \"mednafen_supergrafx\""
+        }
+      }
+    },
+    {
       "name": "RetroArch32 Beetle PCE Fast",
       "unique_id": "pccd.ra32.mednafen_pce_fast",
       "description": "Supported extensions: ccd, chd, cue, m3u, pce, toc.",
@@ -89,6 +113,30 @@
       "platforms": {
         "android": {
           "launch_arguments": "-n com.retroarch.ra32/com.retroarch.browser.retroactivity.RetroActivityFuture --es ROM \"{file.path}\" --es LIBRETRO \"mednafen_pce\""
+        }
+      }
+    },
+    {
+      "name": "RetroArch Beetle SuperGrafx",
+      "default_core": true,
+      "unique_id": "pccd.ra.mednafen_supergrafx",
+      "description": "Supported extensions: pce, sgx, cue, ccd, chd, pce.",
+      "is_retroachievements_compatible": true,
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.retroarch/com.retroarch.browser.retroactivity.RetroActivityFuture --es ROM \"{file.path}\" --es LIBRETRO \"mednafen_supergrafx\""
+        },
+        "windows": {
+          "executable": "retroarch.exe",
+          "args": "-L mednafen_supergrafx_libretro.dll \"{file.path}\""
+        },
+        "linux": {
+          "executable": "retroarch",
+          "args": "-L mednafen_supergrafx_libretro.so \"{file.path}\""
+        },
+        "macos": {
+          "executable": "RetroArch.App",
+          "args": "-L mednafen_supergrafx_libretro.dylib \"{file.path}\""
         }
       }
     },
@@ -117,7 +165,6 @@
     },
     {
       "name": "RetroArch Beetle PCE",
-      "default": true,
       "unique_id": "pccd.ra.mednafen_pce",
       "description": "Supported extensions: ccd, chd, cue, m3u, pce, sgx, toc, zip, 7z.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/pce.json
+++ b/assets/systems/pce.json
@@ -48,6 +48,18 @@
       }
     },
     {
+      "name": "RetroArch64 Beetle SuperGrafx",
+      "default_core": true,
+      "unique_id": "pce.ra64.mednafen_supergrafx",
+      "description": "Supported extensions: pce, sgx, cue, ccd, chd, pce.",
+      "is_retroachievements_compatible": true,
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.retroarch.aarch64/com.retroarch.browser.retroactivity.RetroActivityFuture --es ROM \"{file.path}\" --es LIBRETRO \"mednafen_supergrafx\""
+        }
+      }
+    },
+    {
       "name": "RetroArch64 Beetle PCE Fast",
       "unique_id": "pce.ra64.mednafen_pce_fast",
       "description": "Supported extensions: ccd, chd, cue, m3u, pce, toc.",
@@ -70,6 +82,18 @@
       }
     },
     {
+      "name": "RetroArch32 Beetle SuperGrafx",
+      "default_core": true,
+      "unique_id": "pce.ra32.mednafen_supergrafx",
+      "description": "Supported extensions: pce, sgx, cue, ccd, chd, pce.",
+      "is_retroachievements_compatible": true,
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.retroarch.ra32/com.retroarch.browser.retroactivity.RetroActivityFuture --es ROM \"{file.path}\" --es LIBRETRO \"mednafen_supergrafx\""
+        }
+      }
+    },
+    {
       "name": "RetroArch32 Beetle PCE Fast",
       "unique_id": "pce.ra32.mednafen_pce_fast",
       "description": "Supported extensions: ccd, chd, cue, m3u, pce, toc.",
@@ -88,6 +112,30 @@
       "platforms": {
         "android": {
           "launch_arguments": "-n com.retroarch.ra32/com.retroarch.browser.retroactivity.RetroActivityFuture --es ROM \"{file.path}\" --es LIBRETRO \"mednafen_pce\""
+        }
+      }
+    },
+    {
+      "name": "RetroArch Beetle SuperGrafx",
+      "default_core": true,
+      "unique_id": "pce.ra.mednafen_supergrafx",
+      "description": "Supported extensions: pce, sgx, cue, ccd, chd, pce.",
+      "is_retroachievements_compatible": true,
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.retroarch/com.retroarch.browser.retroactivity.RetroActivityFuture --es ROM \"{file.path}\" --es LIBRETRO \"mednafen_supergrafx\""
+        },
+        "windows": {
+          "executable": "retroarch.exe",
+          "args": "-L mednafen_supergrafx_libretro.dll \"{file.path}\""
+        },
+        "linux": {
+          "executable": "retroarch",
+          "args": "-L mednafen_supergrafx_libretro.so \"{file.path}\""
+        },
+        "macos": {
+          "executable": "RetroArch.App",
+          "args": "-L mednafen_supergrafx_libretro.dylib \"{file.path}\""
         }
       }
     },
@@ -116,7 +164,6 @@
     },
     {
       "name": "RetroArch Beetle PCE",
-      "default": true,
       "unique_id": "pce.ra.mednafen_pce",
       "description": "Supported extensions: ccd, chd, cue, m3u, pce, sgx, toc, zip, 7z.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/pcfx.json
+++ b/assets/systems/pcfx.json
@@ -32,6 +32,7 @@
   "emulators": [
     {
       "name": "RetroArch64 Beetle PC-FX",
+      "default_core": true,
       "unique_id": "pcfx.ra64.mednafen_pcfx",
       "description": "Supported extensions: cue, ccd, toc, chd.",
       "is_retroachievements_compatible": false,
@@ -43,6 +44,7 @@
     },
     {
       "name": "RetroArch32 Beetle PC-FX",
+      "default_core": true,
       "unique_id": "pcfx.ra32.mednafen_pcfx",
       "description": "Supported extensions: cue, ccd, toc, chd.",
       "is_retroachievements_compatible": false,
@@ -54,7 +56,7 @@
     },
     {
       "name": "RetroArch Beetle PC-FX",
-      "default": true,
+      "default_core": true,
       "unique_id": "pcfx.ra.mednafen_pcfx",
       "description": "Supported extensions: cue, ccd, toc, chd.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/pet.json
+++ b/assets/systems/pet.json
@@ -51,6 +51,7 @@
   "emulators": [
     {
       "name": "RetroArch64 Vice XPet",
+      "default_core": true,
       "unique_id": "pet.ra64.vice_xpet",
       "description": "Supported extensions: bin, crt, d64, d6z, d71, d7z, d80, d81, d82, d8z, g41, g4z, g64, g6z, gz, lnx, p00, prg, t64, tap, x64, x6z, zip.",
       "is_retroachievements_compatible": false,
@@ -62,6 +63,7 @@
     },
     {
       "name": "RetroArch32 Vice XPet",
+      "default_core": true,
       "unique_id": "pet.ra32.vice_xpet",
       "description": "Supported extensions: bin, cmd, crt, d2m, d4m, d64, d6z, d71, d7z, d80, d81, d82, d8z, g41, g4z, g64, g6z, gz, m3u, nbz, nib, p00, prg, t64, tap, vfl, vsf, x64, x6z, zip.",
       "is_retroachievements_compatible": false,
@@ -73,7 +75,7 @@
     },
     {
       "name": "RetroArch Vice XPet",
-      "default": true,
+      "default_core": true,
       "unique_id": "pet.ra.vice_xpet",
       "description": "Supported extensions: bin, cmd, crt, d2m, d4m, d64, d6z, d71, d7z, d80, d81, d82, d8z, g41, g4z, g64, g6z, gz, m3u, nbz, nib, p00, prg, t64, tap, vfl, vsf, x64, x6z, zip.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/pico.json
+++ b/assets/systems/pico.json
@@ -30,6 +30,7 @@
   "emulators": [
     {
       "name": "RetroArch64 Picodrive",
+      "default_core": true,
       "unique_id": "pico.ra64.picodrive",
       "description": "Supported extensions: md, 7z, zip.",
       "is_retroachievements_compatible": false,
@@ -41,6 +42,7 @@
     },
     {
       "name": "RetroArch32 Picodrive",
+      "default_core": true,
       "unique_id": "pico.ra32.picodrive",
       "description": "Supported extensions: md, 7z, zip.",
       "is_retroachievements_compatible": false,
@@ -52,7 +54,7 @@
     },
     {
       "name": "RetroArch Picodrive",
-      "default": true,
+      "default_core": true,
       "unique_id": "pico.ra.picodrive",
       "description": "Supported extensions: md, 7z, zip.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/pico8.json
+++ b/assets/systems/pico8.json
@@ -29,7 +29,7 @@
   },
   "emulators": [
     {
-      "name": "PICO-8 Android",
+      "name": "Standalone PICO-8 Android",
       "unique_id": "pico8.io.wip.pico8",
       "description": "Supported extensions: p8, png.",
       "is_retroachievements_compatible": false,
@@ -63,6 +63,7 @@
     },
     {
       "name": "RetroArch64 Retro8",
+      "default_core": true,
       "unique_id": "pico8.ra64.retro8",
       "description": "Supported extensions: p8, png.",
       "is_retroachievements_compatible": false,
@@ -85,6 +86,7 @@
     },
     {
       "name": "RetroArch32 Retro8",
+      "default_core": true,
       "unique_id": "pico8.ra32.retro8",
       "description": "Supported extensions: p8, png.",
       "is_retroachievements_compatible": false,
@@ -107,6 +109,7 @@
     },
     {
       "name": "RetroArch Retro8",
+      "default_core": true,
       "unique_id": "pico8.ra.retro8",
       "description": "Supported extensions: p8, png.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/plus4.json
+++ b/assets/systems/plus4.json
@@ -53,6 +53,7 @@
   "emulators": [
     {
       "name": "RetroArch64 Vice XPlus4",
+      "default_core": true,
       "unique_id": "plus4.ra64.vice_xplus4",
       "description": "Supported extensions: bin, crt, d64, d6z, d71, d7z, d80, d81, d82, d8z, g41, g4z, g64, g6z, gz, lnx, p00, prg, t64, tap, x64, x6z, zip.",
       "is_retroachievements_compatible": false,
@@ -64,6 +65,7 @@
     },
     {
       "name": "RetroArch32 Vice XPlus4",
+      "default_core": true,
       "unique_id": "plus4.ra32.vice_xplus4",
       "description": "Supported extensions: bin, cmd, crt, d2m, d4m, d64, d6z, d71, d7z, d80, d81, d82, d8z, g41, g4z, g64, g6z, gz, m3u, nbz, nib, p00, prg, t64, tap, vfl, vsf, x64, x6z, zip.",
       "is_retroachievements_compatible": false,
@@ -75,6 +77,7 @@
     },
     {
       "name": "RetroArch Vice XPlus4",
+      "default_core": true,
       "unique_id": "plus4.ra.vice_xplus4",
       "description": "Supported extensions: bin, cmd, crt, d2m, d4m, d64, d6z, d71, d7z, d80, d81, d82, d8z, g41, g4z, g64, g6z, gz, m3u, nbz, nib, p00, prg, t64, tap, vfl, vsf, x64, x6z, zip.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/ps1.json
+++ b/assets/systems/ps1.json
@@ -113,6 +113,7 @@
     },
     {
       "name": "RetroArch64 Beetle PSX HW",
+      "default_core": true,
       "unique_id": "ps1.ra64.mednafen_psx_hw",
       "description": "Supported extensions: cue, toc, m3u, ccd, exe, pbp, chd.",
       "is_retroachievements_compatible": true,
@@ -168,6 +169,7 @@
     },
     {
       "name": "RetroArch32 Beetle PSX HW",
+      "default_core": true,
       "unique_id": "ps1.ra32.mednafen_psx_hw",
       "description": "Supported extensions: cue, toc, m3u, ccd, exe, pbp, chd.",
       "is_retroachievements_compatible": true,
@@ -223,7 +225,7 @@
     },
     {
       "name": "RetroArch Beetle PSX HW",
-      "default": true,
+      "default_core": true,
       "unique_id": "ps1.ra.mednafen_psx_hw",
       "description": "Supported extensions: cue, toc, m3u, ccd, exe, pbp, chd.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/ps2.json
+++ b/assets/systems/ps2.json
@@ -38,6 +38,7 @@
   "emulators": [
     {
       "name": "RetroArch Play!",
+      "default_core": true,
       "unique_id": "ps2.ra.play",
       "description": "Play! core for RetroArch.",
       "is_retroachievements_compatible": false,
@@ -49,6 +50,7 @@
     },
     {
       "name": "RetroArch64 Play!",
+      "default_core": true,
       "unique_id": "ps2.ra64.play",
       "description": "Play! core for RetroArch 64.",
       "is_retroachievements_compatible": false,
@@ -60,6 +62,7 @@
     },
     {
       "name": "RetroArch32 Play!",
+      "default_core": true,
       "unique_id": "ps2.ra32.play",
       "description": "Play! core for RetroArch 32.",
       "is_retroachievements_compatible": false,
@@ -191,7 +194,7 @@
     },
     {
       "name": "Standalone NetherSX2/AetherSX2",
-      "default": true,
+      "default_standalone": true,
       "unique_id": "ps2.xyz.aethersx2.android",
       "description": "Supported extensions: iso, chd, gz, mdf.",
       "is_retroachievements_compatible": true,
@@ -202,7 +205,7 @@
       }
     },
     {
-      "name": "Standalone Aethersx2 Turnip",
+      "name": "Standalone NetherSX2/AetherSX2 Turnip",
       "unique_id": "ps2.xyz.aethersx2.custom",
       "description": "Supported extensions: iso, chd, gz.",
       "is_retroachievements_compatible": false,
@@ -213,7 +216,7 @@
       }
     },
     {
-      "name": "Standalone NetherSX2 Turnip",
+      "name": "Standalone NetherSX2/AetherSX2 Turnip",
       "unique_id": "ps2.xyz.aethersx2.tturnip",
       "description": "Supported extensions: iso, chd, gz.",
       "is_retroachievements_compatible": false,
@@ -224,7 +227,7 @@
       }
     },
     {
-      "name": "Standalone NetherSX2 Classic Turnip",
+      "name": "Standalone NetherSX2/AetherSX2 Classic Turnip",
       "unique_id": "ps2.xyz.aethersx2.cturnip",
       "description": "Supported extensions: iso, chd, gz.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/ps3.json
+++ b/assets/systems/ps3.json
@@ -29,7 +29,7 @@
   "emulators": [
     {
       "name": "Standalone aPS3e",
-      "default": true,
+      "default_standalone": true,
       "unique_id": "ps3.aenu.aps3e",
       "description": "Supported extensions: iso.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/psp.json
+++ b/assets/systems/psp.json
@@ -80,6 +80,7 @@
     },
     {
       "name": "RetroArch64 PPSSPP",
+      "default_core": true,
       "unique_id": "psp.ra64.ppsspp",
       "description": "Supported extensions: cso, elf, iso, pbp, prx.",
       "is_retroachievements_compatible": true,
@@ -91,6 +92,7 @@
     },
     {
       "name": "RetroArch32 PPSSPP",
+      "default_core": true,
       "unique_id": "psp.ra32.ppsspp",
       "description": "Supported extensions: cso, elf, iso, pbp, prx.",
       "is_retroachievements_compatible": true,
@@ -102,7 +104,7 @@
     },
     {
       "name": "RetroArch PPSSPP",
-      "default": true,
+      "default_core": true,
       "unique_id": "psp.ra.ppsspp",
       "description": "Supported extensions: cso, elf, iso, pbp, prx.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/pspminis.json
+++ b/assets/systems/pspminis.json
@@ -66,6 +66,7 @@
     },
     {
       "name": "RetroArch64 PPSSPP",
+      "default_core": true,
       "unique_id": "pspminis.ra64.ppsspp",
       "description": "Supported extensions: cso, elf, iso, pbp, prx.",
       "is_retroachievements_compatible": false,
@@ -77,6 +78,7 @@
     },
     {
       "name": "RetroArch32 PPSSPP",
+      "default_core": true,
       "unique_id": "pspminis.ra32.ppsspp",
       "description": "Supported extensions: cso, elf, iso, pbp, prx.",
       "is_retroachievements_compatible": false,
@@ -88,6 +90,7 @@
     },
     {
       "name": "RetroArch PPSSPP",
+      "default_core": true,
       "unique_id": "pspminis.ra.ppsspp",
       "description": "Supported extensions: cso, elf, iso, pbp, prx.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/rpgmaker.json
+++ b/assets/systems/rpgmaker.json
@@ -30,6 +30,7 @@
   "emulators": [
     {
       "name": "RetroArch64 easyRPG",
+      "default_core": true,
       "unique_id": "rpgmaker.ra64.easyrpg",
       "description": "Supported extensions: easyrpg, ldb, zip.",
       "is_retroachievements_compatible": false,
@@ -41,6 +42,7 @@
     },
     {
       "name": "RetroArch32 easyRPG",
+      "default_core": true,
       "unique_id": "rpgmaker.ra32.easyrpg",
       "description": "Supported extensions: easyrpg, ldb, zip.",
       "is_retroachievements_compatible": false,
@@ -52,6 +54,7 @@
     },
     {
       "name": "RetroArch easyRPG",
+      "default_core": true,
       "unique_id": "rpgmaker.ra.easyrpg",
       "description": "Supported extensions: easyrpg, ldb, zip.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/sat.json
+++ b/assets/systems/sat.json
@@ -93,6 +93,7 @@
     },
     {
       "name": "RetroArch64 Beetle Saturn",
+      "default_core": true,
       "unique_id": "sat.ra64.mednafen_saturn",
       "description": "Supported extensions: ccd, chd, cue, m3u, toc.",
       "is_retroachievements_compatible": true,
@@ -126,6 +127,7 @@
     },
     {
       "name": "RetroArch32 Beetle Saturn",
+      "default_core": true,
       "unique_id": "sat.ra32.mednafen_saturn",
       "description": "Supported extensions: ccd, chd, cue, m3u, toc.",
       "is_retroachievements_compatible": true,
@@ -159,7 +161,7 @@
     },
     {
       "name": "RetroArch Beetle Saturn",
-      "default": true,
+      "default_core": true,
       "unique_id": "sat.ra.mednafen_saturn",
       "description": "Supported extensions: ccd, chd, cue, m3u, toc.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/satellaview.json
+++ b/assets/systems/satellaview.json
@@ -54,6 +54,7 @@
     },
     {
       "name": "RetroArch64 snes9x",
+      "default_core": true,
       "unique_id": "satellaview.ra64.snes9x",
       "description": "Supported extensions: bs, fig, sfc, smc, st, swc, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -153,6 +154,7 @@
     },
     {
       "name": "RetroArch32 Snes9x",
+      "default_core": true,
       "unique_id": "satellaview.ra32.snes9x",
       "description": "Supported extensions: bs, fig, sfc, smc, st, swc, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -252,6 +254,7 @@
     },
     {
       "name": "RetroArch Snes9x",
+      "default_core": true,
       "unique_id": "satellaview.ra.snes9x",
       "description": "Supported extensions: bs, fig, sfc, smc, st, swc, zip, 7z.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/scd.json
+++ b/assets/systems/scd.json
@@ -58,6 +58,7 @@
     },
     {
       "name": "RetroArch64 Genesis Plus GX",
+      "default_core": true,
       "unique_id": "scd.ra64.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -91,6 +92,7 @@
     },
     {
       "name": "RetroArch32 Genesis Plus GX",
+      "default_core": true,
       "unique_id": "scd.ra32.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -124,7 +126,7 @@
     },
     {
       "name": "RetroArch Genesis Plus GX",
-      "default": true,
+      "default_core": true,
       "unique_id": "scd.ra.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/scummvm.json
+++ b/assets/systems/scummvm.json
@@ -50,6 +50,7 @@
     },
     {
       "name": "RetroArch64 ScummVM",
+      "default_core": true,
       "unique_id": "scummvm.ra64.scummvm",
       "description": "Supported extensions: sh, svm, scummvm.",
       "is_retroachievements_compatible": false,
@@ -61,6 +62,7 @@
     },
     {
       "name": "RetroArch32 ScummVM",
+      "default_core": true,
       "unique_id": "scummvm.ra32.scummvm",
       "description": "Supported extensions: sh, svm, scummvm.",
       "is_retroachievements_compatible": false,
@@ -72,7 +74,7 @@
     },
     {
       "name": "RetroArch ScummVM",
-      "default": true,
+      "default_core": true,
       "unique_id": "scummvm.ra.scummvm",
       "description": "Supported extensions: sh, svm, scummvm.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/sfc-hacks.json
+++ b/assets/systems/sfc-hacks.json
@@ -55,6 +55,7 @@
     },
     {
       "name": "RetroArch64 Snes9x",
+      "default_core": true,
       "unique_id": "sfc-hacks.ra64.snes9x",
       "description": "Supported extensions: bs, fig, sfc, smc, st, swc, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -264,6 +265,7 @@
     },
     {
       "name": "RetroArch32 Snes9x",
+      "default_core": true,
       "unique_id": "sfc-hacks.ra32.snes9x",
       "description": "Supported extensions: bs, fig, sfc, smc, st, swc, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -473,7 +475,7 @@
     },
     {
       "name": "RetroArch Snes9x",
-      "default": true,
+      "default_core": true,
       "unique_id": "sfc-hacks.ra.snes9x",
       "description": "Supported extensions: bs, fig, sfc, smc, st, swc, zip, 7z.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/sfc.json
+++ b/assets/systems/sfc.json
@@ -54,6 +54,7 @@
     },
     {
       "name": "RetroArch64 Snes9x",
+      "default_core": true,
       "unique_id": "sfc.ra64.snes9x",
       "description": "Supported extensions: bs, fig, sfc, smc, st, swc, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -263,6 +264,7 @@
     },
     {
       "name": "RetroArch32 Snes9x",
+      "default_core": true,
       "unique_id": "sfc.ra32.snes9x",
       "description": "Supported extensions: bs, fig, sfc, smc, st, swc, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -472,7 +474,7 @@
     },
     {
       "name": "RetroArch Snes9x",
-      "default": true,
+      "default_core": true,
       "unique_id": "sfc.ra.snes9x",
       "description": "Supported extensions: bs, fig, sfc, smc, st, swc, zip, 7z.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/sg1k.json
+++ b/assets/systems/sg1k.json
@@ -46,6 +46,7 @@
   "emulators": [
     {
       "name": "RetroArch64 Genesis Plus GX",
+      "default_core": true,
       "unique_id": "sg1k.ra64.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -90,6 +91,7 @@
     },
     {
       "name": "RetroArch32 Genesis Plus GX",
+      "default_core": true,
       "unique_id": "sg1k.ra32.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -134,7 +136,7 @@
     },
     {
       "name": "RetroArch Genesis Plus GX",
-      "default": true,
+      "default_core": true,
       "unique_id": "sg1k.ra.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/sharpx68000.json
+++ b/assets/systems/sharpx68000.json
@@ -41,6 +41,7 @@
   "emulators": [
     {
       "name": "RetroArch64 PX68k",
+      "default_core": true,
       "unique_id": "sharpx68000.x68000.ra64.px68k",
       "description": "Supported extensions: 2hd, 88d, cmd, d88, dim, dup, hdf, hdm, img, m3u, xdf, zip, 7z.",
       "is_retroachievements_compatible": false,
@@ -52,6 +53,7 @@
     },
     {
       "name": "RetroArch32 PX68k",
+      "default_core": true,
       "unique_id": "sharpx68000.x68000.ra32.px68k",
       "description": "Supported extensions: 2hd, 88d, cmd, d88, dim, dup, hdf, hdm, img, m3u, xdf, zip, 7z.",
       "is_retroachievements_compatible": false,
@@ -63,7 +65,7 @@
     },
     {
       "name": "RetroArch PX68k",
-      "default": true,
+      "default_core": true,
       "unique_id": "sharpx68000.x68000.ra.px68k",
       "description": "Supported extensions: 2hd, 88d, cmd, d88, dim, dup, hdf, hdm, img, m3u, xdf, zip, 7z.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/sms.json
+++ b/assets/systems/sms.json
@@ -71,6 +71,7 @@
     },
     {
       "name": "RetroArch64 Genesis Plus GX",
+      "default_core": true,
       "unique_id": "sms.ra64.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -126,6 +127,7 @@
     },
     {
       "name": "RetroArch32 Genesis Plus GX",
+      "default_core": true,
       "unique_id": "sms.ra32.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -181,7 +183,7 @@
     },
     {
       "name": "RetroArch Genesis Plus GX",
-      "default": true,
+      "default_core": true,
       "unique_id": "sms.ra.genesis_plus_gx",
       "description": "Supported extensions: 68k, bin, chd, cue, gen, gg, iso, md, mdx, sg, smd, sms, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -191,15 +193,15 @@
         },
         "windows": {
           "executable": "retroarch.exe",
-          "args": "-L genesis_plus_gx_wide_libretro.dll \"{file.path}\""
+          "args": "-L genesis_plus_gx_libretro.dll \"{file.path}\""
         },
         "linux": {
           "executable": "retroarch",
-          "args": "-L genesis_plus_gx_wide_libretro.so \"{file.path}\""
+          "args": "-L genesis_plus_gx_libretro.so \"{file.path}\""
         },
         "macos": {
           "executable": "RetroArch.App",
-          "args": "-L genesis_plus_gx_wide_libretro.dylib \"{file.path}\""
+          "args": "-L genesis_plus_gx_libretro.dylib \"{file.path}\""
         }
       }
     },

--- a/assets/systems/snes-hacks.json
+++ b/assets/systems/snes-hacks.json
@@ -58,6 +58,7 @@
     },
     {
       "name": "RetroArch64 Snes9x",
+      "default_core": true,
       "unique_id": "snes-hacks.ra64.snes9x",
       "description": "Supported extensions: bs, fig, sfc, smc, st, swc, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -267,6 +268,7 @@
     },
     {
       "name": "RetroArch32 Snes9x",
+      "default_core": true,
       "unique_id": "snes-hacks.ra32.snes9x",
       "description": "Supported extensions: bs, fig, sfc, smc, st, swc, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -476,7 +478,7 @@
     },
     {
       "name": "RetroArch Snes9x",
-      "default": true,
+      "default_core": true,
       "unique_id": "snes-hacks.ra.snes9x",
       "description": "Supported extensions: bs, fig, sfc, smc, st, swc, zip, 7z.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/snes.json
+++ b/assets/systems/snes.json
@@ -57,6 +57,7 @@
     },
     {
       "name": "RetroArch64 Snes9x",
+      "default_core": true,
       "unique_id": "snes.ra64.snes9x",
       "description": "Supported extensions: bs, fig, sfc, smc, st, swc, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -266,6 +267,7 @@
     },
     {
       "name": "RetroArch32 Snes9x",
+      "default_core": true,
       "unique_id": "snes.ra32.snes9x",
       "description": "Supported extensions: bs, fig, sfc, smc, st, swc, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -475,7 +477,7 @@
     },
     {
       "name": "RetroArch Snes9x",
-      "default": true,
+      "default_core": true,
       "unique_id": "snes.ra.snes9x",
       "description": "Supported extensions: bs, fig, sfc, smc, st, swc, zip, 7z.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/steam.json
+++ b/assets/systems/steam.json
@@ -32,7 +32,7 @@
     {
       "name": "Standalone GameNative (Steam)",
       "unique_id": "steam.app.gamenative.steam",
-      "default": true,
+      "default_standalone": true,
       "is_retroachievements_compatible": false,
       "description": "Supported extensions: steamappid.",
       "platforms": {

--- a/assets/systems/switch.json
+++ b/assets/systems/switch.json
@@ -43,7 +43,7 @@
     },
     {
       "name": "Standalone Eden",
-      "default": true,
+      "default_standalone": true,
       "unique_id": "switch.dev.eden.eden_emulator",
       "description": "Supported extensions: nro, nso, nca, xci, nsp.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/tg16.json
+++ b/assets/systems/tg16.json
@@ -48,6 +48,18 @@
       }
     },
     {
+      "name": "RetroArch64 Beetle SuperGrafx",
+      "default_core": true,
+      "unique_id": "tg16.ra64.mednafen_supergrafx",
+      "description": "Supported extensions: pce, sgx, cue, ccd, chd, pce.",
+      "is_retroachievements_compatible": true,
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.retroarch.aarch64/com.retroarch.browser.retroactivity.RetroActivityFuture --es ROM \"{file.path}\" --es LIBRETRO \"mednafen_supergrafx\""
+        }
+      }
+    },
+    {
       "name": "RetroArch64 Beetle PCE Fast",
       "unique_id": "tg16.ra64.mednafen_pce_fast",
       "description": "Supported extensions: ccd, chd, cue, m3u, pce, toc.",
@@ -70,6 +82,18 @@
       }
     },
     {
+      "name": "RetroArch32 Beetle SuperGrafx",
+      "default_core": true,
+      "unique_id": "tg16.ra32.mednafen_supergrafx",
+      "description": "Supported extensions: pce, sgx, cue, ccd, chd, pce.",
+      "is_retroachievements_compatible": true,
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.retroarch.ra32/com.retroarch.browser.retroactivity.RetroActivityFuture --es ROM \"{file.path}\" --es LIBRETRO \"mednafen_supergrafx\""
+        }
+      }
+    },
+    {
       "name": "RetroArch32 Beetle PCE Fast",
       "unique_id": "tg16.ra32.mednafen_pce_fast",
       "description": "Supported extensions: ccd, chd, cue, m3u, pce, toc.",
@@ -88,6 +112,30 @@
       "platforms": {
         "android": {
           "launch_arguments": "-n com.retroarch.ra32/com.retroarch.browser.retroactivity.RetroActivityFuture --es ROM \"{file.path}\" --es LIBRETRO \"mednafen_pce\""
+        }
+      }
+    },
+    {
+      "name": "RetroArch Beetle SuperGrafx",
+      "default_core": true,
+      "unique_id": "tg16.ra.mednafen_supergrafx",
+      "description": "Supported extensions: pce, sgx, cue, ccd, chd, pce.",
+      "is_retroachievements_compatible": true,
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.retroarch/com.retroarch.browser.retroactivity.RetroActivityFuture --es ROM \"{file.path}\" --es LIBRETRO \"mednafen_supergrafx\""
+        },
+        "windows": {
+          "executable": "retroarch.exe",
+          "args": "-L mednafen_supergrafx_libretro.dll \"{file.path}\""
+        },
+        "linux": {
+          "executable": "retroarch",
+          "args": "-L mednafen_supergrafx_libretro.so \"{file.path}\""
+        },
+        "macos": {
+          "executable": "retroarch",
+          "args": "-L mednafen_supergrafx_libretro.dylib \"{file.path}\""
         }
       }
     },
@@ -116,7 +164,6 @@
     },
     {
       "name": "RetroArch Beetle PCE",
-      "default": true,
       "unique_id": "tg16.ra.mednafen_pce",
       "description": "Supported extensions: ccd, chd, cue, m3u, pce, sgx, toc, zip, 7z.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/tgcd.json
+++ b/assets/systems/tgcd.json
@@ -47,6 +47,18 @@
       }
     },
     {
+      "name": "RetroArch64 Beetle SuperGrafx",
+      "default_core": true,
+      "unique_id": "tgcd.ra64.mednafen_supergrafx",
+      "description": "Supported extensions: pce, sgx, cue, ccd, chd, pce.",
+      "is_retroachievements_compatible": true,
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.retroarch.aarch64/com.retroarch.browser.retroactivity.RetroActivityFuture --es ROM \"{file.path}\" --es LIBRETRO \"mednafen_supergrafx\""
+        }
+      }
+    },
+    {
       "name": "RetroArch64 Beetle PCE Fast",
       "unique_id": "tgcd.ra64.mednafen_pce_fast",
       "description": "Supported extensions: ccd, chd, cue, m3u, pce, toc.",
@@ -69,6 +81,18 @@
       }
     },
     {
+      "name": "RetroArch32 Beetle SuperGrafx",
+      "default_core": true,
+      "unique_id": "tgcd.ra32.mednafen_supergrafx",
+      "description": "Supported extensions: pce, sgx, cue, ccd, chd, pce.",
+      "is_retroachievements_compatible": true,
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.retroarch.ra32/com.retroarch.browser.retroactivity.RetroActivityFuture --es ROM \"{file.path}\" --es LIBRETRO \"mednafen_supergrafx\""
+        }
+      }
+    },
+    {
       "name": "RetroArch32 Beetle PCE Fast",
       "unique_id": "tgcd.ra32.mednafen_pce_fast",
       "description": "Supported extensions: ccd, chd, cue, m3u, pce, toc.",
@@ -87,6 +111,30 @@
       "platforms": {
         "android": {
           "launch_arguments": "-n com.retroarch.ra32/com.retroarch.browser.retroactivity.RetroActivityFuture --es ROM \"{file.path}\" --es LIBRETRO \"mednafen_pce\""
+        }
+      }
+    },
+    {
+      "name": "RetroArch Beetle SuperGrafx",
+      "default_core": true,
+      "unique_id": "tgcd.ra.mednafen_supergrafx",
+      "description": "Supported extensions: pce, sgx, cue, ccd, chd, pce.",
+      "is_retroachievements_compatible": true,
+      "platforms": {
+        "android": {
+          "launch_arguments": "-n com.retroarch/com.retroarch.browser.retroactivity.RetroActivityFuture --es ROM \"{file.path}\" --es LIBRETRO \"mednafen_supergrafx\""
+        },
+        "windows": {
+          "executable": "retroarch.exe",
+          "args": "-L mednafen_supergrafx_libretro.dll \"{file.path}\""
+        },
+        "linux": {
+          "executable": "retroarch",
+          "args": "-L mednafen_supergrafx_libretro.so \"{file.path}\""
+        },
+        "macos": {
+          "executable": "RetroArch.App",
+          "args": "-L mednafen_supergrafx_libretro.dylib \"{file.path}\""
         }
       }
     },
@@ -115,7 +163,6 @@
     },
     {
       "name": "RetroArch Beetle PCE",
-      "default": true,
       "unique_id": "tgcd.ra.mednafen_pce",
       "description": "Supported extensions: ccd, chd, cue, m3u, pce, sgx, toc, zip, 7z.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/tic80.json
+++ b/assets/systems/tic80.json
@@ -29,6 +29,7 @@
   "emulators": [
     {
       "name": "RetroArch64 TIC80",
+      "default_core": true,
       "unique_id": "tic80.ra64.tic80",
       "description": "Supported extensions: tic.",
       "is_retroachievements_compatible": false,
@@ -40,6 +41,7 @@
     },
     {
       "name": "RetroArch32 TIC80",
+      "default_core": true,
       "unique_id": "tic80.ra32.tic80",
       "description": "Supported extensions: tic.",
       "is_retroachievements_compatible": false,
@@ -51,6 +53,7 @@
     },
     {
       "name": "RetroArch TIC80",
+      "default_core": true,
       "unique_id": "tic80.ra.tic80",
       "description": "Supported extensions: tic.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/triforce.json
+++ b/assets/systems/triforce.json
@@ -32,7 +32,7 @@
     {
       "name": "Standalone Dolphin",
       "unique_id": "triforce.org.dolphinemu.dolphinemu",
-      "default": true,
+      "default_standalone": true,
       "description": "Supported extensions: gcz, iso, wia, gcm.",
       "is_retroachievements_compatible": false,
       "platforms": {

--- a/assets/systems/uze.json
+++ b/assets/systems/uze.json
@@ -30,6 +30,7 @@
   "emulators": [
     {
       "name": "RetroArch64 Uzem",
+      "default_core": true,
       "unique_id": "uze.ra64.uzem",
       "description": "Supported extensions: uze.",
       "is_retroachievements_compatible": true,
@@ -41,6 +42,7 @@
     },
     {
       "name": "RetroArch32 Uzem",
+      "default_core": true,
       "unique_id": "uze.ra32.uzem",
       "description": "Supported extensions: uze.",
       "is_retroachievements_compatible": true,
@@ -52,7 +54,7 @@
     },
     {
       "name": "RetroArch Uzem",
-      "default": true,
+      "default_core": true,
       "unique_id": "uze.ra.uzem",
       "description": "Supported extensions: uze.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/vb.json
+++ b/assets/systems/vb.json
@@ -45,6 +45,7 @@
     },
     {
       "name": "RetroArch64 Beetle VB",
+      "default_core": true,
       "unique_id": "vb.ra64.mednafen_vb",
       "description": "Supported extensions: bin, vb, vboy.",
       "is_retroachievements_compatible": true,
@@ -56,6 +57,7 @@
     },
     {
       "name": "RetroArch32 Beetle VB",
+      "default_core": true,
       "unique_id": "vb.ra32.mednafen_vb",
       "description": "Supported extensions: bin, vb, vboy.",
       "is_retroachievements_compatible": true,
@@ -67,7 +69,7 @@
     },
     {
       "name": "RetroArch Beetle VB",
-      "default": true,
+      "default_core": true,
       "unique_id": "vb.ra.mednafen_vb",
       "description": "Supported extensions: bin, vb, vboy.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/vc4k.json
+++ b/assets/systems/vc4k.json
@@ -41,6 +41,7 @@
     },
     {
       "name": "RetroArch64 MESS",
+      "default_core": true,
       "unique_id": "vc4k.vc4000.ra64.mess",
       "description": "Supported extensions: cmd.",
       "is_retroachievements_compatible": false,
@@ -52,6 +53,7 @@
     },
     {
       "name": "RetroArch MESS",
+      "default_core": true,
       "unique_id": "vc4k.vc4000.ra.mess",
       "description": "Supported extensions: cmd.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/vect.json
+++ b/assets/systems/vect.json
@@ -31,6 +31,7 @@
   "emulators": [
     {
       "name": "RetroArch64 Vecx",
+      "default_core": true,
       "unique_id": "vect.ra64.vecx",
       "description": "Supported extensions: bin, vec, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -42,6 +43,7 @@
     },
     {
       "name": "RetroArch32 Vecx",
+      "default_core": true,
       "unique_id": "vect.ra32.vecx",
       "description": "Supported extensions: bin, vec, zip, 7z.",
       "is_retroachievements_compatible": true,
@@ -53,7 +55,7 @@
     },
     {
       "name": "RetroArch Vecx",
-      "default": true,
+      "default_core": true,
       "unique_id": "vect.ra.vecx",
       "description": "Supported extensions: bin, vec, zip, 7z.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/vic20.json
+++ b/assets/systems/vic20.json
@@ -64,6 +64,7 @@
   "emulators": [
     {
       "name": "RetroArch64 VICE XVIC",
+      "default_core": true,
       "unique_id": "vic20.ra64.vice_xvic",
       "description": "Supported extensions: d64, d71, d80, d81, d82, g64, g41, x64, t64, tap, prg, p00, crt, bin, zip, gz, d6z, d7z, d8z, g6z, g4z, x6z, cmd, m3u, vfl, vsf, nib, nbz, d2m, d4m, 20, 40, 60, a0, b0, rom.",
       "is_retroachievements_compatible": false,
@@ -75,6 +76,7 @@
     },
     {
       "name": "RetroArch32 VICE XVIC",
+      "default_core": true,
       "unique_id": "vic20.ra32.vice_xvic",
       "description": "Supported extensions: d64, d71, d80, d81, d82, g64, g41, x64, t64, tap, prg, p00, crt, bin, zip, gz, d6z, d7z, d8z, g6z, g4z, x6z, cmd, m3u, vfl, vsf, nib, nbz, d2m, d4m, 20, 40, 60, a0, b0, rom.",
       "is_retroachievements_compatible": false,
@@ -86,6 +88,7 @@
     },
     {
       "name": "RetroArch VICE XVIC",
+      "default_core": true,
       "unique_id": "vic20.ra.vice_xvic",
       "description": "Supported extensions: d64, d71, d80, d81, d82, g64, g41, x64, t64, tap, prg, p00, crt, bin, zip, gz, d6z, d7z, d8z, g6z, g4z, x6z, cmd, m3u, vfl, vsf, nib, nbz, d2m, d4m, 20, 40, 60, a0, b0, rom.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/vita.json
+++ b/assets/systems/vita.json
@@ -29,7 +29,7 @@
   "emulators": [
     {
       "name": "Standalone Vita3K",
-      "default": true,
+      "default_standalone": true,
       "unique_id": "vita.vita3k",
       "description": "Supported extensions: psvita.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/wasm4.json
+++ b/assets/systems/wasm4.json
@@ -28,6 +28,7 @@
   "emulators": [
     {
       "name": "RetroArch64 WASM-4",
+      "default_core": true,
       "unique_id": "wasm4.ra64.wasm4",
       "description": "Supported extensions: wasm.",
       "is_retroachievements_compatible": true,
@@ -39,6 +40,7 @@
     },
     {
       "name": "RetroArch32 WASM-4",
+      "default_core": true,
       "unique_id": "wasm4.ra32.wasm4",
       "description": "Supported extensions: wasm.",
       "is_retroachievements_compatible": true,
@@ -50,7 +52,7 @@
     },
     {
       "name": "RetroArch WASM-4",
-      "default": true,
+      "default_core": true,
       "unique_id": "wasm4.ra.wasm4",
       "description": "Supported extensions: wasm.",
       "is_retroachievements_compatible": true,

--- a/assets/systems/wii.json
+++ b/assets/systems/wii.json
@@ -118,6 +118,7 @@
     },
     {
       "name": "RetroArch64 Dolphin",
+      "default_core": true,
       "unique_id": "wii.ra64.dolphin",
       "description": "Supported extensions: ciso, dff, dol, elf, gcm, gcz, iso, m3u, rvz, tgc, wad, wbfs, wia",
       "is_retroachievements_compatible": false,
@@ -129,7 +130,7 @@
     },
     {
       "name": "RetroArch Dolphin",
-      "default": true,
+      "default_core": true,
       "unique_id": "wii.ra.dolphin",
       "description": "Supported extensions: ciso, dff, dol, elf, gcm, gcz, iso, m3u, rvz, tgc, wad, wbfs, wia",
       "is_retroachievements_compatible": false,

--- a/assets/systems/wiiu.json
+++ b/assets/systems/wiiu.json
@@ -34,7 +34,7 @@
   "emulators": [
     {
       "name": "Standalone CEMU",
-      "default": true,
+      "default_standalone": true,
       "unique_id": "wiiu.info.cemu.cemu",
       "description": "Supported extensions: wua, wud, wux, rpx.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/ws.json
+++ b/assets/systems/ws.json
@@ -45,6 +45,7 @@
     },
     {
       "name": "RetroArch64 Beetle Cygne",
+      "default_core": true,
       "unique_id": "ws.ra64.mednafen_wswan",
       "description": "Supported extensions: ws, wsc, pc2, 7z, zip",
       "is_retroachievements_compatible": true,
@@ -56,6 +57,7 @@
     },
     {
       "name": "RetroArch32 Beetle Cygne",
+      "default_core": true,
       "unique_id": "ws.ra32.mednafen_wswan",
       "description": "Supported extensions: ws, wsc, pc2, 7z, zip",
       "is_retroachievements_compatible": true,
@@ -67,7 +69,7 @@
     },
     {
       "name": "RetroArch Beetle Cygne",
-      "default": true,
+      "default_core": true,
       "unique_id": "ws.ra.mednafen_wswan",
       "description": "Supported extensions: ws, wsc, pc2, 7z, zip",
       "is_retroachievements_compatible": true,

--- a/assets/systems/wsc.json
+++ b/assets/systems/wsc.json
@@ -46,6 +46,7 @@
     },
     {
       "name": "Retroarch64 Beetle Cygne",
+      "default_core": true,
       "unique_id": "wsc.ra64.mednafen_wswan",
       "description": "Supported extensions: ws, wsc, pc2, 7z, zip",
       "is_retroachievements_compatible": true,
@@ -57,6 +58,7 @@
     },
     {
       "name": "Retroarch32 Beetle Cygne",
+      "default_core": true,
       "unique_id": "wsc.ra32.mednafen_wswan",
       "description": "Supported extensions: ws, wsc, pc2, 7z, zip",
       "is_retroachievements_compatible": true,
@@ -68,7 +70,7 @@
     },
     {
       "name": "Retroarch Beetle Cygne",
-      "default": true,
+      "default_core": true,
       "unique_id": "wsc.ra.mednafen_wswan",
       "description": "Supported extensions: ws, wsc, pc2, 7z, zip",
       "is_retroachievements_compatible": true,

--- a/assets/systems/wsv.json
+++ b/assets/systems/wsv.json
@@ -33,6 +33,7 @@
   "emulators": [
     {
       "name": "RetroArch64 Potator",
+      "default_core": true,
       "unique_id": "wsv.ra64.potator",
       "description": "Supported extensions: bin, sv, zip, 7z",
       "is_retroachievements_compatible": true,
@@ -44,6 +45,7 @@
     },
     {
       "name": "RetroArch32 Potator",
+      "default_core": true,
       "unique_id": "wsv.ra32.potator",
       "description": "Supported extensions: bin, sv, zip, 7z",
       "is_retroachievements_compatible": true,
@@ -55,7 +57,7 @@
     },
     {
       "name": "RetroArch Potator",
-      "default": true,
+      "default_core": true,
       "unique_id": "wsv.ra.potator",
       "description": "Supported extensions: bin, sv, zip, 7z",
       "is_retroachievements_compatible": true,

--- a/assets/systems/x1.json
+++ b/assets/systems/x1.json
@@ -40,6 +40,7 @@
   "emulators": [
     {
       "name": "RetroArch64 X1",
+      "default_core": true,
       "unique_id": "x1.ra64.x1",
       "description": "Supported extensions: 2hd, 88d, cmd, d88, dim, dup, hdf, hdm, img, m3u, xdf, zip, 7z.",
       "is_retroachievements_compatible": false,
@@ -51,6 +52,7 @@
     },
     {
       "name": "RetroArch32 X1",
+      "default_core": true,
       "unique_id": "x1.ra32.x1",
       "description": "Supported extensions: 2hd, 88d, cmd, d88, dim, dup, hdf, hdm, img, m3u, xdf, zip, 7z.",
       "is_retroachievements_compatible": false,
@@ -62,6 +64,7 @@
     },
     {
       "name": "RetroArch X1",
+      "default_core": true,
       "unique_id": "x1.ra.x1",
       "description": "Supported extensions: 2hd, 88d, cmd, d88, dim, dup, hdf, hdm, img, m3u, xdf, zip, 7z.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/xbox.json
+++ b/assets/systems/xbox.json
@@ -34,7 +34,7 @@
     {
       "name": "Standalone X1 Box",
       "unique_id": "xbox.com.izzy2lost.x1box",
-      "default": true,
+      "default_standalone": true,
       "is_retroachievements_compatible": false,
       "description": "Supported extensions: xiso, iso.",
       "platforms": {

--- a/assets/systems/xbox360.json
+++ b/assets/systems/xbox360.json
@@ -41,7 +41,7 @@
     },
     {
       "name": "AX360e (Free)",
-      "default": true,
+      "default_standalone": true,
       "unique_id": "xbox360.aenu.ax360e.free",
       "description": "Supported extensions: iso.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/zx81.json
+++ b/assets/systems/zx81.json
@@ -32,6 +32,7 @@
   "emulators": [
     {
       "name": "RetroArch64 ZX81",
+      "default_core": true,
       "unique_id": "zx81.ra64.81",
       "description": "Supported extensions: p, t81, tzx.",
       "is_retroachievements_compatible": false,
@@ -43,6 +44,7 @@
     },
     {
       "name": "RetroArch32 ZX81",
+      "default_core": true,
       "unique_id": "zx81.ra32.81",
       "description": "Supported extensions: p, t81, tzx.",
       "is_retroachievements_compatible": false,
@@ -54,6 +56,7 @@
     },
     {
       "name": "RetroArch ZX81",
+      "default_core": true,
       "unique_id": "zx81.ra.81",
       "description": "Supported extensions: p, t81, tzx.",
       "is_retroachievements_compatible": false,

--- a/assets/systems/zxspectrum.json
+++ b/assets/systems/zxspectrum.json
@@ -40,6 +40,7 @@
   "emulators": [
     {
       "name": "RetroArch64 FUSE",
+      "default_core": true,
       "unique_id": "zxspectrum.ra64.fuse",
       "description": "Supported extensions: dsk, rzx, scl, tap, trd, tzx, z80, zip, 7z.",
       "is_retroachievements_compatible": false,
@@ -51,6 +52,7 @@
     },
     {
       "name": "RetroArch32 FUSE",
+      "default_core": true,
       "unique_id": "zxspectrum.ra32.fuse",
       "description": "Supported extensions: dsk, rzx, scl, tap, trd, tzx, z80, zip, 7z.",
       "is_retroachievements_compatible": false,
@@ -62,8 +64,8 @@
     },
     {
       "name": "RetroArch FUSE",
+      "default_core": true,
       "unique_id": "zxspectrum.ra.fuse",
-      "default": true,
       "description": "Supported extensions: dsk, rzx, scl, tap, trd, tzx, z80, zip, 7z.",
       "is_retroachievements_compatible": false,
       "platforms": {

--- a/lib/data/datasources/sqlite_migrations.dart
+++ b/lib/data/datasources/sqlite_migrations.dart
@@ -282,6 +282,9 @@ class SqliteMigrations {
       case 92:
         await _migrateToVersion92(db);
         break;
+      case 93:
+        await _migrateToVersion93(db);
+        break;
       default:
         _log.w('No migration defined for version $version');
     }
@@ -4611,6 +4614,29 @@ class SqliteMigrations {
       }
     } catch (e, stackTrace) {
       _log.e('Error in migration v92: $e');
+      _log.e('   StackTrace: $stackTrace');
+      rethrow;
+    }
+  }
+
+  /// Migration v93: Adds `is_default_core` column to `app_emulators` to mark
+  /// which RetroArch core is the recommended default per variant (RA, RA32, RA64).
+  static Future<void> _migrateToVersion93(Database db) async {
+    _log.i('Migration v93: Adding is_default_core to app_emulators');
+    try {
+      final tableInfo = db.select('PRAGMA table_info(app_emulators)');
+      final columns = tableInfo.map((c) => c['name'].toString()).toList();
+
+      if (!columns.contains('is_default_core')) {
+        db.execute(
+          'ALTER TABLE app_emulators ADD COLUMN is_default_core INTEGER NOT NULL DEFAULT 0',
+        );
+        _log.i('Column is_default_core added via v93');
+      } else {
+        _log.i('Column is_default_core already exists');
+      }
+    } catch (e, stackTrace) {
+      _log.e('Error in migration v93: $e');
       _log.e('   StackTrace: $stackTrace');
       rethrow;
     }

--- a/lib/data/datasources/sqlite_service.dart
+++ b/lib/data/datasources/sqlite_service.dart
@@ -421,7 +421,7 @@ class SqliteService {
   SqliteService._internal();
 
   // Database configuration
-  static const int _databaseVersion = 92;
+  static const int _databaseVersion = 93;
   static const String _databaseName = 'data.sqlite';
 
   DatabaseAdapter? _database;
@@ -793,8 +793,14 @@ class SqliteService {
         }
 
         // Determine if we should apply default from JSON
-        final bool applyJsonDefault =
-            !hasDefaultInDB && !defaultSetInLoop && emuDef.isDefault;
+        final bool isDefaultCore = emuDef.isDefaultCore;
+        final bool isDefaultStandalone = emuDef.isDefaultStandalone;
+        // On Android, skip setting is_default for RetroArch cores here;
+        // RA detection (_fixRetroarchAndroidDefault) handles that separately.
+        final bool isAndroidTarget = osName == 'android';
+        final bool isRetroArchCore = isDefaultCore && !isStandalone;
+        final bool skipCoreDefault = isAndroidTarget && isRetroArchCore;
+        final bool applyJsonDefault = !hasDefaultInDB && !defaultSetInLoop && !skipCoreDefault && (isDefaultCore || isDefaultStandalone);
 
         if (applyJsonDefault) {
           defaultSetInLoop = true;
@@ -826,6 +832,9 @@ class SqliteService {
           if (applyJsonDefault) {
             updateData['is_default'] = 1;
           }
+          if (isDefaultCore) {
+            updateData['is_default_core'] = 1;
+          }
 
           await txn.update(
             'app_emulators',
@@ -844,16 +853,21 @@ class SqliteService {
           );
 
           if (existingByName.isNotEmpty) {
-            // Update old record to add unique_identifier
+            // Prepare update map
+            final Map<String, Object?> updateData = {
+              'unique_identifier': emuDef.uniqueId,
+              'is_standalone': isStandalone ? 1 : 0,
+              'core_filename': coreFilename,
+              'android_package_name': packageName,
+              'is_ra_compatible': retroAchievementsCompatible ? 1 : 0,
+            };
+            if (isDefaultCore) {
+              updateData['is_default_core'] = 1;
+            }
+
             await txn.update(
               'app_emulators',
-              {
-                'unique_identifier': emuDef.uniqueId,
-                'is_standalone': isStandalone ? 1 : 0,
-                'core_filename': coreFilename,
-                'android_package_name': packageName,
-                'is_ra_compatible': retroAchievementsCompatible ? 1 : 0,
-              },
+              updateData,
               where:
                   'system_id = ? AND os_id = ? AND name = ? AND unique_identifier IS NULL',
               whereArgs: [systemId, osId, dbName],
@@ -861,7 +875,7 @@ class SqliteService {
             processedUniqueIds.add(emuDef.uniqueId);
           } else {
             // New emulator
-            await txn.insert('app_emulators', {
+            final Map<String, Object?> insertData = {
               'system_id': systemId,
               'os_id': osId,
               'name': dbName,
@@ -871,7 +885,12 @@ class SqliteService {
               'android_package_name': packageName,
               'is_default': applyJsonDefault ? 1 : 0,
               'is_ra_compatible': retroAchievementsCompatible ? 1 : 0,
-            });
+            };
+            if (isDefaultCore) {
+              insertData['is_default_core'] = 1;
+            }
+
+            await txn.insert('app_emulators', insertData);
             processedUniqueIds.add(emuDef.uniqueId);
           }
         }
@@ -1222,6 +1241,15 @@ class SqliteService {
       }
     }
 
+    // FIX: Ensure is_default_core column in app_emulators.
+    if (tableNames.contains('app_emulators')) {
+      try {
+        await _ensureEmulatorDefaultCoreColumn(db);
+      } catch (e) {
+        _log.e('Minor fix for emulator default core column failed: $e');
+      }
+    }
+
     // FIX: Ensure app_neo_sync_state exists (legacy support for v58).
     await db.execute('''
       CREATE TABLE IF NOT EXISTS app_neo_sync_state (
@@ -1251,6 +1279,22 @@ class SqliteService {
       }
     } catch (e) {
       _log.e('Minor fix ensuring emulator unique identifier failed: $e');
+      rethrow;
+    }
+  }
+
+  /// Ensures the is_default_core column exists in app_emulators.
+  Future<void> _ensureEmulatorDefaultCoreColumn(DatabaseAdapter db) async {
+    try {
+      final tableInfo = await db.rawQuery('PRAGMA table_info(app_emulators)');
+      final columns = tableInfo.map((c) => c['name'].toString()).toList();
+      if (!columns.contains('is_default_core')) {
+        await db.execute(
+          'ALTER TABLE app_emulators ADD COLUMN is_default_core INTEGER NOT NULL DEFAULT 0',
+        );
+      }
+    } catch (e) {
+      _log.e('Minor fix ensuring emulator default core column failed: $e');
       rethrow;
     }
   }
@@ -1519,6 +1563,7 @@ class SqliteService {
           is_standalone INTEGER NOT NULL DEFAULT 0,
           core_filename TEXT,
           is_default INTEGER NOT NULL DEFAULT 0,
+          is_default_core INTEGER NOT NULL DEFAULT 0,
           is_ra_compatible INTEGER NOT NULL DEFAULT 0,
           android_package_name TEXT,
           android_activity_name TEXT,
@@ -3282,6 +3327,34 @@ class SqliteService {
         where: 'os_id = ? AND unique_identifier = ?',
         whereArgs: [osId, uniqueIdentifier],
       );
+
+      // Track user selection in user_emulator_config so RA auto-detection
+      // does not override it on subsequent startups.
+      final existing = await txn.query(
+        'user_emulator_config',
+        columns: ['emulator_unique_id'],
+        where: 'emulator_unique_id = ?',
+        whereArgs: [uniqueIdentifier],
+      );
+      if (existing.isNotEmpty) {
+        await txn.update(
+          'user_emulator_config',
+          {
+            'is_user_default': 1,
+            'updated_at': DateTime.now().toIso8601String(),
+          },
+          where: 'emulator_unique_id = ?',
+          whereArgs: [uniqueIdentifier],
+        );
+      } else {
+        await txn.insert('user_emulator_config', {
+          'emulator_unique_id': uniqueIdentifier,
+          'emulator_path': '',
+          'is_user_default': 1,
+          'created_at': DateTime.now().toIso8601String(),
+          'updated_at': DateTime.now().toIso8601String(),
+        });
+      }
     });
 
     // Enforce disk persistence via WAL checkpoint.
@@ -3464,9 +3537,26 @@ class SqliteService {
             [systemId],
           );
         }
-        // FALLBACK: Assign the first available core if no default exists.
+        // FALLBACK: Assign the first available default_core, then standalone, then any core.
         else if (!hasCoreDefault && !hasStandaloneDefault) {
-          if (cores.isNotEmpty) {
+          // Prefer the core marked as default_core in JSON
+          final defaultCore = cores.firstWhere(
+            (c) => c['is_default_core'] == 1,
+            orElse: () => {},
+          );
+          if (defaultCore.isNotEmpty) {
+            await db.rawUpdate(
+              'UPDATE app_emulators SET is_default = 1 WHERE unique_identifier = ? AND os_id = ?',
+              [defaultCore['unique_identifier'], defaultCore['os_id']],
+            );
+          } else if (standalones.isNotEmpty) {
+            // Fall back to the first standalone
+            await db.rawUpdate(
+              'UPDATE user_emulator_config SET is_user_default = 1 WHERE emulator_unique_id = ?',
+              [standalones.first['unique_identifier']],
+            );
+          } else if (cores.isNotEmpty) {
+            // Absolute fallback: any core
             await db.rawUpdate(
               'UPDATE app_emulators SET is_default = 1 WHERE unique_identifier = ? AND os_id = ?',
               [cores.first['unique_identifier'], cores.first['os_id']],
@@ -4186,13 +4276,29 @@ class SqliteService {
         .toList();
   }
 
-  /// Updates [is_default] across all systems so that [preferredPackage] is the
-  /// active RetroArch variant on Android. Resets all other RetroArch packages
-  /// to non-default, then sets [preferredPackage] as the default.
+  /// Updates [is_default] so that [preferredPackage] is the active RetroArch
+  /// variant on Android. Skips entirely if the user has made any custom
+  /// emulator selections (tracked in [user_emulator_config]). Sets only the
+  /// entries marked as [is_default_core] for the preferred package, and
+  /// clears conflicting standalone defaults.
   static Future<void> fixRetroArchDefaultForAndroid(
     String preferredPackage,
   ) async {
     final db = await instance.database;
+
+    // If user has made any emulator selections, respect them and skip
+    final userChoices = await db.rawQuery(
+      'SELECT COUNT(*) as count FROM user_emulator_config WHERE is_user_default = 1',
+    );
+    final userChoiceCount = userChoices.isNotEmpty
+        ? (int.tryParse(userChoices.first['count']?.toString() ?? '0') ?? 0)
+        : 0;
+    if (userChoiceCount > 0) {
+      _log.i(
+        'Android: User has custom emulator choices ($userChoiceCount), skipping RA defaults',
+      );
+      return;
+    }
 
     final osResult = await db.query(
       'app_os',
@@ -4203,15 +4309,28 @@ class SqliteService {
     final osId = int.tryParse(osResult.first['id']?.toString() ?? '0') ?? 0;
 
     await db.transaction((txn) async {
+      // Clear all RetroArch core defaults
       await txn.rawUpdate(
         'UPDATE app_emulators SET is_default = 0 '
         'WHERE os_id = ? AND android_package_name LIKE ?',
         [osId, 'com.retroarch%'],
       );
+
+      // Set default only for entries with default_core marker
       await txn.rawUpdate(
         'UPDATE app_emulators SET is_default = 1 '
-        'WHERE os_id = ? AND android_package_name = ?',
+        'WHERE os_id = ? AND android_package_name = ? AND is_default_core = 1',
         [osId, preferredPackage],
+      );
+
+      // Clear standalone defaults for systems that now have an RA core default
+      await txn.rawUpdate(
+        'UPDATE app_emulators SET is_default = 0 '
+        'WHERE os_id = ? AND is_standalone = 1 AND system_id IN ('
+        'SELECT DISTINCT system_id FROM app_emulators '
+        'WHERE os_id = ? AND android_package_name = ? AND is_default_core = 1 AND is_default = 1'
+        ')',
+        [osId, osId, preferredPackage],
       );
     });
 
@@ -4220,6 +4339,68 @@ class SqliteService {
     } catch (e) {
       _log.e(
         'Failed to finalize RetroArch default fix via WAL checkpoint',
+        error: e,
+      );
+    }
+  }
+
+  /// Clears all RetroArch core defaults on Android when no RetroArch variant
+  /// is installed. Skips entirely if the user has made custom selections.
+  /// For systems that lose their default, falls back to the first available
+  /// standalone emulator.
+  static Future<void> clearRetroArchDefaultsForAndroid() async {
+    final db = await instance.database;
+
+    // If user has made any emulator selections, respect them and skip
+    final userChoices = await db.rawQuery(
+      'SELECT COUNT(*) as count FROM user_emulator_config WHERE is_user_default = 1',
+    );
+    final userChoiceCount = userChoices.isNotEmpty
+        ? (int.tryParse(userChoices.first['count']?.toString() ?? '0') ?? 0)
+        : 0;
+    if (userChoiceCount > 0) {
+      _log.i(
+        'Android: User has custom emulator choices ($userChoiceCount), skipping RA default clear',
+      );
+      return;
+    }
+
+    final osResult = await db.query(
+      'app_os',
+      where: 'name = ?',
+      whereArgs: ['android'],
+    );
+    if (osResult.isEmpty) return;
+    final osId = int.tryParse(osResult.first['id']?.toString() ?? '0') ?? 0;
+
+    await db.transaction((txn) async {
+      // Reset all RetroArch core defaults
+      await txn.rawUpdate(
+        'UPDATE app_emulators SET is_default = 0 '
+        'WHERE os_id = ? AND android_package_name LIKE ?',
+        [osId, 'com.retroarch%'],
+      );
+
+      // For systems with no default after clearing RA, fall back to standalone
+      // Only set standalone as default if it has is_default = 0 AND the system has no other default
+      await txn.rawUpdate(
+        'UPDATE app_emulators SET is_default = 1 '
+        'WHERE os_id = ? AND is_standalone = 1 AND is_default = 0 AND system_id IN ('
+        'SELECT DISTINCT e.system_id FROM app_emulators e '
+        'WHERE e.os_id = ? AND e.android_package_name LIKE ? AND e.is_default = 0'
+        ') AND NOT EXISTS ('
+        'SELECT 1 FROM app_emulators e2 '
+        'WHERE e2.system_id = app_emulators.system_id AND e2.os_id = ? AND e2.is_default = 1'
+        ')',
+        [osId, osId, 'com.retroarch%', osId],
+      );
+    });
+
+    try {
+      await db.execute('PRAGMA wal_checkpoint(FULL)');
+    } catch (e) {
+      _log.e(
+        'Failed to finalize RetroArch default clear via WAL checkpoint',
         error: e,
       );
     }

--- a/lib/models/core_emulator_model.dart
+++ b/lib/models/core_emulator_model.dart
@@ -21,6 +21,9 @@ class CoreEmulatorModel {
   /// Whether this emulator is the default choice for its system.
   final bool isDefault;
 
+  /// Whether this core is marked as default_core in the system definition JSON.
+  final bool isDefaultCore;
+
   /// Whether this emulator supports RetroAchievements.
   final bool isretroAchievementsCompatible;
 
@@ -38,6 +41,7 @@ class CoreEmulatorModel {
     required this.isStandalone,
     this.coreFilename,
     required this.isDefault,
+    this.isDefaultCore = false,
     required this.isretroAchievementsCompatible,
     this.androidPackageName,
     this.isInstalled = false,
@@ -54,6 +58,8 @@ class CoreEmulatorModel {
           (int.tryParse(map['is_standalone']?.toString() ?? '0') ?? 0) == 1,
       coreFilename: map['core_filename']?.toString(),
       isDefault: (int.tryParse(map['is_default']?.toString() ?? '0') ?? 0) == 1,
+      isDefaultCore:
+          (int.tryParse(map['is_default_core']?.toString() ?? '0') ?? 0) == 1,
       isretroAchievementsCompatible:
           (int.tryParse(map['is_ra_compatible']?.toString() ?? '0') ?? 0) == 1,
       androidPackageName: map['android_package_name']?.toString(),
@@ -71,6 +77,7 @@ class CoreEmulatorModel {
       'is_standalone': isStandalone ? 1 : 0,
       'core_filename': coreFilename,
       'is_default': isDefault ? 1 : 0,
+      'is_default_core': isDefaultCore ? 1 : 0,
       'is_ra_compatible': isretroAchievementsCompatible ? 1 : 0,
       'android_package_name': androidPackageName,
     };
@@ -85,6 +92,7 @@ class CoreEmulatorModel {
     bool? isStandalone,
     String? coreFilename,
     bool? isDefault,
+    bool? isDefaultCore,
     bool? isretroAchievementsCompatible,
     String? androidPackageName,
     bool? isInstalled,
@@ -97,6 +105,7 @@ class CoreEmulatorModel {
       isStandalone: isStandalone ?? this.isStandalone,
       coreFilename: coreFilename ?? this.coreFilename,
       isDefault: isDefault ?? this.isDefault,
+      isDefaultCore: isDefaultCore ?? this.isDefaultCore,
       isretroAchievementsCompatible:
           isretroAchievementsCompatible ?? this.isretroAchievementsCompatible,
       androidPackageName: androidPackageName ?? this.androidPackageName,
@@ -106,7 +115,7 @@ class CoreEmulatorModel {
 
   @override
   String toString() {
-    return 'CoreEmulatorModel(uniqueId: $uniqueId, name: $name, isDefault: $isDefault, isretroAchievementsCompatible: $isretroAchievementsCompatible, androidPackageName: $androidPackageName)';
+    return 'CoreEmulatorModel(uniqueId: $uniqueId, name: $name, isDefault: $isDefault, isDefaultCore: $isDefaultCore, isretroAchievementsCompatible: $isretroAchievementsCompatible, androidPackageName: $androidPackageName)';
   }
 
   @override
@@ -138,6 +147,8 @@ class CoreEmulatorModel {
         return coreFilename;
       case 'is_default':
         return isDefault ? 1 : 0;
+      case 'is_default_core':
+        return isDefaultCore ? 1 : 0;
       case 'is_ra_compatible':
         return isretroAchievementsCompatible ? 1 : 0;
       case 'android_package_name':

--- a/lib/models/system_configuration.dart
+++ b/lib/models/system_configuration.dart
@@ -17,8 +17,11 @@ class EmulatorDefinition {
   /// Map containing platform-specific execution details (e.g., 'android', 'windows').
   final Map<String, dynamic> platforms;
 
-  /// Whether this emulator is considered the recommended default for the system.
-  final bool isDefault;
+  /// Whether this RetroArch core is the recommended default core for the system.
+  final bool isDefaultCore;
+
+  /// Whether this standalone emulator is the recommended default for the system.
+  final bool isDefaultStandalone;
 
   /// Whether the emulator supports RetroAchievements synchronization.
   final bool? isretroAchievementsCompatible;
@@ -28,7 +31,8 @@ class EmulatorDefinition {
     required this.uniqueId,
     required this.description,
     required this.platforms,
-    this.isDefault = false,
+    this.isDefaultCore = false,
+    this.isDefaultStandalone = false,
     this.isretroAchievementsCompatible,
   });
 
@@ -41,12 +45,13 @@ class EmulatorDefinition {
       platforms: json['platforms'] is Map
           ? Map<String, dynamic>.from(json['platforms'])
           : {},
-      isDefault:
-          (json['default'] ?? json['isDefault'] ?? false)
+      isDefaultCore:
+          (json['default_core'] ?? false).toString().toLowerCase() == 'true',
+      isDefaultStandalone:
+          (json['default_standalone'] ?? false)
                   .toString()
                   .toLowerCase() ==
-              'true' ||
-          (json['default'] ?? json['isDefault'] ?? 0).toString() == '1',
+              'true',
       isretroAchievementsCompatible:
           (json['is_retroachievements_compatible'] ??
                       json['is_ra_compatible'] ??

--- a/lib/repositories/emulator_repository.dart
+++ b/lib/repositories/emulator_repository.dart
@@ -86,6 +86,9 @@ class EmulatorRepository {
   static Future<void> fixRetroArchDefaultForAndroid(String preferredPackage) =>
       SqliteService.fixRetroArchDefaultForAndroid(preferredPackage);
 
+  static Future<void> clearRetroArchDefaultsForAndroid() =>
+      SqliteService.clearRetroArchDefaultsForAndroid();
+
   /// Resolves the detected RetroArch executable path for the current OS.
   static Future<String?> getRetroArchExecutablePath() async {
     final db = await SqliteService.getDatabase();

--- a/lib/screens/app_screen.dart
+++ b/lib/screens/app_screen.dart
@@ -188,12 +188,19 @@ class AppScreenState extends State<AppScreen> with WidgetsBindingObserver {
   /// Detects which RetroArch variant the user has installed on Android and sets
   /// it as the default package for all systems. Priority order:
   ///   com.retroarch.aarch64 > com.retroarch > com.retroarch.ra32
+  ///
+  /// If no RetroArch is installed, clears RetroArch defaults so standalone
+  /// defaults (marked with [default_standalone] in JSON) take effect.
   Future<void> _fixRetroarchAndroidDefault() async {
     if (!Platform.isAndroid) return;
 
     try {
       final packages = await EmulatorRepository.getAndroidRetroArchPackages();
-      if (packages.isEmpty) return;
+      if (packages.isEmpty) {
+        await EmulatorRepository.clearRetroArchDefaultsForAndroid();
+        _log.i('Android: No RetroArch found, cleared RetroArch defaults');
+        return;
+      }
 
       const priorityOrder = [
         'com.retroarch.aarch64',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ workspace:
   - packages/gamepads_platform_interface
   - packages/gamepads_windows
 
-version: 0.9.3+114
+version: 0.9.4+115
 
 environment:
   sdk: '>=3.9.2'


### PR DESCRIPTION
## Cambios

### Modelos
- **EmulatorDefinition**: reemplazado \isDefault\ por \isDefaultCore\ (lee \default_core\ del JSON) y \isDefaultStandalone\ (lee \default_standalone\)
- **CoreEmulatorModel**: agregado campo \isDefaultCore\ para la nueva columna DB

### Base de datos
- Nueva columna \is_default_core INTEGER NOT NULL DEFAULT 0\ en \pp_emulators\
- Migration v93 para instalaciones existentes
- \_ensureEmulatorDefaultCoreColumn\ en secuencia de inicio

### Lógica de defaults
- **\_syncEmulators**: marca \is_default_core=1\ en cores RetroArch con \default_core: true\. En Android no setea \is_default\ para RA cores (lo maneja la detección)
- **fixRetroArchDefaultForAndroid**: ahora usa \is_default_core\ para seleccionar solo el core correcto. Salta completamente si el usuario tiene selecciones personalizadas
- **clearRetroArchDefaultsForAndroid**: cuando no hay RA instalado, asigna standalone como fallback. Respeta selecciones del usuario
- **setDefaultCore**: ahora guarda la selección del usuario en \user_emulator_config\ para que RA detection no la sobreescriba en reinicios
- **\_fixEmulatorDefaults**: fallback prioriza \is_default_core\, luego standalone, luego cualquier core

### Flujo corregido
- Primer inicio: RA detection aplica defaults correctos
- Usuario selecciona otro core: se guarda en \user_emulator_config\
- Siguientes inicios: RA detection respeta la selección del usuario