### PR TITLE
Fixed softcore user logic

### DIFF
--- a/lib/models/retro_achievements_user.dart
+++ b/lib/models/retro_achievements_user.dart
@@ -95,7 +95,7 @@ class RetroAchievementsUser {
   }
 
   /// Whether the user primarily or exclusively plays in softcore (casual) mode.
-  bool get isSoftcore => totalSoftcorePoints > 0;
+  bool get isSoftcore => totalSoftcorePoints > totalTruePoints;
 
   /// Returns a display string representing the user's primary gameplay mode.
   String get userType => isSoftcore ? 'Softcore User' : 'Hardcore User';

--- a/lib/models/retro_achievements_user.dart
+++ b/lib/models/retro_achievements_user.dart
@@ -95,7 +95,7 @@ class RetroAchievementsUser {
   }
 
   /// Whether the user primarily or exclusively plays in softcore (casual) mode.
-  bool get isSoftcore => totalSoftcorePoints > totalTruePoints;
+  bool get isSoftcore => totalSoftcorePoints > totalPoints;
 
   /// Returns a display string representing the user's primary gameplay mode.
   String get userType => isSoftcore ? 'Softcore User' : 'Hardcore User';


### PR DESCRIPTION
# Description

Changed isSoftcore logic from if softcorePoints > 0 to if softcorePoints > truePoints. This way if a user has more hardcore points than softcore points it labels them as a hardcore player. 

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [X] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [X] My changes do not introduce secrets, credentials, or sensitive data.
- [ ] I have verified that any new assets have compatible licenses.
- [X] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [X] Android
- [ ] **Gamepad support verified** (if applicable).

## Screenshots (if applicable)

Add screenshots or GIFs showing the visual change.
