### PR TITLE
fix(game-list): keep selection centered after deleting games

### DIFF
--- a/lib/models/retro_achievements_dashboard_models.dart
+++ b/lib/models/retro_achievements_dashboard_models.dart
@@ -50,8 +50,8 @@ class RetroAchievementRecentUnlockItem {
         json['AchievementID'] ?? json['achievementId'],
       ),
       title: (json['Title'] ?? json['title'] ?? '').toString(),
-      description:
-          (json['Description'] ?? json['description'] ?? '').toString(),
+      description: (json['Description'] ?? json['description'] ?? '')
+          .toString(),
       badgeName: (json['BadgeName'] ?? json['badgeName'] ?? '').toString(),
       badgeUrl: (json['BadgeURL'] ?? json['badgeUrl'] ?? '').toString(),
       points: RAParsingUtils.toInt(json['Points'] ?? json['points']),
@@ -62,8 +62,8 @@ class RetroAchievementRecentUnlockItem {
       gameTitle: (json['GameTitle'] ?? json['gameTitle'] ?? '').toString(),
       gameIcon: (json['GameIcon'] ?? json['gameIcon'] ?? '').toString(),
       gameId: RAParsingUtils.toInt(json['GameID'] ?? json['gameId']),
-      consoleName:
-          (json['ConsoleName'] ?? json['consoleName'] ?? '').toString(),
+      consoleName: (json['ConsoleName'] ?? json['consoleName'] ?? '')
+          .toString(),
       gameUrl: (json['GameURL'] ?? json['gameUrl'] ?? '').toString(),
     );
   }
