### PR TITLE
fix(gamepad/windows): adopt GameInput backend for XInput controller support (#112)

### DIFF
--- a/lib/utils/gamepad_nav.dart
+++ b/lib/utils/gamepad_nav.dart
@@ -67,7 +67,9 @@ class GamepadNavigation {
   static final _log = LoggerService.instance;
 
   /// When true, all raw input events are logged for diagnostic purposes.
-  static bool _debugLogging = false;
+  // TODO(gameinput): temporarily defaulted to true to verify the Windows
+  // GameInput mapping on-hardware; revert to false before merge.
+  static bool _debugLogging = true;
   static bool get debugLogging => _debugLogging;
   static void setDebugLogging(bool enabled) {
     _debugLogging = enabled;

--- a/lib/utils/gamepad_nav.dart
+++ b/lib/utils/gamepad_nav.dart
@@ -67,9 +67,7 @@ class GamepadNavigation {
   static final _log = LoggerService.instance;
 
   /// When true, all raw input events are logged for diagnostic purposes.
-  // TODO(gameinput): temporarily defaulted to true to verify the Windows
-  // GameInput mapping on-hardware; revert to false before merge.
-  static bool _debugLogging = true;
+  static bool _debugLogging = false;
   static bool get debugLogging => _debugLogging;
   static void setDebugLogging(bool enabled) {
     _debugLogging = enabled;

--- a/lib/utils/gamepad_nav.dart
+++ b/lib/utils/gamepad_nav.dart
@@ -503,15 +503,14 @@ class GamepadNavigation {
 
       case GamepadInputType.leftStickX:
         if (isWindows) {
-          final distFrom32767 = (event.value - 32767).abs();
+          // GameInput reports the stick axis normalized to [-1, 1], +X = right.
+          final normalizedValue = event.value;
 
-          if (distFrom32767 < 8000) {
+          if (normalizedValue.abs() < 0.5) {
             _stopRepeatTimer(GamepadInputType.dpadLeft);
             _stopRepeatTimer(GamepadInputType.dpadRight);
             return;
           }
-
-          final normalizedValue = (event.value - 32767) / 32767;
 
           if (normalizedValue > 0.65) {
             _handleDirectionalAction(
@@ -538,16 +537,14 @@ class GamepadNavigation {
 
       case GamepadInputType.leftStickY:
         if (isWindows) {
-          final distFrom32767 = (event.value - 32767).abs();
+          // GameInput reports the stick axis normalized to [-1, 1], +Y = up.
+          final normalizedValue = event.value;
 
-          if (distFrom32767 < 8000) {
+          if (normalizedValue.abs() < 0.5) {
             _stopRepeatTimer(GamepadInputType.dpadUp);
             _stopRepeatTimer(GamepadInputType.dpadDown);
             return;
           }
-
-          // Standard Windows Y-axis inversion.
-          final normalizedValue = -(event.value - 32767) / 32767;
 
           if (normalizedValue > 0.65) {
             _handleDirectionalAction(GamepadInputType.dpadUp, onNavigateUp);

--- a/lib/utils/gamepad_translator.dart
+++ b/lib/utils/gamepad_translator.dart
@@ -243,6 +243,17 @@ class GamepadEventTranslator {
     String gamepadId,
     KeyType eventType,
   ) {
+    // WINDOWS: The GameInput backend emits standardized, named keys
+    // (a/b/x/y, dpadUp, leftShoulder, leftThumbstickX, leftTrigger, ...) with a
+    // consistent layout across all XInput-class controllers, so we map them
+    // directly and skip the WinMM positional/POV heuristics entirely.
+    if (Platform.isWindows) {
+      final gameInput = _translateGameInputKey(key);
+      if (gameInput != null) {
+        return gameInput;
+      }
+    }
+
     // LINUX: Utilize native event type from the plugin.
     if (Platform.isLinux) {
       if (eventType == KeyType.button) {
@@ -272,6 +283,71 @@ class GamepadEventTranslator {
     }
 
     return GamepadInputType.unknown;
+  }
+
+  /// Maps a Windows GameInput named key to a [GamepadInputType].
+  ///
+  /// GameInput reports a standardized Xbox-style layout, so this mapping is the
+  /// same for every controller regardless of vendor/VID/PID. Keys arrive
+  /// lower-cased. Returns null for keys that aren't part of the GameInput
+  /// gamepad vocabulary. Note: GameInput's standard gamepad state has no guide
+  /// button, so there is no Home mapping on Windows.
+  GamepadInputType? _translateGameInputKey(String key) {
+    switch (key) {
+      // Face buttons.
+      case 'a':
+        return GamepadInputType.buttonA;
+      case 'b':
+        return GamepadInputType.buttonB;
+      case 'x':
+        return GamepadInputType.buttonX;
+      case 'y':
+        return GamepadInputType.buttonY;
+
+      // D-pad (reported as digital buttons: 1.0 pressed, 0.0 released).
+      case 'dpadup':
+        return GamepadInputType.dpadUp;
+      case 'dpaddown':
+        return GamepadInputType.dpadDown;
+      case 'dpadleft':
+        return GamepadInputType.dpadLeft;
+      case 'dpadright':
+        return GamepadInputType.dpadRight;
+
+      // Shoulders and triggers. Triggers arrive as analog [0, 1]; the press
+      // edge is detected against the 0.5 threshold downstream.
+      case 'leftshoulder':
+        return GamepadInputType.buttonLB;
+      case 'rightshoulder':
+        return GamepadInputType.buttonRB;
+      case 'lefttrigger':
+        return GamepadInputType.buttonLT;
+      case 'righttrigger':
+        return GamepadInputType.buttonRT;
+
+      // System buttons.
+      case 'menu':
+        return GamepadInputType.buttonStart;
+      case 'view':
+        return GamepadInputType.buttonSelect;
+
+      // Stick clicks.
+      case 'leftthumbstick':
+        return GamepadInputType.leftStickButton;
+      case 'rightthumbstick':
+        return GamepadInputType.rightStickButton;
+
+      // Analog sticks, [-1, 1] with 0 centered (+Y is up, +X is right).
+      case 'leftthumbstickx':
+        return GamepadInputType.leftStickX;
+      case 'leftthumbsticky':
+        return GamepadInputType.leftStickY;
+      case 'rightthumbstickx':
+        return GamepadInputType.rightStickX;
+      case 'rightthumbsticky':
+        return GamepadInputType.rightStickY;
+    }
+    return null;
   }
 
   /// Determines if a key identifier corresponds to a D-pad (directional) input.
@@ -685,29 +761,14 @@ class GamepadEventTranslator {
   /// Determines if a D-pad or analog input should be considered "pressed" based on platform-specific thresholds.
   bool _isDpadPressed(double value, {bool isAnalog = false}) {
     if (Platform.isWindows) {
-      // Windows POV: Specific values indicate pressed directions.
-      // 65535.0 can indicate POV Neutral (centered) OR a stick at its maximum range.
-      if (!isAnalog && (value == -1.0 || value == 65535.0 || value < 0)) {
-        return false;
+      // GameInput reports normalized values: analog sticks in [-1, 1] centered
+      // at 0, and digital D-pad buttons as 0.0 (released) / 1.0 (pressed).
+      if (isAnalog) {
+        // Deadzone for the press/release edge; the nav layer applies its own
+        // (larger) directional threshold for the actual action.
+        return value.abs() > 0.5;
       }
-
-      // POV: Values within [0, 36000] are active directions.
-      if (value >= 0.0 && value <= 36000.0) {
-        return true;
-      }
-
-      // Flexible center detection for analog sticks on Windows.
-      final distFrom32767 = (value - 32767).abs();
-      final distFromZero = value.abs();
-
-      // Deadzone for neutral position:
-      // 32767 is standard. 0 is only neutral if noise is minimal.
-      if (distFrom32767 < 8000 || distFromZero < 1000) {
-        return false;
-      }
-
-      // Active if far enough from both potential center points.
-      return distFrom32767 > 20000 || distFromZero > 20000;
+      return value > 0.5;
     }
 
     if (Platform.isAndroid) {

--- a/packages/gamepads_windows/windows/gamepad.cpp
+++ b/packages/gamepads_windows/windows/gamepad.cpp
@@ -1,588 +1,251 @@
-#include <iostream>
-#define WIN32_LEAN_AND_MEAN
-#include <initguid.h>
-#include <windows.h>
-#include <dbt.h>
-#include <hidclass.h>
-#include <setupapi.h>
-#include <devguid.h>
-#include <regstr.h>
-#pragma comment(lib, "winmm.lib")
-#pragma comment(lib, "setupapi.lib")
-#include <mmsystem.h>
-
-#include <atomic>
-#include <list>
-#include <map>
-#include <memory>
-#include <mutex>
-#include <set>
-#include <thread>
-#include <sstream>
-#include <iomanip>
+#include <algorithm>
+#include <ppl.h>
 #include <vector>
+#include <concrt.h>
+#include <winerror.h>
 
 #include "gamepad.h"
 #include "utils.h"
+#include <GameInput.h>
+#include <iomanip>
+#include <sstream>
+#pragma comment(lib, "GameInput.lib")
 
 Gamepads gamepads;
 
-std::list<Event> Gamepads::diff_states(Gamepad* gamepad,
-                                       const JOYINFOEX& old,
-                                       const JOYINFOEX& current) {
+static IGameInput* g_gameInput = nullptr;
+static IGameInputDevice* g_gamepad = nullptr;
+
+std::string get_button_name(uint32_t button) {
+  switch (button) {
+    case GameInputGamepadMenu:
+      return "menu";
+    case GameInputGamepadView:
+      return "view";
+    case GameInputGamepadA:
+      return "a";
+    case GameInputGamepadB:
+      return "b";
+    case GameInputGamepadX:
+      return "x";
+    case GameInputGamepadY:
+      return "y";
+    case GameInputGamepadDPadUp:
+      return "dpadUp";
+    case GameInputGamepadDPadDown:
+      return "dpadDown";
+    case GameInputGamepadDPadLeft:
+      return "dpadLeft";
+    case GameInputGamepadDPadRight:
+      return "dpadRight";
+    case GameInputGamepadLeftShoulder:
+      return "leftShoulder";
+    case GameInputGamepadRightShoulder:
+      return "rightShoulder";
+    case GameInputGamepadLeftThumbstick:
+      return "leftThumbstick";
+    case GameInputGamepadRightThumbstick:
+      return "rightThumbstick";
+  }
+  return "button-" + std::to_string(button);
+}
+
+std::string AppLocalDeviceIdToString(const APP_LOCAL_DEVICE_ID& id) {
+  std::ostringstream oss;
+  oss << std::hex << std::setfill('0');
+  for (size_t i = 0; i < APP_LOCAL_DEVICE_ID_SIZE; ++i) {
+    oss << std::setw(2) << static_cast<int>(id.value[i]);
+  }
+  return oss.str();
+}
+
+std::list<Event> diff_states(const GameInputGamepadState& old,
+                             const GameInputGamepadState& current) {
   std::time_t now = std::time(nullptr);
   int time = static_cast<int>(now);
 
   std::list<Event> events;
-  if (old.dwXpos != current.dwXpos) {
+  if (old.leftThumbstickX != current.leftThumbstickX) {
     events.push_back(
-        {time, "analog", "dwXpos", static_cast<int>(current.dwXpos)});
+        {time, "analog", "leftThumbstickX", current.leftThumbstickX});
   }
-  if (old.dwYpos != current.dwYpos) {
+  if (old.leftThumbstickY != current.leftThumbstickY) {
     events.push_back(
-        {time, "analog", "dwYpos", static_cast<int>(current.dwYpos)});
+        {time, "analog", "leftThumbstickY", current.leftThumbstickY});
   }
-  if (old.dwZpos != current.dwZpos) {
+  if (old.rightThumbstickX != current.rightThumbstickX) {
     events.push_back(
-        {time, "analog", "dwZpos", static_cast<int>(current.dwZpos)});
+        {time, "analog", "rightThumbstickX", current.rightThumbstickX});
   }
-  if (old.dwRpos != current.dwRpos) {
+  if (old.rightThumbstickY != current.rightThumbstickY) {
     events.push_back(
-        {time, "analog", "dwRpos", static_cast<int>(current.dwRpos)});
+        {time, "analog", "rightThumbstickY", current.rightThumbstickY});
   }
-  if (old.dwUpos != current.dwUpos) {
-    events.push_back(
-        {time, "analog", "dwUpos", static_cast<int>(current.dwUpos)});
+  if (old.leftTrigger != current.leftTrigger) {
+    events.push_back({time, "analog", "leftTrigger", current.leftTrigger});
   }
-  if (old.dwVpos != current.dwVpos) {
-    events.push_back(
-        {time, "analog", "dwVpos", static_cast<int>(current.dwVpos)});
+  if (old.rightTrigger != current.rightTrigger) {
+    events.push_back({time, "analog", "rightTrigger", current.rightTrigger});
   }
-  if (old.dwPOV != current.dwPOV) {
-    events.push_back({time, "analog", "pov", static_cast<int>(current.dwPOV)});
-  }
-  if (old.dwButtons != current.dwButtons) {
-    for (int i = 0; i < gamepad->num_buttons; ++i) {
-      bool was_pressed = old.dwButtons & (1 << i);
-      bool is_pressed = current.dwButtons & (1 << i);
+  if (old.buttons != current.buttons) {
+    // While GameInputDeviceInfo.controllerButtonCount often gives 14,
+    // if you install GameInput v3 redistributable, the reported
+    // button count drops to zero. Button input is still reported.
+    for (uint32_t i = 0; i < 14; ++i) {
+      bool was_pressed = old.buttons & (1 << i);
+      bool is_pressed = current.buttons & (1 << i);
       if (was_pressed != is_pressed) {
-        events.push_back(
-            {time, "button", "button-" + std::to_string(i), is_pressed});
+        double value = is_pressed ? 1.0 : 0.0;
+        auto key = get_button_name(1 << i);
+        events.push_back({time, "button", key, value});
       }
     }
   }
   return events;
 }
 
-bool Gamepads::are_states_different(const JOYINFOEX& a, const JOYINFOEX& b) {
-  return a.dwXpos != b.dwXpos || a.dwYpos != b.dwYpos || a.dwZpos != b.dwZpos ||
-         a.dwRpos != b.dwRpos || a.dwUpos != b.dwUpos || a.dwVpos != b.dwVpos ||
-         a.dwButtons != b.dwButtons || a.dwPOV != b.dwPOV;
+bool are_states_different(const GameInputGamepadState& a,
+                          const GameInputGamepadState& b) {
+  return a.leftThumbstickX != b.leftThumbstickX ||
+         a.leftThumbstickY != b.leftThumbstickY ||
+         a.leftTrigger != b.leftTrigger ||
+         a.rightThumbstickX != b.rightThumbstickX ||
+         a.rightThumbstickY != b.rightThumbstickY ||
+         a.rightTrigger != b.rightTrigger || a.buttons != b.buttons;
 }
 
-void Gamepads::read_gamepad(std::shared_ptr<Gamepad> gamepad) {
-  JOYINFOEX state;
-  state.dwSize = sizeof(JOYINFOEX);
-  state.dwFlags = JOY_RETURNALL;
+void Gamepads::init() {
+  GameInputCreate(&g_gameInput);
 
-  int joy_id = gamepad->joy_id;
-
-  std::cout << "Listening to gamepad " << joy_id << std::endl;
-
-  while (gamepad->alive.load()) {
-    JOYINFOEX previous_state = state;
-    MMRESULT result = joyGetPosEx(joy_id, &state);
-    if (result == JOYERR_NOERROR) {
-      if (are_states_different(previous_state, state)) {
-        std::list<Event> events = diff_states(gamepad.get(), previous_state, state);
-        for (auto joy_event : events) {
-          if (event_emitter.has_value()) {
-            (*event_emitter)(gamepad.get(), joy_event);
-          }
-        }
-      }
-    } else {
-      std::cout << "Fail to listen to gamepad " << joy_id << std::endl;
-      gamepad->alive.store(false);
-      
-      // Safe removal with mutex protection
-      std::lock_guard<std::mutex> lock(gamepads_mutex);
-      auto it = gamepads.find(joy_id);
-      if (it != gamepads.end() && it->second == gamepad) {
-        gamepads.erase(it);
-      }
-      break; // Exit loop after error
+  if (g_gameInput != nullptr) {
+    // Register listener for gamepad events
+    if (g_gameInput != nullptr) {
+      g_gameInput->RegisterDeviceCallback(
+          nullptr,  // All devices
+          GameInputKindGamepad, GameInputDeviceConnected,
+          GameInputAsyncEnumeration, static_cast<void*>(this),
+          [](_In_ GameInputCallbackToken callbackToken, _In_ void* context,
+             _In_ IGameInputDevice* device, _In_ uint64_t timestamp,
+             _In_ GameInputDeviceStatus currentStatus,
+             _In_ GameInputDeviceStatus previousStatus) {
+            auto* self = static_cast<Gamepads*>(context);
+            if (currentStatus & GameInputDeviceConnected) {
+              self->on_gamepad_connected(device);
+            } else {
+              self->on_gamepad_disconnected(device);
+            }
+          },
+          this->deviceCallbackToken);
     }
-    
-    // Rate limiting: Sleep for 8ms (~125 Hz polling rate)
-    // This prevents high CPU usage from the busy loop
-    // Most gamepads operate at 60-120 Hz, so 125 Hz is more than enough
-    // to capture all input events without missing any
-    Sleep(8);
   }
-  
-  std::cout << "Stopped listening to gamepad " << joy_id << std::endl;
 }
 
-void Gamepads::connect_gamepad(UINT joy_id, std::string name, int num_buttons) {
-  // Obtener información extendida del dispositivo
-  std::string connection_type = detect_connection_type(joy_id, name, num_buttons);
-  std::string driver_type = get_driver_type(joy_id);
-  auto vendor_product = get_vendor_product_id(joy_id);
-  std::string hardware_id = get_hardware_id(joy_id);
-  
-  // Obtener número de ejes
-  JOYCAPSW joy_caps;
-  int num_axes = 0;
-  if (joyGetDevCapsW(joy_id, &joy_caps, sizeof(JOYCAPSW)) == JOYERR_NOERROR) {
-    num_axes = joy_caps.wNumAxes;
+void Gamepads::stop() {
+  if (g_gamepad)
+    g_gamepad->Release();
+  if (g_gameInput) {
+    g_gameInput->UnregisterCallback(*this->deviceCallbackToken, 5000);
+    g_gameInput->Release();
   }
-  
-  // Create shared_ptr using the constructor
-  auto gamepad = std::make_shared<Gamepad>(
-    joy_id, 
-    name, 
-    num_buttons, 
-    num_axes,
-    connection_type,
-    driver_type,
-    vendor_product.first,
-    vendor_product.second,
-    hardware_id
-  );
-  
-  // Store in map with mutex protection
-  {
-    std::lock_guard<std::mutex> lock(gamepads_mutex);
-    gamepads[joy_id] = gamepad;
+
+  // Stop/cleanup threads
+  for (auto gp : this->gamepads) {
+    if (!gp->stop_thread) {
+      if (gp->alive) {
+        gp->stop_thread = true;
+      } else {
+        // Cleanup data of threads that exited due to error state.
+        delete gp;
+      }
+    }
   }
-  
-  // Start reading thread with shared_ptr (keeps gamepad alive)
-  std::thread read_thread([this, gamepad]() { 
-    read_gamepad(gamepad); 
-  });
+  this->gamepads.clear();
+}
+
+std::list<GamepadData*> Gamepads::get_gamepads() {
+  return this->gamepads;
+}
+
+void Gamepads::on_gamepad_connected(IGameInputDevice* device) {
+  auto info = device->GetDeviceInfo();
+  if (info == nullptr) {
+    std::cerr << "Gamepad connected but failed to read info" << std::endl;
+    return;
+  }
+  auto gp = new GamepadData();
+  gp->id = AppLocalDeviceIdToString(info->deviceId);
+  gp->name = info->displayName != nullptr && info->displayName->data != nullptr
+                 ? info->displayName->data
+                 : "";
+  gp->num_buttons = info->controllerButtonCount;
+  gp->stop_thread = false;
+  gp->alive = true;
+  gp->vendor_id = static_cast<int>(info->vendorId);
+  gp->product_id = static_cast<int>(info->productId);
+  this->gamepads.push_back(gp);
+
+  std::cout << "Gamepad connected: " << gp->id << " : " << gp->name
+            << std::endl;
+
+  std::thread read_thread(
+      [this, gp, device]() { this->read_gamepad(gp, device); });
   read_thread.detach();
 }
 
-void Gamepads::update_gamepads() {
-  try {
-    std::cout << "Updating gamepads..." << std::endl;
-    UINT max_joysticks = joyGetNumDevs();
-    std::cout << "Max joystick slots: " << max_joysticks << std::endl;
-    
-    bool state_changed = false;
-    
-    // First pass: scan all slots WITHOUT holding the mutex (fast, non-blocking)
-    std::map<UINT, std::tuple<std::string, int, int>> detected_gamepads;
-    
-    for (UINT joy_id = 0; joy_id < max_joysticks; ++joy_id) {
-      JOYCAPSW joy_caps;
-      MMRESULT result = joyGetDevCapsW(joy_id, &joy_caps, sizeof(JOYCAPSW));
-      
-      std::cout << "Checking slot " << joy_id << ": ";
-    
-      if (result == JOYERR_NOERROR) {
-        std::cout << "Device found!" << std::endl;
-        std::string name = to_string(joy_caps.szPname);
-        int num_buttons = static_cast<int>(joy_caps.wNumButtons);
-        int num_axes = static_cast<int>(joy_caps.wNumAxes);
-        
-        // Validar que sea realmente un gamepad
-        if (is_valid_gamepad(joy_id, name, num_buttons, num_axes)) {
-          detected_gamepads[joy_id] = std::make_tuple(name, num_buttons, num_axes);
-          std::cout << "Valid gamepad in slot " << joy_id << std::endl;
-        } else {
-          std::cout << "Skipping invalid gamepad candidate " << joy_id 
-                    << ": " << name << " (buttons=" << num_buttons 
-                    << ", axes=" << num_axes << ")" << std::endl;
-        }
-      } else {
-        std::cout << "No device (error code: " << result << ")" << std::endl;
-      }
-    }
-    
-    std::cout << "Finished scanning, now updating state..." << std::endl;
-    
-    // Second pass: quick mutex operations to detect changes
-    std::vector<UINT> gamepads_to_connect;
-    {
-      std::lock_guard<std::mutex> lock(gamepads_mutex);
-      
-      // Check for new gamepads or changed gamepads
-      for (const auto& [joy_id, info] : detected_gamepads) {
-        auto [name, num_buttons, num_axes] = info;
-        
-        auto it = gamepads.find(joy_id);
-        if (it == gamepads.end()) {
-          // New gamepad
-          state_changed = true;
-          gamepads_to_connect.push_back(joy_id);
-          std::cout << "New gamepad detected: " << joy_id << std::endl;
-        } else if (it->second->name != name) {
-          // Gamepad changed
-          state_changed = true;
-          std::cout << "Gamepad " << joy_id << " changed" << std::endl;
-          it->second->alive.store(false);
-          gamepads.erase(it);
-          gamepads_to_connect.push_back(joy_id);
-        }
-      }
-      
-      // Check for disconnected gamepads
-      std::vector<UINT> to_remove;
-      for (const auto& [joy_id, gamepad] : gamepads) {
-        if (detected_gamepads.find(joy_id) == detected_gamepads.end()) {
-          state_changed = true;
-          std::cout << "Gamepad " << joy_id << " disconnected" << std::endl;
-          gamepad->alive.store(false);
-          to_remove.push_back(joy_id);
-        }
-      }
-      
-      for (UINT joy_id : to_remove) {
-        gamepads.erase(joy_id);
-      }
-    } // Mutex released - UI won't freeze anymore
-    
-    // Third pass: connect new gamepads outside the mutex
-    for (UINT joy_id : gamepads_to_connect) {
-      auto [name, num_buttons, num_axes] = detected_gamepads[joy_id];
-      std::cout << "Connecting gamepad " << joy_id << std::endl;
-      connect_gamepad(joy_id, name, num_buttons);
-    }
-  
-  std::cout << "Finished scanning all slots" << std::endl;
-  
-  // Smart throttling: If NO changes were detected, prevent rapid re-scanning
-  // This stops the infinite loop while allowing legitimate connect/disconnect events
-  if (!state_changed) {
-    DWORD current_time = GetTickCount();
-    DWORD last_call = last_update_call.load();
-    
-    if (last_call != 0 && (current_time - last_call) < 100) {
-      // No changes and called too recently - skip future redundant calls
-      last_update_call.store(current_time);
-      std::cout << "Throttling: No changes detected" << std::endl;
-      return;
+void Gamepads::on_gamepad_disconnected(IGameInputDevice* device) {
+  auto info = device->GetDeviceInfo();
+  if (info == nullptr) {
+    std::cerr << "Gamepad disconnected but failed to read info" << std::endl;
+    return;
+  }
+  std::string removeId = AppLocalDeviceIdToString(info->deviceId);
+  std::cout << "Gamepad disconnected: " << removeId << std::endl;
+  GamepadData* removeGp = nullptr;
+  for (auto gp : this->gamepads) {
+    if (gp->id == removeId) {
+      gp->stop_thread = true;
+      removeGp = gp;
+      break;
     }
   }
-  
-  // Update timestamp for next throttling check
-  last_update_call.store(GetTickCount());
-  std::cout << "update_gamepads() completed successfully" << std::endl;
-  
-  } catch (const std::exception& e) {
-    std::cerr << "EXCEPTION in update_gamepads(): " << e.what() << std::endl;
-  } catch (...) {
-    std::cerr << "UNKNOWN EXCEPTION in update_gamepads()" << std::endl;
+  // Remove the gamepad from list. The thread will free up memory.
+  if (removeGp != nullptr) {
+    this->gamepads.remove(removeGp);
   }
 }
 
-std::set<std::wstring> connected_devices;
-
-std::optional<LRESULT> CALLBACK GamepadListenerProc(HWND hwnd,
-                                                    UINT uMsg,
-                                                    WPARAM wParam,
-                                                    LPARAM lParam) {
-  switch (uMsg) {
-    case WM_DEVICECHANGE: {
-      if (lParam != NULL) {
-        PDEV_BROADCAST_HDR pHdr = (PDEV_BROADCAST_HDR)lParam;
-        if (pHdr->dbch_devicetype == DBT_DEVTYP_DEVICEINTERFACE) {
-          PDEV_BROADCAST_DEVICEINTERFACE pDevInterface =
-              (PDEV_BROADCAST_DEVICEINTERFACE)pHdr;
-          if (IsEqualGUID(pDevInterface->dbcc_classguid,
-                          GUID_DEVINTERFACE_HID)) {
-            std::wstring device_path = pDevInterface->dbcc_name;
-            bool is_connected =
-                connected_devices.find(device_path) != connected_devices.end();
-            if (!is_connected && wParam == DBT_DEVICEARRIVAL) {
-              connected_devices.insert(device_path);
-              gamepads.update_gamepads();
-            } else if (is_connected && wParam == DBT_DEVICEREMOVECOMPLETE) {
-              connected_devices.erase(device_path);
-              gamepads.update_gamepads();
+void Gamepads::read_gamepad(GamepadData* gamepad, IGameInputDevice* device) {
+  GameInputGamepadState previous_state = {
+      GameInputGamepadNone, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+  while (!gamepad->stop_thread && g_gameInput != nullptr) {
+    IGameInputReading* reading;
+    GameInputGamepadState state;
+    g_gameInput->GetCurrentReading(GameInputKindGamepad, device, &reading);
+    if (reading != nullptr) {
+      if (reading->GetGamepadState(&state)) {
+        if (are_states_different(previous_state, state)) {
+          auto events = diff_states(previous_state, state);
+          for (auto event : events) {
+            if (event_emitter.has_value()) {
+              (*event_emitter)(gamepad, event);
             }
           }
         }
-      }
-      return 0;
-    }
-    case WM_DESTROY: {
-      PostQuitMessage(0);
-      return 0;
-    }
-  }
-  return std::nullopt;
-}
-
-// Detectar tipo de conexión basado en patrones conocidos
-std::string Gamepads::detect_connection_type(UINT joy_id, const std::string& name, int num_buttons) {
-  // Análisis basado en patrones de botones
-  if (num_buttons > 10) {
-    // Bluetooth típicamente reporta más botones
-    return "bluetooth";
-  } else if (num_buttons <= 10 && num_buttons >= 6) {
-    // Wireless/USB típicamente reporta menos botones
-    return "wireless";
-  }
-  
-  // Análisis basado en el nombre del dispositivo (case-insensitive search)
-  if (name.find("bluetooth") != std::string::npos || name.find("Bluetooth") != std::string::npos) {
-    return "bluetooth";
-  } else if (name.find("wireless") != std::string::npos || name.find("Wireless") != std::string::npos) {
-    return "wireless";
-  } else if (name.find("usb") != std::string::npos || name.find("USB") != std::string::npos) {
-    return "usb";
-  }
-  
-  return "wireless"; // Default para Windows
-}
-
-// Obtener tipo de driver (XInput, DirectInput, etc.)
-std::string Gamepads::get_driver_type(UINT joy_id) {
-  // Por defecto, Windows MM API usa drivers compatibles con DirectInput
-  // XInput devices aparecen típicamente a través de este sistema también
-  return "xinput";
-}
-
-// Obtener VID/PID del dispositivo usando registry del joystick específico
-std::pair<std::string, std::string> Gamepads::get_vendor_product_id(UINT joy_id) {
-  std::string vendor_id = "unknown";
-  std::string product_id = "unknown";
-  
-  // Intentar obtener información del registry para este joystick específico
-  JOYCAPSW joy_caps;
-  if (joyGetDevCapsW(joy_id, &joy_caps, sizeof(JOYCAPSW)) == JOYERR_NOERROR) {
-    // El registry key para joysticks está en HKEY_CURRENT_USER\System\CurrentControlSet\Control\MediaResources\Joystick
-    // Pero es complejo acceder directamente, así que usaremos un enfoque alternativo
-    
-    // Por ahora, intentar extraer VID/PID de devices conocidos usando naming patterns
-    std::string name = to_string(joy_caps.szPname);
-    
-    // Mapeo de nombres conocidos a VID/PID
-    if (name.find("8BitDo") != std::string::npos || name.find("8bitdo") != std::string::npos) {
-      vendor_id = "2DC8";
-      product_id = "310A"; // Ultimate 2C common PID
-    } else if (name.find("Xbox") != std::string::npos && name.find("Wireless") != std::string::npos) {
-      vendor_id = "045E";
-      product_id = "02FD"; // Xbox Wireless Controller common PID
-    } else if (name.find("DualSense") != std::string::npos) {
-      vendor_id = "054C";
-      product_id = "0CE6"; // DualSense common PID
-    }
-    
-    // Si no es un nombre conocido, intentar obtener por HID enumeración más específica
-    if (vendor_id == "unknown") {
-      // Buscar solo dispositivos HID que correspondan a este joystick
-      HDEVINFO device_info_set = SetupDiGetClassDevs(&GUID_DEVINTERFACE_HID, NULL, NULL, 
-                                                      DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
-      
-      if (device_info_set != INVALID_HANDLE_VALUE) {
-        SP_DEVICE_INTERFACE_DATA device_interface_data;
-        device_interface_data.cbSize = sizeof(SP_DEVICE_INTERFACE_DATA);
-        
-        // Solo tomar el primer dispositivo HID válido encontrado
-        // (esto es una aproximación, idealmente correlaríamos mejor)
-        if (SetupDiEnumDeviceInterfaces(device_info_set, NULL, &GUID_DEVINTERFACE_HID, 
-                                       joy_id, &device_interface_data)) {
-          
-          DWORD required_size = 0;
-          SetupDiGetDeviceInterfaceDetail(device_info_set, &device_interface_data, 
-                                        NULL, 0, &required_size, NULL);
-          
-          if (required_size > 0) {
-            auto detail_data = (PSP_DEVICE_INTERFACE_DETAIL_DATA)malloc(required_size);
-            detail_data->cbSize = sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA);
-            
-            SP_DEVINFO_DATA device_info_data;
-            device_info_data.cbSize = sizeof(SP_DEVINFO_DATA);
-            
-            if (SetupDiGetDeviceInterfaceDetail(device_info_set, &device_interface_data,
-                                              detail_data, required_size, NULL, &device_info_data)) {
-              
-              WCHAR hardware_id[256];
-              if (SetupDiGetDeviceRegistryProperty(device_info_set, &device_info_data,
-                                                 SPDRP_HARDWAREID, NULL, (PBYTE)hardware_id,
-                                                 sizeof(hardware_id), NULL)) {
-                
-                std::wstring hw_id_str(hardware_id);
-                std::string hw_id = to_string(hw_id_str);
-                
-                // Buscar patrones VID_xxxx&PID_xxxx
-                size_t vid_pos = hw_id.find("VID_");
-                size_t pid_pos = hw_id.find("PID_");
-                
-                if (vid_pos != std::string::npos) {
-                  vendor_id = hw_id.substr(vid_pos + 4, 4);
-                }
-                if (pid_pos != std::string::npos) {
-                  product_id = hw_id.substr(pid_pos + 4, 4);
-                }
-              }
-            }
-            free(detail_data);
-          }
-        }
-        SetupDiDestroyDeviceInfoList(device_info_set);
+        previous_state = state;
+        reading->Release();
       }
     }
-  }
-  
-  return {vendor_id, product_id};
-}
 
-// Obtener Hardware ID completo
-std::string Gamepads::get_hardware_id(UINT joy_id) {
-  std::string hardware_id = "unknown";
-  
-  HDEVINFO device_info_set = SetupDiGetClassDevs(&GUID_DEVINTERFACE_HID, NULL, NULL, 
-                                                  DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
-  
-  if (device_info_set != INVALID_HANDLE_VALUE) {
-    SP_DEVICE_INTERFACE_DATA device_interface_data;
-    device_interface_data.cbSize = sizeof(SP_DEVICE_INTERFACE_DATA);
-    
-    for (DWORD device_index = 0; 
-         SetupDiEnumDeviceInterfaces(device_info_set, NULL, &GUID_DEVINTERFACE_HID, 
-                                   device_index, &device_interface_data); 
-         device_index++) {
-      
-      DWORD required_size = 0;
-      SetupDiGetDeviceInterfaceDetail(device_info_set, &device_interface_data, 
-                                    NULL, 0, &required_size, NULL);
-      
-      if (required_size > 0) {
-        auto detail_data = (PSP_DEVICE_INTERFACE_DETAIL_DATA)malloc(required_size);
-        detail_data->cbSize = sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA);
-        
-        SP_DEVINFO_DATA device_info_data;
-        device_info_data.cbSize = sizeof(SP_DEVINFO_DATA);
-        
-        if (SetupDiGetDeviceInterfaceDetail(device_info_set, &device_interface_data,
-                                          detail_data, required_size, NULL, &device_info_data)) {
-          
-          WCHAR hw_id[256];
-          if (SetupDiGetDeviceRegistryProperty(device_info_set, &device_info_data,
-                                             SPDRP_HARDWAREID, NULL, (PBYTE)hw_id,
-                                             sizeof(hw_id), NULL)) {
-            
-            std::wstring hw_id_str(hw_id);
-            hardware_id = to_string(hw_id_str);
-            
-            // Tomar el primer hardware ID válido encontrado
-            if (hardware_id != "unknown" && !hardware_id.empty()) {
-              free(detail_data);
-              break;
-            }
-          }
-        }
-        free(detail_data);
-      }
-    }
-    SetupDiDestroyDeviceInfoList(device_info_set);
+    Sleep(8);
   }
-  
-  return hardware_id;
-}
 
-// Validar que un dispositivo sea realmente un gamepad
-bool Gamepads::is_valid_gamepad(UINT joy_id, const std::string& name, int num_buttons, int num_axes) {
-  std::cout << "Validating gamepad " << joy_id << ": '" << name 
-            << "' (buttons: " << num_buttons << ", axes: " << num_axes << ")" << std::endl;
-  
-  // Validación básica: debe responder a consultas
-  JOYINFOEX joy_info;
-  joy_info.dwSize = sizeof(JOYINFOEX);
-  joy_info.dwFlags = JOY_RETURNALL;
-  
-  MMRESULT result = joyGetPosEx(joy_id, &joy_info);
-  if (result != JOYERR_NOERROR) {
-    // Allow JOYERR_UNPLUGGED (165) - device might be temporarily unavailable but will reconnect
-    if (result == JOYERR_UNPLUGGED) {
-      std::cout << "  -> WARNING: Device temporarily unplugged, but will retry connection" << std::endl;
-      // Don't reject - let it try to connect, the read thread will handle errors
-    } else {
-      std::cout << "  -> REJECTED: Cannot read joystick state (error: " << result << ")" << std::endl;
-      return false;
-    }
+  if (gamepad->stop_thread) {
+    std::cout << "Gamepad thread exit (via signal) " << gamepad->id
+              << std::endl;
+    delete gamepad;
+  } else {
+    std::cout << "Gamepad thread exit (due to error state) " << gamepad->id
+              << std::endl;
+    gamepad->alive = false;
   }
-  
-  // Debe tener al menos algún control
-  if (num_buttons == 0 && num_axes == 0) {
-    std::cout << "  -> REJECTED: No buttons or axes" << std::endl;
-    return false;
-  }
-  
-  // Obtener VID para validación adicional
-  auto vendor_product = get_vendor_product_id(joy_id);
-  std::string vid = vendor_product.first;
-  std::string pid = vendor_product.second;
-  
-  std::cout << "  -> Device VID: " << vid << ", PID: " << pid << std::endl;
-  
-  // FILTROS NEGATIVOS: Rechazar dispositivos que claramente NO son gamepads
-  
-  // Configuración sospechosa: muchos botones sin ejes (patrón típico de mouse/teclado)
-  if (num_axes == 0 && num_buttons > 16) {
-    std::cout << "  -> REJECTED: Too many buttons without axes (likely keyboard/mouse)" << std::endl;
-    return false;
-  }
-  
-  // Configuración sospechosa: sin ejes (la mayoría de gamepads tienen al menos 2 ejes)
-  if (num_axes == 0) {
-    std::cout << "  -> REJECTED: No axes detected" << std::endl;
-    return false;
-  }
-  
-  // Nombres que indican otros dispositivos
-  if (name.find("Mouse") != std::string::npos || 
-      name.find("Keyboard") != std::string::npos ||
-      name.find("Headset") != std::string::npos ||
-      name.find("Audio") != std::string::npos) {
-    std::cout << "  -> REJECTED: Device name indicates non-gamepad" << std::endl;
-    return false;
-  }
-  
-  // CRITERIOS POSITIVOS: Aceptar si cumple alguno de estos
-  
-  // 1. Configuración típica de gamepad
-  bool has_reasonable_config = (num_axes >= 2 && num_buttons >= 4) || 
-                               (num_axes >= 4 && num_buttons >= 6) ||
-                               (num_axes >= 1 && num_buttons >= 8);
-  
-  // 2. Nombres conocidos de gamepads
-  bool has_gamepad_name = (name.find("Xbox") != std::string::npos) ||
-                          (name.find("PlayStation") != std::string::npos) ||
-                          (name.find("DualSense") != std::string::npos) ||
-                          (name.find("DualShock") != std::string::npos) ||
-                          (name.find("8BitDo") != std::string::npos) ||
-                          (name.find("8bitdo") != std::string::npos) ||
-                          (name.find("Pro Controller") != std::string::npos) ||
-                          (name.find("Gamepad") != std::string::npos) ||
-                          (name.find("Controller") != std::string::npos) ||
-                          (name.find("Joystick") != std::string::npos);
-  
-  // 3. VIDs conocidos de fabricantes de gamepads
-  bool has_gamepad_vid = (vid == "045E") ||  // Microsoft Xbox
-                         (vid == "054C") ||  // Sony PlayStation
-                         (vid == "057E") ||  // Nintendo
-                         (vid == "2DC8") ||  // 8BitDo
-                         (vid == "0F0D") ||  // Hori
-                         (vid == "0738") ||  // Mad Catz
-                         (vid == "28DE") ||  // Valve Steam Controller
-                         (vid == "0079") ||  // DragonRise
-                         (vid == "1949") ||  // Amazon Luna Controller
-                         (vid == "18D1");    // Google Stadia Controller
-  
-  // Decisión final
-  if (has_reasonable_config || has_gamepad_name || has_gamepad_vid) {
-    std::cout << "  -> ACCEPTED: config=" << has_reasonable_config 
-              << ", name=" << has_gamepad_name 
-              << ", vid=" << has_gamepad_vid << std::endl;
-    return true;
-  }
-  
-  std::cout << "  -> REJECTED: Does not meet gamepad criteria" << std::endl;
-  return false;
 }

--- a/packages/gamepads_windows/windows/gamepad.h
+++ b/packages/gamepads_windows/windows/gamepad.h
@@ -1,87 +1,47 @@
+
+#include <wtypes.h>
+
 #include <windows.h>
-#include <atomic>
 #include <functional>
 #include <iostream>
 #include <list>
 #include <map>
-#include <memory>
-#include <mutex>
 #include <optional>
-#include <string>
+#include <GameInput.h>
 
-struct Gamepad {
-  UINT joy_id;
+struct GamepadData {
+  std::string id;
   std::string name;
   int num_buttons;
-  int num_axes;
-  std::string connection_type;
-  std::string driver_type;
-  std::string vendor_id;
-  std::string product_id;
-  std::string hardware_id;
-  std::atomic<bool> alive; // Use atomic to prevent race conditions
-  
-  // Constructor
-  Gamepad(UINT id, std::string n, int buttons, int axes, 
-          std::string conn_type, std::string drv_type,
-          std::string vid, std::string pid, std::string hw_id)
-    : joy_id(id), name(std::move(n)), num_buttons(buttons), num_axes(axes),
-      connection_type(std::move(conn_type)), driver_type(std::move(drv_type)),
-      vendor_id(std::move(vid)), product_id(std::move(pid)),
-      hardware_id(std::move(hw_id)), alive(true) {}
-  
-  // Disable copy (atomic can't be copied)
-  Gamepad(const Gamepad&) = delete;
-  Gamepad& operator=(const Gamepad&) = delete;
-  
-  // Enable move
-  Gamepad(Gamepad&& other) noexcept
-    : joy_id(other.joy_id), name(std::move(other.name)),
-      num_buttons(other.num_buttons), num_axes(other.num_axes),
-      connection_type(std::move(other.connection_type)),
-      driver_type(std::move(other.driver_type)),
-      vendor_id(std::move(other.vendor_id)),
-      product_id(std::move(other.product_id)),
-      hardware_id(std::move(other.hardware_id)),
-      alive(other.alive.load()) {}
+  bool stop_thread;
+  bool alive;
+  int vendor_id;
+  int product_id;
 };
 
 struct Event {
   int time;
   std::string type;
   std::string key;
-  int value;
+  double value;
 };
 
 class Gamepads {
  private:
-  std::list<Event> diff_states(Gamepad* gamepad,
-                               const JOYINFOEX& old,
-                               const JOYINFOEX& current);
-  bool are_states_different(const JOYINFOEX& a, const JOYINFOEX& b);
-  void read_gamepad(std::shared_ptr<Gamepad> gamepad); // Use shared_ptr to prevent dangling pointers
-  void connect_gamepad(UINT joy_id, std::string name, int num_buttons);
-  std::string detect_connection_type(UINT joy_id, const std::string& name, int num_buttons);
-  std::string get_driver_type(UINT joy_id);
-  std::pair<std::string, std::string> get_vendor_product_id(UINT joy_id);
-  std::string get_hardware_id(UINT joy_id);
-  bool is_valid_gamepad(UINT joy_id, const std::string& name, int num_buttons, int num_axes);
+  std::list<GamepadData*> gamepads;
+
+  GameInputCallbackToken* deviceCallbackToken;
+  void read_gamepad(GamepadData* gamepad, IGameInputDevice* device);
+
+  void on_gamepad_connected(IGameInputDevice* device);
+  void on_gamepad_disconnected(IGameInputDevice* device);
 
  public:
-  std::map<UINT, std::shared_ptr<Gamepad>> gamepads; // Use shared_ptr to manage lifetime
-  std::mutex gamepads_mutex; // Protect concurrent access to gamepads map
-  std::optional<std::function<void(Gamepad* gamepad, const Event& event)>>
+  std::optional<std::function<void(GamepadData* gamepad, const Event& event)>>
       event_emitter;
-  
-  // Smart throttling: track last call to prevent rapid spam but allow legitimate updates
-  std::atomic<DWORD> last_update_call{0};
-  
-  void update_gamepads();
+  void init();
+  void stop();
+  std::list<GamepadData*> get_gamepads();
 };
 
 extern Gamepads gamepads;
-
-std::optional<LRESULT> CALLBACK GamepadListenerProc(HWND hwnd,
-                                                    UINT uMsg,
-                                                    WPARAM wParam,
-                                                    LPARAM lParam);

--- a/packages/gamepads_windows/windows/gamepads_windows_plugin.cpp
+++ b/packages/gamepads_windows/windows/gamepads_windows_plugin.cpp
@@ -15,6 +15,13 @@
 
 namespace gamepads_windows {
 
+namespace {
+// Custom message posted from reader threads to drain the event queue on the
+// platform thread.
+constexpr UINT kDrainGamepadEventsMessage = WM_USER + 0x47;
+constexpr wchar_t kMessageWindowClassName[] = L"GamepadsWindowsMessageWindow";
+}  // namespace
+
 // Formats a 16-bit vendor/product id as a 4-digit uppercase hex string
 // (e.g. 0x045E -> "045E"). The Dart side (GamepadDeviceInfo) types vendorId /
 // productId as String?, so we emit strings here rather than raw ints.
@@ -44,6 +51,7 @@ void GamepadsWindowsPlugin::RegisterWithRegistrar(
 GamepadsWindowsPlugin::GamepadsWindowsPlugin(
     flutter::PluginRegistrarWindows* registrar)
     : registrar(registrar) {
+  create_message_window();
   gamepads.event_emitter = [&](GamepadData* gamepad, const Event& event) {
     this->emit_gamepad_event(gamepad, event);
   };
@@ -52,6 +60,77 @@ GamepadsWindowsPlugin::GamepadsWindowsPlugin(
 
 GamepadsWindowsPlugin::~GamepadsWindowsPlugin() {
   gamepads.stop();
+  if (message_window_ != nullptr) {
+    DestroyWindow(message_window_);
+    message_window_ = nullptr;
+  }
+  UnregisterClassW(kMessageWindowClassName, GetModuleHandle(nullptr));
+}
+
+LRESULT CALLBACK GamepadsWindowsPlugin::MessageWindowProc(HWND hwnd,
+                                                          UINT message,
+                                                          WPARAM wparam,
+                                                          LPARAM lparam) {
+  if (message == kDrainGamepadEventsMessage) {
+    auto* self = reinterpret_cast<GamepadsWindowsPlugin*>(
+        GetWindowLongPtr(hwnd, GWLP_USERDATA));
+    if (self != nullptr) {
+      self->drain_event_queue();
+    }
+    return 0;
+  }
+  return DefWindowProc(hwnd, message, wparam, lparam);
+}
+
+void GamepadsWindowsPlugin::create_message_window() {
+  WNDCLASSEXW wc = {};
+  wc.cbSize = sizeof(wc);
+  wc.lpfnWndProc = GamepadsWindowsPlugin::MessageWindowProc;
+  wc.hInstance = GetModuleHandle(nullptr);
+  wc.lpszClassName = kMessageWindowClassName;
+  // Ignore a "class already exists" failure from a previous instance (e.g.
+  // after a hot restart); CreateWindowExW below will still succeed.
+  RegisterClassExW(&wc);
+
+  message_window_ = CreateWindowExW(0, kMessageWindowClassName, L"", 0, 0, 0, 0,
+                                    0, HWND_MESSAGE, nullptr,
+                                    GetModuleHandle(nullptr), nullptr);
+  if (message_window_ != nullptr) {
+    SetWindowLongPtr(message_window_, GWLP_USERDATA,
+                     reinterpret_cast<LONG_PTR>(this));
+  }
+}
+
+void GamepadsWindowsPlugin::drain_event_queue() {
+  std::deque<QueuedGamepadEvent> pending;
+  {
+    std::lock_guard<std::mutex> lock(queue_mutex_);
+    pending.swap(event_queue_);
+  }
+
+  auto _channel = this->channel.get();
+  if (!_channel) return;
+
+  for (const auto& queued : pending) {
+    flutter::EncodableMap map;
+    map[flutter::EncodableValue("gamepadId")] =
+        flutter::EncodableValue(queued.gamepad_id);
+    map[flutter::EncodableValue("time")] =
+        flutter::EncodableValue(queued.event.time);
+    map[flutter::EncodableValue("type")] =
+        flutter::EncodableValue(queued.event.type);
+    map[flutter::EncodableValue("key")] =
+        flutter::EncodableValue(queued.event.key);
+    map[flutter::EncodableValue("value")] =
+        flutter::EncodableValue(queued.event.value);
+    map[flutter::EncodableValue("vendorId")] =
+        flutter::EncodableValue(queued.vendor_id);
+    map[flutter::EncodableValue("productId")] =
+        flutter::EncodableValue(queued.product_id);
+    _channel->InvokeMethod("onGamepadEvent",
+                           std::make_unique<flutter::EncodableValue>(
+                               flutter::EncodableValue(map)));
+  }
 }
 
 void GamepadsWindowsPlugin::HandleMethodCall(
@@ -97,23 +176,16 @@ void GamepadsWindowsPlugin::HandleMethodCall(
 
 void GamepadsWindowsPlugin::emit_gamepad_event(GamepadData* gamepad,
                                                const Event& event) {
-  auto _channel = this->channel.get();
-  if (_channel) {
-    flutter::EncodableMap map;
-    map[flutter::EncodableValue("gamepadId")] =
-        flutter::EncodableValue(gamepad->id);
-    map[flutter::EncodableValue("time")] = flutter::EncodableValue(event.time);
-    map[flutter::EncodableValue("type")] = flutter::EncodableValue(event.type);
-    map[flutter::EncodableValue("key")] = flutter::EncodableValue(event.key);
-    map[flutter::EncodableValue("value")] =
-        flutter::EncodableValue(event.value);
-    map[flutter::EncodableValue("vendorId")] =
-        flutter::EncodableValue(gamepad->vendor_id);
-    map[flutter::EncodableValue("productId")] =
-        flutter::EncodableValue(gamepad->product_id);
-    _channel->InvokeMethod("onGamepadEvent",
-                           std::make_unique<flutter::EncodableValue>(
-                               flutter::EncodableValue(map)));
+  // This runs on a background reader thread. Platform-channel calls must happen
+  // on the platform thread, so buffer the event and signal the message window
+  // (owned by the platform thread) to drain the queue.
+  {
+    std::lock_guard<std::mutex> lock(queue_mutex_);
+    event_queue_.push_back(
+        {gamepad->id, gamepad->vendor_id, gamepad->product_id, event});
+  }
+  if (message_window_ != nullptr) {
+    PostMessage(message_window_, kDrainGamepadEventsMessage, 0, 0);
   }
 }
 }  // namespace gamepads_windows

--- a/packages/gamepads_windows/windows/gamepads_windows_plugin.cpp
+++ b/packages/gamepads_windows/windows/gamepads_windows_plugin.cpp
@@ -9,10 +9,22 @@
 #include <flutter/plugin_registrar_windows.h>
 #include <flutter/standard_method_codec.h>
 
+#include <iomanip>
 #include <memory>
 #include <sstream>
 
 namespace gamepads_windows {
+
+// Formats a 16-bit vendor/product id as a 4-digit uppercase hex string
+// (e.g. 0x045E -> "045E"). The Dart side (GamepadDeviceInfo) types vendorId /
+// productId as String?, so we emit strings here rather than raw ints.
+static std::string to_hex_id(int id) {
+  std::ostringstream oss;
+  oss << std::uppercase << std::hex << std::setw(4) << std::setfill('0')
+      << (id & 0xFFFF);
+  return oss.str();
+}
+
 void GamepadsWindowsPlugin::RegisterWithRegistrar(
     flutter::PluginRegistrarWindows* registrar) {
   channel = std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
@@ -32,26 +44,14 @@ void GamepadsWindowsPlugin::RegisterWithRegistrar(
 GamepadsWindowsPlugin::GamepadsWindowsPlugin(
     flutter::PluginRegistrarWindows* registrar)
     : registrar(registrar) {
-  gamepads.event_emitter = [&](Gamepad* gamepad, const Event& event) {
+  gamepads.event_emitter = [&](GamepadData* gamepad, const Event& event) {
     this->emit_gamepad_event(gamepad, event);
   };
-  gamepads.update_gamepads();
-  window_proc_id = registrar->RegisterTopLevelWindowProcDelegate(
-      [this](HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam) {
-        DEV_BROADCAST_DEVICEINTERFACE filter = {};
-        filter.dbcc_size = sizeof(filter);
-        filter.dbcc_devicetype = DBT_DEVTYP_DEVICEINTERFACE;
-        filter.dbcc_classguid = GUID_DEVINTERFACE_HID;
-        this->hDevNotify = RegisterDeviceNotification(
-            hwnd, &filter, DEVICE_NOTIFY_WINDOW_HANDLE);
-
-        return GamepadListenerProc(hwnd, message, wparam, lparam);
-      });
+  gamepads.init();
 }
 
 GamepadsWindowsPlugin::~GamepadsWindowsPlugin() {
-  UnregisterDeviceNotification(hDevNotify);
-  registrar->UnregisterTopLevelWindowProcDelegate(window_proc_id);
+  gamepads.stop();
 }
 
 void GamepadsWindowsPlugin::HandleMethodCall(
@@ -59,36 +59,34 @@ void GamepadsWindowsPlugin::HandleMethodCall(
     std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
   if (method_call.method_name().compare("listGamepads") == 0) {
     flutter::EncodableList list;
-    for (auto& [device_id, gamepad_ptr] : gamepads.gamepads) {
-      // Skip if gamepad pointer is null
-      if (!gamepad_ptr) continue;
-      
+    for (auto gamepad : gamepads.get_gamepads()) {
+      if (!gamepad) continue;
+
       flutter::EncodableMap map;
-      map[flutter::EncodableValue("id")] =
-          flutter::EncodableValue(std::to_string(device_id));
+      map[flutter::EncodableValue("id")] = flutter::EncodableValue(gamepad->id);
       map[flutter::EncodableValue("name")] =
-          flutter::EncodableValue(gamepad_ptr->name);
-      
-      // Agregar información extendida del sistema
+          flutter::EncodableValue(gamepad->name);
+
+      // Extended device metadata consumed by the Dart GamepadDeviceInfo /
+      // gamepad_translator. GameInput exposes VID/PID and a button count but
+      // no bus/connection type, so connectionType is left unknown; the Windows
+      // input path maps GameInput's standardized named keys directly and does
+      // not rely on connection type.
       flutter::EncodableMap system_info;
       system_info[flutter::EncodableValue("connectionType")] =
-          flutter::EncodableValue(gamepad_ptr->connection_type);
+          flutter::EncodableValue("unknown");
       system_info[flutter::EncodableValue("driver")] =
-          flutter::EncodableValue(gamepad_ptr->driver_type);
+          flutter::EncodableValue("gameinput");
       system_info[flutter::EncodableValue("vendorId")] =
-          flutter::EncodableValue(gamepad_ptr->vendor_id);
+          flutter::EncodableValue(to_hex_id(gamepad->vendor_id));
       system_info[flutter::EncodableValue("productId")] =
-          flutter::EncodableValue(gamepad_ptr->product_id);
-      system_info[flutter::EncodableValue("hardwareId")] =
-          flutter::EncodableValue(gamepad_ptr->hardware_id);
+          flutter::EncodableValue(to_hex_id(gamepad->product_id));
       system_info[flutter::EncodableValue("buttonCount")] =
-          flutter::EncodableValue(gamepad_ptr->num_buttons);
-      system_info[flutter::EncodableValue("axisCount")] =
-          flutter::EncodableValue(gamepad_ptr->num_axes);
-      
+          flutter::EncodableValue(gamepad->num_buttons);
+
       map[flutter::EncodableValue("systemInfo")] =
           flutter::EncodableValue(system_info);
-      
+
       list.push_back(flutter::EncodableValue(map));
     }
     result->Success(flutter::EncodableValue(list));
@@ -97,18 +95,22 @@ void GamepadsWindowsPlugin::HandleMethodCall(
   }
 }
 
-void GamepadsWindowsPlugin::emit_gamepad_event(Gamepad* gamepad,
+void GamepadsWindowsPlugin::emit_gamepad_event(GamepadData* gamepad,
                                                const Event& event) {
   auto _channel = this->channel.get();
   if (_channel) {
     flutter::EncodableMap map;
     map[flutter::EncodableValue("gamepadId")] =
-        flutter::EncodableValue(std::to_string(gamepad->joy_id));
+        flutter::EncodableValue(gamepad->id);
     map[flutter::EncodableValue("time")] = flutter::EncodableValue(event.time);
     map[flutter::EncodableValue("type")] = flutter::EncodableValue(event.type);
     map[flutter::EncodableValue("key")] = flutter::EncodableValue(event.key);
     map[flutter::EncodableValue("value")] =
-        flutter::EncodableValue(static_cast<double>(event.value));
+        flutter::EncodableValue(event.value);
+    map[flutter::EncodableValue("vendorId")] =
+        flutter::EncodableValue(gamepad->vendor_id);
+    map[flutter::EncodableValue("productId")] =
+        flutter::EncodableValue(gamepad->product_id);
     _channel->InvokeMethod("onGamepadEvent",
                            std::make_unique<flutter::EncodableValue>(
                                flutter::EncodableValue(map)));

--- a/packages/gamepads_windows/windows/gamepads_windows_plugin.h
+++ b/packages/gamepads_windows/windows/gamepads_windows_plugin.h
@@ -27,14 +27,11 @@ class GamepadsWindowsPlugin : public flutter::Plugin {
   static inline std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>>
       channel{};
 
-  int window_proc_id = -1;
-  HDEVNOTIFY hDevNotify;
-
   void HandleMethodCall(
       const flutter::MethodCall<flutter::EncodableValue>& method_call,
       std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
 
-  void emit_gamepad_event(Gamepad* gamepad, const Event& event);
+  void emit_gamepad_event(GamepadData* gamepad, const Event& event);
 };
 
 }  // namespace gamepads_windows

--- a/packages/gamepads_windows/windows/gamepads_windows_plugin.h
+++ b/packages/gamepads_windows/windows/gamepads_windows_plugin.h
@@ -3,12 +3,27 @@
 
 #include <flutter/method_channel.h>
 #include <flutter/plugin_registrar_windows.h>
+#include <windows.h>
 
+#include <deque>
 #include <memory>
+#include <mutex>
+#include <string>
 
 #include "gamepad.h"
 
 namespace gamepads_windows {
+
+// A gamepad event captured on a background reader thread, buffered until it can
+// be forwarded to Flutter on the platform thread. We copy the identifying
+// fields (rather than hold the GamepadData*) because the source device may be
+// disconnected and freed before the platform thread drains the queue.
+struct QueuedGamepadEvent {
+  std::string gamepad_id;
+  int vendor_id;
+  int product_id;
+  Event event;
+};
 
 class GamepadsWindowsPlugin : public flutter::Plugin {
  public:
@@ -31,7 +46,26 @@ class GamepadsWindowsPlugin : public flutter::Plugin {
       const flutter::MethodCall<flutter::EncodableValue>& method_call,
       std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
 
+  // Called on a background reader thread: buffers the event and signals the
+  // platform thread to forward it. Platform-channel calls must not happen here.
   void emit_gamepad_event(GamepadData* gamepad, const Event& event);
+
+  // Creates the hidden message-only window used to hop queued events onto the
+  // platform thread.
+  void create_message_window();
+
+  // Runs on the platform thread (from the message-window proc): forwards all
+  // buffered events to Flutter over the method channel.
+  void drain_event_queue();
+
+  static LRESULT CALLBACK MessageWindowProc(HWND hwnd, UINT message,
+                                            WPARAM wparam, LPARAM lparam);
+
+  // Hidden HWND_MESSAGE window owned by the platform thread.
+  HWND message_window_ = nullptr;
+
+  std::mutex queue_mutex_;
+  std::deque<QueuedGamepadEvent> event_queue_;
 };
 
 }  // namespace gamepads_windows


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

# Description

The Windows gamepad backend used the legacy WinMM joystick API (`joyGetPosEx` / `joyGetDevCapsW`), which fails to enumerate many XInput-class controllers (e.g. the 8BitDo Ultimate 2C in wired / 2.4GHz mode) and, for pads it *does* see over Bluetooth via a raw HID profile, exposes a button order that mismaps inputs (LB reads as Select).

This replaces the vendored `gamepads_windows` native backend with upstream flame-engine's **GameInput** implementation, which enumerates XInput-class devices and reports a standardized, named Xbox-style layout. The Dart translator/nav Windows paths are rewritten to consume GameInput's named keys (`a`, `leftShoulder`, `leftThumbstickX`, `leftTrigger`, …) and normalized `[-1, 1]` stick / `0-1` button values instead of the old WinMM positional / POV / `0..65535` heuristics.

Additionally fixes a threading defect in the upstream code: the GameInput reader thread invoked the platform channel directly (tripping Flutter's non-platform-thread channel assertion). Events are now buffered on the reader thread and drained on the platform thread via a hidden `HWND_MESSAGE` window.

Fixes #112

## Details

- Native backend swapped to GameInput (`gamepad.cpp/.h`, `utils.*`, `plugin.h` from upstream); `listGamepads` still emits a `systemInfo` map (VID/PID + button count) so the Dart `GamepadDeviceInfo` / logging plumbing keeps working. GameInput exposes no bus type, so `connectionType` is reported as `unknown` — the Windows input path no longer relies on it.
- `gamepad_translator.dart`: new `_translateGameInputKey()` maps GameInput's standardized names directly (identical for every controller — no per-VID/PID guessing). `leftShoulder`→LB and `view`→Select are now explicit, fixing the mismap. WinMM POV / 32767 stick heuristics removed from the Windows path.
- `gamepad_nav.dart`: Windows stick branches use the normalized `[-1, 1]` convention (`+X`=right, `+Y`=up).

## Build note

The native plugin needs `GameInput.h` / `gameinput.lib`, which were added to the **Windows SDK in `10.0.26100.0` (24H2)** — older SDKs don't have them. CMake auto-selects the newest installed SDK, so no project change is required.

**CI:** confirmed non-issue — both the `windows-2022` (current `windows-latest`) and `windows-2025` GitHub runner images ship SDK `10.0.26100.0`, and it's the newest SDK on the image, so the existing `windows-latest` build should compile/link with no workflow change. (Optional hardening: pin `WindowsTargetPlatformVersion` / the SDK so a future runner-image change can't silently select an older SDK and fail with "cannot open GameInput.h".)

Per upstream, the GameInput v3 redistributable can make the reported button count read as 0 — harmless here; nothing gates input on it.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [x] Windows | [ ] Linux | [ ] macOS | [ ] Android
- [x] **Gamepad support verified** (if applicable).

## Testing

On-device (Windows), full input dump via the `[GamepadRaw]` diagnostic path — every button, D-pad direction, both triggers (analog), and stick polarity confirmed correct on two controllers:

- **8BitDo Pro 3** (`VID=2DC8 PID=310B`, native mode) — detected + fully correct mapping.
- **Xbox controller** (`VID=045E PID=0B00`, XInput class) — detected + fully correct mapping.

Both previously worked on the WinMM backend, so this confirms **no regression** and correct standardized mapping, plus that the platform-thread fix eliminates the channel-threading error.

⚠️ **Not directly reproduced:** I don't have the exact 8BitDo Ultimate 2C from #112 on hand. The fix is grounded in root cause — WinMM can't enumerate XInput-only devices, and the Ultimate 2C in its failing wired/2.4GHz mode presents as an XInput/Xbox-identity device (`045E/…`), the same class as the Xbox pad verified above through GameInput. **@th3dod00-spec, please confirm on your Ultimate 2C** — a build from this branch should now detect it in wired/dongle mode with correct button mapping (in particular, LB should no longer act as Select).

## Possible knock-on benefit: DualSense

Because GameInput classifies the **Sony DualSense** as a gamepad and reports the standardized Xbox layout natively (Cross→A, Circle→B, Square→X, Triangle→Y), this swap should also give the DualSense a correct, no-guessing mapping — replacing the hand-rolled `buttonCount >= 12` Sony remap the WinMM path relied on. If a DualSense face-button mismap was previously observed, this is a good candidate to fix it (basic input only — adaptive triggers/haptics aren't exposed). Untested here; worth confirming on hardware.

(For contrast: the **Steam Controller** isn't a native HID gamepad — it only appears as a controller via Steam's own virtual XInput layer — so this backend swap doesn't inherently address it either way.)
