### PR TITLE
fix(systems): pin Favourites after All in systems list

### DIFF
--- a/lib/providers/sqlite_config_provider.dart
+++ b/lib/providers/sqlite_config_provider.dart
@@ -1613,7 +1613,12 @@ class SqliteConfigProvider extends ChangeNotifier {
     final isAsc = _config.systemSortOrder == 'asc';
 
     // Map priority folders that should NEVER be sorted
-    final priorityMap = <String, int>{'all': 1, 'music': 2, 'android': 3};
+    final priorityMap = <String, int>{
+      'all': 1,
+      'favorites': 2,
+      'music': 3,
+      'android': 4,
+    };
 
     _detectedSystems.sort((a, b) {
       final pA = priorityMap[a.folderName] ?? 999;


### PR DESCRIPTION
> 🤖 This PR was created with the assistance of [Claude Code](https://claude.com/claude-code).

# Description

In the systems list, **Favourites** was sorted alphabetically among the detected systems, so its position drifted depending on the other system names. This pins it to a fixed slot immediately after **All**, ahead of the alphabetically-sorted systems.

The fix adds `favorites` to the "float-to-top" priority map in `_sortDetectedSystems` (`sqlite_config_provider.dart`), which already exempts `all`/`music`/`android` from alphabetical sorting.

Fixes # (issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [ ] **Gamepad support verified** (if applicable).

## Screenshots (if applicable)

N/A — ordering change. Verified on the AYN Thor (dev channel): Favourites now appears directly after All. Note the card only shows when at least one game is favourited.