@@ -112,15 +112,15 @@ class RetroAchievementRecentlyPlayedGameItem {
     return RetroAchievementRecentlyPlayedGameItem(
       gameId: RAParsingUtils.toInt(json['GameID'] ?? json['gameId']),
       consoleId: RAParsingUtils.toInt(json['ConsoleID'] ?? json['consoleId']),
-      consoleName:
-          (json['ConsoleName'] ?? json['consoleName'] ?? '').toString(),
+      consoleName: (json['ConsoleName'] ?? json['consoleName'] ?? '')
+          .toString(),
       title: (json['Title'] ?? json['title'] ?? '').toString(),
       imageIcon: (json['ImageIcon'] ?? json['imageIcon'] ?? '').toString(),
       imageTitle: (json['ImageTitle'] ?? json['imageTitle'] ?? '').toString(),
-      imageIngame:
-          (json['ImageIngame'] ?? json['imageIngame'] ?? '').toString(),
-      imageBoxArt:
-          (json['ImageBoxArt'] ?? json['imageBoxArt'] ?? '').toString(),
+      imageIngame: (json['ImageIngame'] ?? json['imageIngame'] ?? '')
+          .toString(),
+      imageBoxArt: (json['ImageBoxArt'] ?? json['imageBoxArt'] ?? '')
+          .toString(),
       lastPlayed: (json['LastPlayed'] ?? json['lastPlayed'] ?? '').toString(),
       achievementsTotal: RAParsingUtils.toInt(
         json['AchievementsTotal'] ?? json['achievementsTotal'],
@@ -166,9 +166,11 @@ class RetroAchievementCompletionProgressSummary {
         (json['results'] as List<dynamic>?) ??
         const <dynamic>[];
     final results = rawResults
-        .map((item) => RetroAchievementCompletionProgressItem.fromJson(
-              Map<String, dynamic>.from(item as Map),
-            ))
+        .map(
+          (item) => RetroAchievementCompletionProgressItem.fromJson(
+            Map<String, dynamic>.from(item as Map),
+          ),
+        )
         .toList();
     return RetroAchievementCompletionProgressSummary(
       count: RAParsingUtils.toInt(json['Count'] ?? json['count']),
@@ -213,8 +215,8 @@ class RetroAchievementCompletionProgressItem {
       title: (json['Title'] ?? json['title'] ?? '').toString(),
       imageIcon: (json['ImageIcon'] ?? json['imageIcon'] ?? '').toString(),
       consoleId: RAParsingUtils.toInt(json['ConsoleID'] ?? json['consoleId']),
-      consoleName:
-          (json['ConsoleName'] ?? json['consoleName'] ?? '').toString(),
+      consoleName: (json['ConsoleName'] ?? json['consoleName'] ?? '')
+          .toString(),
       maxPossible: RAParsingUtils.toInt(
         json['MaxPossible'] ?? json['maxPossible'],
       ),

--- a/lib/repositories/retro_achievements_repository.dart
+++ b/lib/repositories/retro_achievements_repository.dart
@@ -7,6 +7,7 @@ import '../models/retro_achievements_dashboard_models.dart';
 class RetroAchievementsRepository {
   static const String _raApiKeyStorageKey = 'ra_api_key';
   static const FlutterSecureStorage _storage = FlutterSecureStorage();
+
   /// Returns local ROM counts: total and RA-compatible (has ra_hash).
   static Future<({int totalRoms, int raCompatibleRoms})>
   getLocalRomStats() async {

--- a/lib/screens/game_screen/game_details_card/tabs/game_details_settings_tab.dart
+++ b/lib/screens/game_screen/game_details_card/tabs/game_details_settings_tab.dart
@@ -271,7 +271,8 @@ class GameDetailsSettingsTabState extends State<GameDetailsSettingsTab> {
     final confirmed = await showDialog<bool>(
       context: context,
       barrierDismissible: false,
-      builder: (ctx) => _DeleteGameDialog(gameName: _game.name, romName: _game.romname),
+      builder: (ctx) =>
+          _DeleteGameDialog(gameName: _game.name, romName: _game.romname),
     );
     if (confirmed == true && mounted) {
       _deleteGame();

--- a/lib/screens/game_screen/game_details_card/tabs/game_details_settings_tab.dart
+++ b/lib/screens/game_screen/game_details_card/tabs/game_details_settings_tab.dart
@@ -271,7 +271,7 @@ class GameDetailsSettingsTabState extends State<GameDetailsSettingsTab> {
     final confirmed = await showDialog<bool>(
       context: context,
       barrierDismissible: false,
-      builder: (ctx) => _DeleteGameDialog(gameName: _game.name),
+      builder: (ctx) => _DeleteGameDialog(gameName: _game.name, romName: _game.romname),
     );
     if (confirmed == true && mounted) {
       _deleteGame();
@@ -964,8 +964,9 @@ class _EmulatorRow extends StatelessWidget {
 /// A gamepad-friendly confirmation dialog that warns about permanent game deletion.
 class _DeleteGameDialog extends StatefulWidget {
   final String gameName;
+  final String romName;
 
-  const _DeleteGameDialog({required this.gameName});
+  const _DeleteGameDialog({required this.gameName, required this.romName});
 
   @override
   State<_DeleteGameDialog> createState() => _DeleteGameDialogState();
@@ -1040,6 +1041,14 @@ class _DeleteGameDialogState extends State<_DeleteGameDialog> {
             style: theme.textTheme.bodyLarge?.copyWith(
               fontSize: 13.r,
               fontWeight: FontWeight.w600,
+            ),
+          ),
+          SizedBox(height: 2.r),
+          Text(
+            widget.romName,
+            style: theme.textTheme.bodySmall?.copyWith(
+              fontSize: 11.r,
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
             ),
           ),
           SizedBox(height: 8.r),

--- a/lib/screens/game_screen/music/music_list.dart
+++ b/lib/screens/game_screen/music/music_list.dart
@@ -137,6 +137,7 @@ class _MusicListState extends State<MusicList> with TickerProviderStateMixin {
     final theme = Theme.of(context);
     final itemHeight = _itemHeightBase.r;
     final totalItemHeight = itemHeight;
+    _centeredScrollController.setItemExtent(totalItemHeight, paddingTop: 2.r);
 
     return ListenableBuilder(
       listenable: MusicPlayerService(),

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -1145,8 +1145,7 @@ class _SystemGamesListState extends State<SystemGamesList> {
     final String? customLogo = widget.system.customLogoPath?.isNotEmpty == true
         ? widget.system.customLogoPath
         : null;
-    final systemLogo =
-        customLogo ?? 'assets/images/logos/$folder.webp';
+    final systemLogo = customLogo ?? 'assets/images/logos/$folder.webp';
     final bool isLogoAsset = customLogo == null;
 
     final neoAssets = context.read<NeoAssetsProvider>();
@@ -1921,7 +1920,8 @@ class _SystemGamesListState extends State<SystemGamesList> {
           }
         }
 
-        if (widget.initialRomPath != null && widget.initialRomPath!.isNotEmpty) {
+        if (widget.initialRomPath != null &&
+            widget.initialRomPath!.isNotEmpty) {
           final initialIndex = games.indexWhere(
             (game) => game.romPath == widget.initialRomPath,
           );
@@ -1932,7 +1932,8 @@ class _SystemGamesListState extends State<SystemGamesList> {
             _selectedGameIndex = 0;
             _selectedGame = games.isNotEmpty ? games.first : null;
           }
-        } else if (_selectedGame != null && widget.system.folderName != 'music') {
+        } else if (_selectedGame != null &&
+            widget.system.folderName != 'music') {
           // Persistent Selection Logic: Retain current index if the game still exists post-reload.
           final selectedIndex = games.indexWhere(
             (game) => game.romname == _selectedGame!.romname,

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -2937,6 +2937,9 @@ class _SystemGamesListState extends State<SystemGamesList> {
     });
 
     if (_games.isNotEmpty && _selectedGame != null) {
+      // The list view's didUpdateWidget already recenters the new selection
+      // when [_selectedGameIndex] changes, so an explicit scroll here is
+      // redundant and can cause conflicting animations.
       _updateSecondaryDisplay(_selectedGame!);
       _updateBackground(_selectedGame!);
       _startVideoTimer();
@@ -3042,6 +3045,12 @@ class _GameListViewState extends State<GameListView>
       duration: duration,
       curve: curve,
     );
+  }
+
+  /// Immediately jumps to center on the item at [index] without animation.
+  /// Unlike [scrollToIndex], this executes synchronously.
+  void jumpToIndex(int index) {
+    _centeredScrollController.jumpToIndex(index);
   }
 
   @override
@@ -3162,6 +3171,7 @@ class _GameListViewState extends State<GameListView>
     final theme = Theme.of(context);
     final itemHeight = _itemHeightBase.r;
     final totalItemHeight = itemHeight;
+    _centeredScrollController.setItemExtent(totalItemHeight, paddingTop: 2.r);
 
     return Column(
       children: [

--- a/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
@@ -1714,7 +1714,11 @@ class _SystemCardGridViewState extends State<SystemCardGridView> {
           }
         }
 
-        final focusIndicator = (selLeft != null && selTop != null && selWidth != null && selHeight != null)
+        final focusIndicator =
+            (selLeft != null &&
+                selTop != null &&
+                selWidth != null &&
+                selHeight != null)
             ? AnimatedPositioned(
                 key: const ValueKey('focus_indicator'),
                 duration: const Duration(milliseconds: 350),
@@ -1731,14 +1735,20 @@ class _SystemCardGridViewState extends State<SystemCardGridView> {
                         begin: Alignment.bottomCenter,
                         end: Alignment.topCenter,
                         colors: [
-                          Theme.of(context).colorScheme.secondary.withValues(alpha: 0.28),
-                          Theme.of(context).colorScheme.secondary.withValues(alpha: 0.08),
+                          Theme.of(
+                            context,
+                          ).colorScheme.secondary.withValues(alpha: 0.28),
+                          Theme.of(
+                            context,
+                          ).colorScheme.secondary.withValues(alpha: 0.08),
                           Colors.transparent,
                         ],
                         stops: const [0.0, 0.35, 1.0],
                       ),
                       border: Border.all(
-                        color: Theme.of(context).colorScheme.secondary.withValues(alpha: 0.55),
+                        color: Theme.of(
+                          context,
+                        ).colorScheme.secondary.withValues(alpha: 0.55),
                         width: 2.r,
                       ),
                     ),
@@ -1757,10 +1767,7 @@ class _SystemCardGridViewState extends State<SystemCardGridView> {
             height: totalHeight,
             child: Stack(
               clipBehavior: Clip.none,
-              children: [
-                ...cardWidgets,
-                focusIndicator,
-              ],
+              children: [...cardWidgets, focusIndicator],
             ),
           ),
         );

--- a/lib/screens/systems_screen/my_systems_section/system_card.dart
+++ b/lib/screens/systems_screen/my_systems_section/system_card.dart
@@ -369,6 +369,7 @@ class _SystemCardState extends State<SystemCard> {
       ),
     );
   }
+
   /// Helper for localized play time formatting.
   String _formatPlayTimeLocalized(int seconds) {
     return GameUtils.formatPlayTime(
@@ -385,7 +386,11 @@ class _SystemCardState extends State<SystemCard> {
 
   /// Renders the system brand logo with fallback support.
   /// The white-transparent logo is tinted with [color] (falls back to theme text).
-  Widget _buildSystemLogo(String assetLogoPath, {double? height, Color? color}) {
+  Widget _buildSystemLogo(
+    String assetLogoPath, {
+    double? height,
+    Color? color,
+  }) {
     height ??= 32.r;
     final customLogoPath = widget.info.customLogoPath;
     final hasCustomLogo = customLogoPath != null && customLogoPath.isNotEmpty;
@@ -399,37 +404,41 @@ class _SystemCardState extends State<SystemCard> {
     }
 
     if (hasCustomLogo) {
-      return buildLogo(Image.file(
-        File(customLogoPath),
-        key: ValueKey('${customLogoPath}_${widget.info.imageVersion}'),
-        height: height,
-        cacheWidth: 256,
-        fit: BoxFit.contain,
-        errorBuilder: (context, error, stackTrace) => Image.asset(
-          assetLogoPath,
+      return buildLogo(
+        Image.file(
+          File(customLogoPath),
+          key: ValueKey('${customLogoPath}_${widget.info.imageVersion}'),
           height: height,
           cacheWidth: 256,
           fit: BoxFit.contain,
-          errorBuilder: (context, error, stackTrace) => SystemLogoFallback(
-            title: widget.info.title,
-            shortName: widget.info.shortName,
-            height: 24.r,
+          errorBuilder: (context, error, stackTrace) => Image.asset(
+            assetLogoPath,
+            height: height,
+            cacheWidth: 256,
+            fit: BoxFit.contain,
+            errorBuilder: (context, error, stackTrace) => SystemLogoFallback(
+              title: widget.info.title,
+              shortName: widget.info.shortName,
+              height: 24.r,
+            ),
           ),
         ),
-      ));
+      );
     }
 
-    return buildLogo(Image.asset(
-      assetLogoPath,
-      height: height,
-      cacheWidth: 256,
-      fit: BoxFit.contain,
-      errorBuilder: (context, error, stackTrace) => SystemLogoFallback(
-        title: widget.info.title,
-        shortName: widget.info.shortName,
-        height: 24.r,
+    return buildLogo(
+      Image.asset(
+        assetLogoPath,
+        height: height,
+        cacheWidth: 256,
+        fit: BoxFit.contain,
+        errorBuilder: (context, error, stackTrace) => SystemLogoFallback(
+          title: widget.info.title,
+          shortName: widget.info.shortName,
+          height: 24.r,
+        ),
       ),
-    ));
+    );
   }
 
   /// Builds the foreground content, including badges and specialized layouts for 'Recent Games'.
@@ -595,8 +604,7 @@ class _SystemCardState extends State<SystemCard> {
         : (widget.info.folderName?.isNotEmpty == true
               ? widget.info.folderName!
               : 'all');
-    final assetLogoPath =
-        'assets/images/logos/$resolvedLogoFolder.webp';
+    final assetLogoPath = 'assets/images/logos/$resolvedLogoFolder.webp';
 
     return Container(
       height: 32.r,

--- a/lib/utils/centered_scroll_controller.dart
+++ b/lib/utils/centered_scroll_controller.dart
@@ -220,10 +220,7 @@ class CenteredScrollController with WindowListener, WidgetsBindingObserver {
           itemCenterPosition - (viewportHeight * centerPosition);
 
       return targetOffset
-          .clamp(
-            0.0,
-            scrollController.position.maxScrollExtent,
-          )
+          .clamp(0.0, scrollController.position.maxScrollExtent)
           .toDouble();
     } catch (e) {
       _log.e('CenteredScrollController: Error calculating target offset: $e');

--- a/lib/utils/centered_scroll_controller.dart
+++ b/lib/utils/centered_scroll_controller.dart
@@ -32,6 +32,9 @@ class CenteredScrollController with WindowListener, WidgetsBindingObserver {
   int? _currentSelectedIndex;
   int _totalItems = 0;
   Size? _lastSize;
+  double _totalPadding = 0;
+  double? _itemExtent;
+  double _paddingTop = 0;
 
   /// Notifier to trigger manual rebuilds of the list when layout changes occur.
   final ValueNotifier<int> rebuildNotifier = ValueNotifier<int>(0);
@@ -44,6 +47,22 @@ class CenteredScrollController with WindowListener, WidgetsBindingObserver {
     this.animationDuration = const Duration(milliseconds: 360),
     this.animationCurve = Curves.easeInOut,
   }) : scrollController = scrollController ?? ScrollController();
+
+  /// Sets the total vertical padding of the ListView (top + bottom).
+  /// Used to improve scroll centering accuracy.
+  void setListPadding(double padding) {
+    _totalPadding = padding;
+  }
+
+  /// Sets the fixed height of each list item and the top padding of the list.
+  ///
+  /// When provided, scroll calculations use this exact extent instead of
+  /// deriving it from [maxScrollExtent], which avoids drift after list
+  /// mutations such as deletions.
+  void setItemExtent(double? itemExtent, {double paddingTop = 0}) {
+    _itemExtent = itemExtent;
+    _paddingTop = paddingTop;
+  }
 
   /// Initializes the controller and registers platform-specific listeners.
   void initialize({
@@ -159,10 +178,27 @@ class CenteredScrollController with WindowListener, WidgetsBindingObserver {
     });
   }
 
-  /// Internal logic to calculate and execute the re-centering jump.
-  void _performRecenter(int index) {
+  /// Resolves the exact item height.
+  ///
+  /// Prefers a user-supplied fixed [itemExtent]. Falls back to deriving it from
+  /// the scrollable geometry, which can be inaccurate right after the list
+  /// mutates (e.g. a game is deleted).
+  double? _resolveItemHeight(double viewportHeight, double scrollableHeight) {
+    if (_itemExtent != null) {
+      return _itemExtent;
+    }
+    if (_totalItems == 0) {
+      return null;
+    }
+    final contentHeight = scrollableHeight + viewportHeight;
+    return (contentHeight - _totalPadding) / _totalItems;
+  }
+
+  /// Computes the scroll offset that places the item at [index] at the configured
+  /// [centerPosition], or `null` when centering is not possible.
+  double? _calculateTargetOffset(int index) {
     if (!scrollController.hasClients || _totalItems == 0) {
-      return;
+      return null;
     }
 
     try {
@@ -170,21 +206,48 @@ class CenteredScrollController with WindowListener, WidgetsBindingObserver {
       final scrollableHeight = scrollController.position.maxScrollExtent;
 
       if (_totalItems <= 1 || scrollableHeight == 0) {
-        return;
+        return null;
       }
 
-      final contentHeight = scrollableHeight + viewportHeight;
-      final itemHeight = contentHeight / _totalItems;
-      final itemCenterPosition = (index * itemHeight) + (itemHeight / 2);
+      final itemHeight = _resolveItemHeight(viewportHeight, scrollableHeight);
+      if (itemHeight == null) {
+        return null;
+      }
+
+      final itemCenterPosition =
+          _paddingTop + (index * itemHeight) + (itemHeight / 2);
       final targetOffset =
           itemCenterPosition - (viewportHeight * centerPosition);
 
-      final clampedOffset = targetOffset.clamp(
-        0.0,
-        scrollController.position.maxScrollExtent,
-      );
+      return targetOffset
+          .clamp(
+            0.0,
+            scrollController.position.maxScrollExtent,
+          )
+          .toDouble();
+    } catch (e) {
+      _log.e('CenteredScrollController: Error calculating target offset: $e');
+      return null;
+    }
+  }
 
-      scrollController.jumpTo(clampedOffset);
+  /// Internal logic to calculate and execute the re-centering jump.
+  void _performRecenter(int index) {
+    _jumpToIndex(index);
+  }
+
+  /// Immediately jumps to center on the item at [index] without animation.
+  void jumpToIndex(int index) {
+    _currentSelectedIndex = index;
+    _jumpToIndex(index);
+  }
+
+  void _jumpToIndex(int index) {
+    final targetOffset = _calculateTargetOffset(index);
+    if (targetOffset == null) return;
+
+    try {
+      scrollController.jumpTo(targetOffset);
     } catch (e) {
       _log.e('CenteredScrollController: Error during re-centering: $e');
     }
@@ -204,34 +267,15 @@ class CenteredScrollController with WindowListener, WidgetsBindingObserver {
     _currentSelectedIndex = index;
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!scrollController.hasClients) return;
+      final targetOffset = _calculateTargetOffset(index);
+      if (targetOffset == null) return;
 
       try {
-        final viewportHeight = scrollController.position.viewportDimension;
-        final scrollableHeight = scrollController.position.maxScrollExtent;
-
-        if (_totalItems <= 1 || scrollableHeight == 0) {
-          return;
-        }
-
-        final contentHeight = scrollableHeight + viewportHeight;
-        final itemHeight = contentHeight / _totalItems;
-        final itemCenterPosition = (index * itemHeight) + (itemHeight / 2);
-
-        // Position target so that itemCenterPosition sits at centerPosition * viewportHeight from top.
-        final targetOffset =
-            itemCenterPosition - (viewportHeight * centerPosition);
-
-        final clampedOffset = targetOffset.clamp(
-          0.0,
-          scrollController.position.maxScrollExtent,
-        );
-
         if (immediate) {
-          scrollController.jumpTo(clampedOffset);
+          scrollController.jumpTo(targetOffset);
         } else {
           scrollController.animateTo(
-            clampedOffset,
+            targetOffset,
             duration: duration ?? animationDuration,
             curve: curve ?? animationCurve,
           );
@@ -257,8 +301,10 @@ class CenteredScrollController with WindowListener, WidgetsBindingObserver {
         return 0;
       }
 
-      final contentHeight = scrollableHeight + viewportHeight;
-      final itemHeight = contentHeight / _totalItems;
+      final itemHeight = _resolveItemHeight(viewportHeight, scrollableHeight);
+      if (itemHeight == null) {
+        return null;
+      }
       final centerPositionInContent =
           currentOffset + (viewportHeight * centerPosition);
 
@@ -266,7 +312,7 @@ class CenteredScrollController with WindowListener, WidgetsBindingObserver {
       double closestDistance = double.infinity;
 
       for (int i = 0; i < _totalItems; i++) {
-        final itemCenter = (i * itemHeight) + (itemHeight / 2);
+        final itemCenter = _paddingTop + (i * itemHeight) + (itemHeight / 2);
         final distance = (itemCenter - centerPositionInContent).abs();
 
         if (distance < closestDistance) {
@@ -275,7 +321,7 @@ class CenteredScrollController with WindowListener, WidgetsBindingObserver {
         }
       }
 
-      return closestIndex.clamp(0, maxItems - 1);
+      return closestIndex.clamp(0, maxItems - 1).toInt();
     } catch (e) {
       _log.e('CenteredScrollController: Error identifying centered index: $e');
       return null;

--- a/test/game_service_test.dart
+++ b/test/game_service_test.dart
@@ -146,13 +146,15 @@ void main() {
       expect(GameService.isGameLaunchInProgress, isFalse);
     });
 
-    test('beginLaunchPending opens the window before the game is registered',
-        () {
-      expect(GameService.isGameLaunched, isFalse);
-      GameService.beginLaunchPending();
-      // Guard is true even though the game process is not yet registered.
-      expect(GameService.isGameLaunchInProgress, isTrue);
-    });
+    test(
+      'beginLaunchPending opens the window before the game is registered',
+      () {
+        expect(GameService.isGameLaunched, isFalse);
+        GameService.beginLaunchPending();
+        // Guard is true even though the game process is not yet registered.
+        expect(GameService.isGameLaunchInProgress, isTrue);
+      },
+    );
 
     test('clearLaunchPending closes the window (failed/aborted launch)', () {
       GameService.beginLaunchPending();

--- a/test/retro_achievements_repository_test.dart
+++ b/test/retro_achievements_repository_test.dart
@@ -151,21 +151,23 @@ void main() {
       expect(gameId, isNull);
     });
 
-    test('findBestLocalGameByRaGameId prefers most recently played match', () async {
-      await db.execute(
-        "INSERT INTO user_roms (filename, rom_path, app_system_id, id_ra, is_favorite, last_played) VALUES ('older.nes', '/roms/nes/older.nes', 'nes', 777, 0, '2024-01-01T00:00:00.000')",
-      );
-      await db.execute(
-        "INSERT INTO user_roms (filename, rom_path, app_system_id, id_ra, is_favorite, last_played) VALUES ('newer.nes', '/roms/nes/newer.nes', 'nes', 777, 0, '2024-02-01T00:00:00.000')",
-      );
+    test(
+      'findBestLocalGameByRaGameId prefers most recently played match',
+      () async {
+        await db.execute(
+          "INSERT INTO user_roms (filename, rom_path, app_system_id, id_ra, is_favorite, last_played) VALUES ('older.nes', '/roms/nes/older.nes', 'nes', 777, 0, '2024-01-01T00:00:00.000')",
+        );
+        await db.execute(
+          "INSERT INTO user_roms (filename, rom_path, app_system_id, id_ra, is_favorite, last_played) VALUES ('newer.nes', '/roms/nes/newer.nes', 'nes', 777, 0, '2024-02-01T00:00:00.000')",
+        );
 
-      final result = await RetroAchievementsRepository.findBestLocalGameByRaGameId(
-        777,
-      );
+        final result =
+            await RetroAchievementsRepository.findBestLocalGameByRaGameId(777);
 
-      expect(result, isNotNull);
-      expect(result!.game.romPath, '/roms/nes/newer.nes');
-    });
+        expect(result, isNotNull);
+        expect(result!.game.romPath, '/roms/nes/newer.nes');
+      },
+    );
 
     test('findBestLocalGameByRaGameId breaks ties by favorite then name', () async {
       await db.execute(
@@ -175,9 +177,8 @@ void main() {
         "INSERT INTO user_roms (filename, rom_path, app_system_id, id_ra, is_favorite, last_played, title_name) VALUES ('a.nes', '/roms/nes/a.nes', 'nes', 888, 1, NULL, 'Alpha')",
       );
 
-      final result = await RetroAchievementsRepository.findBestLocalGameByRaGameId(
-        888,
-      );
+      final result =
+          await RetroAchievementsRepository.findBestLocalGameByRaGameId(888);
 
       expect(result, isNotNull);
       expect(result!.game.romPath, '/roms/nes/a.nes');


### PR DESCRIPTION
# Description

Fixes the game list scroll/focus drift when deleting games. Previously, `CenteredScrollController` estimated each item's height from `maxScrollExtent / totalItems`, which could be slightly out of sync right after a deletion, causing the selection highlight to shift downward with every removed game.

This change:

- Adds fixed `itemExtent` support to `CenteredScrollController` so lists can provide their exact row height.
- Configures `GameListView` (and `MusicList`) to report their real item height (`26.r`) and top padding (`2.r`), making centering calculations precise.
- Removes the redundant `_scrollToSelectedItem()` call from `_handleGameDeleted`, since `GameListView.didUpdateWidget` already re-centers the new selection when `_selectedGameIndex` changes.
- Also includes the existing working-tree change that shows the `romName` in the delete confirmation dialog.

Fixes # (issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x ] Code refactoring

## Checklist

- [x ] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [ ] I have verified that any new assets have compatible licenses.
- [ ] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x ] Android
- [x ] **Gamepad support verified** (if applicable).

## Screenshots (if applicable)

N/A