### PR TITLE
fix(secondary-display): clear stale system art/label on relaunch

### DIFF
--- a/lib/providers/sqlite_config_provider.dart
+++ b/lib/providers/sqlite_config_provider.dart
@@ -28,7 +28,7 @@ import '../services/game_session_persistence.dart';
 /// Coordinates filesystem scanning for ROMs, system metadata synchronization,
 /// user preferences persistence, and secondary display state management.
 /// Replaces the legacy JSON-based configuration provider.
-class SqliteConfigProvider extends ChangeNotifier {
+class SqliteConfigProvider extends ChangeNotifier with WidgetsBindingObserver {
   ConfigModel _config = ConfigModel.empty;
   List<SystemModel> _detectedSystems = [];
   List<SystemModel> _availableSystems = [];
@@ -47,6 +47,7 @@ class SqliteConfigProvider extends ChangeNotifier {
   bool _isFastScan = false;
   bool _initialized = false;
   SecondaryDisplayState? _secondaryDisplayState;
+  bool _lifecycleObserverAdded = false;
   int _lastMuteToggleTrigger = 0;
   int _lastScreenshotTrigger = 0;
   int _lastDockEditTrigger = 0;
@@ -162,6 +163,28 @@ class SqliteConfigProvider extends ChangeNotifier {
     _error = null;
 
     try {
+      if (Platform.isAndroid) {
+        // The secondary display's engine persists across a main-engine restart
+        // (its cached engine group survives), so the second screen keeps showing
+        // the LAST session's system artwork. Clear it FIRST — before the DB open,
+        // system-JSON sync, data load and permission checks below — so the stale
+        // art is gone within a frame of the restart instead of lingering while
+        // those finish. Must run after initialSync so we overwrite the retained
+        // shared state rather than racing it; every later seed/dock push
+        // copyWith's from this cleared state, so the art stays cleared until the
+        // systems carousel/grid settles on 'All'.
+        _secondaryDisplayState = SecondaryDisplayState.instance;
+        if (_secondaryDisplayState!.value == null) {
+          await _secondaryDisplayState!.initialSync;
+        }
+        _secondaryDisplayState!.updateState(
+          systemName: 'WELCOME',
+          clearSystemBackground: true,
+          clearSystemLogo: true,
+          useShader: true,
+        );
+      }
+
       // Initialize SQLite
       await SqliteService.getDatabase(); // This initializes the DB
 
@@ -194,6 +217,19 @@ class SqliteConfigProvider extends ChangeNotifier {
         // second init can't accumulate a duplicate listener.
         _secondaryDisplayState!.removeListener(_onSecondaryStateChanged);
         _secondaryDisplayState!.addListener(_onSecondaryStateChanged);
+
+        // Observe app lifecycle so we can neutralise the secondary display's
+        // persisted system artwork on the way OUT (see didChangeAppLifecycleState).
+        // The secondary engine's cached engine group and the native shared-state
+        // store both survive a main-engine restart, so clearing on teardown is
+        // what actually gives a stale-art-free relaunch — the on-launch early
+        // clear can only fire ~half a second after the secondary re-attaches and
+        // has already read the retained art. Guard against a duplicate add since
+        // reinitialize() can re-run this block on the same singleton provider.
+        if (!_lifecycleObserverAdded) {
+          WidgetsBinding.instance.addObserver(this);
+          _lifecycleObserverAdded = true;
+        }
 
         _secondaryDisplayChannel.setMethodCallHandler(
           _handleSecondaryDisplayCall,
@@ -276,6 +312,30 @@ class SqliteConfigProvider extends ChangeNotifier {
       _log.e('$_error');
     } finally {
       _setLoading(false);
+    }
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+    if (!Platform.isAndroid) return;
+    // Neutralise the secondary display's persisted system artwork when the
+    // activity is being torn down (explicit exit, SystemNavigator.pop, or the
+    // OS reclaiming the activity). The native shared-state store survives a
+    // main-engine restart, so writing the cleared state here means the next
+    // launch's secondary re-attach reads neutral art instead of the last
+    // session's — eliminating the stale-art flash on a warm relaunch.
+    //
+    // Only `detached` (not `paused`/`inactive`) triggers this: launching a game
+    // backgrounds the app with the activity still alive (paused), and we must
+    // keep the current system art so it's still there on resume.
+    if (state == AppLifecycleState.detached) {
+      _secondaryDisplayState?.updateState(
+        systemName: 'WELCOME',
+        clearSystemBackground: true,
+        clearSystemLogo: true,
+        useShader: true,
+      );
     }
   }
 

--- a/lib/screens/settings_screen/new_settings_screen.dart
+++ b/lib/screens/settings_screen/new_settings_screen.dart
@@ -408,6 +408,9 @@ class _NewSettingsScreenState extends State<NewSettingsScreen> {
     final bool shouldShutdown = config.bartopExitPoweroff;
 
     if (Platform.isAndroid) {
+      // The secondary display's persisted artwork is neutralised by
+      // SqliteConfigProvider.didChangeAppLifecycleState on the detached that
+      // follows this pop, so no explicit clear is needed here.
       SystemNavigator.pop();
     } else {
       if (shouldShutdown) {

--- a/lib/screens/systems_screen/my_systems_section/my_systems_carousel.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_carousel.dart
@@ -143,6 +143,9 @@ class _MySystemsCarouselState extends State<MySystemsCarousel> {
   }
 
   bool _prevIsSecondaryActive = false;
+  // Tracks the scan-active state across builds so we can re-push the settled
+  // selection to the secondary display exactly when the initial scan finishes.
+  bool _wasScanning = false;
 
   // When secondary display signals it's active (startup or reconnect),
   // immediately push current system state so default logo never shows.
@@ -826,11 +829,32 @@ class _MySystemsCarouselState extends State<MySystemsCarousel> {
     final neoThemeFolder = context.select<NeoAssetsProvider, String>(
       (p) => p.activeThemeFolder,
     );
+    final isScanning = context.select<SqliteConfigProvider, bool>(
+      (p) => p.isScanning,
+    );
     if (neoThemeFolder != _lastThemeFolder) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         _loadThemeAssetsForSystems();
+        // Theme assets (and thus _themeBackgrounds) have only just resolved.
+        // Re-push the current selection so the secondary display picks up the
+        // now-available background — otherwise the initially-settled system
+        // (e.g. the 'All' virtual system) stays blank on the secondary until
+        // the user navigates and triggers a push via onPageChanged.
+        // Skip while scanning so the background doesn't pop in over the scan
+        // display; the scan-settle branch below re-pushes once the scan ends.
+        if (!isScanning) _updateSecondaryScreenName();
       });
     }
+    // When the initial scan settles, re-push the settled selection so the
+    // secondary display reveals its background at the same moment the primary
+    // screen settles — not partway through the scan.
+    if (_wasScanning && !isScanning) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _loadThemeAssetsForSystems();
+        _updateSecondaryScreenName();
+      });
+    }
+    _wasScanning = isScanning;
 
     final theme = Theme.of(context);
 

--- a/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
@@ -842,6 +842,9 @@ class _SystemCardGridViewState extends State<SystemCardGridView> {
   }
 
   bool _prevIsSecondaryActive = false;
+  // Tracks the scan-active state across builds so we can re-push the settled
+  // selection to the secondary display exactly when the initial scan finishes.
+  bool _wasScanning = false;
 
   // When secondary display signals it's active (startup or reconnect),
   // immediately push current system state so default logo never shows.
@@ -1417,11 +1420,32 @@ class _SystemCardGridViewState extends State<SystemCardGridView> {
         final neoThemeFolder = context.select<NeoAssetsProvider, String>(
           (p) => p.activeThemeFolder,
         );
+        final isScanning = context.select<SqliteConfigProvider, bool>(
+          (p) => p.isScanning,
+        );
         if (neoThemeFolder != _lastThemeFolder) {
           WidgetsBinding.instance.addPostFrameCallback((_) {
             _loadThemeAssetsForSystems();
+            // Theme assets (and thus _themeBackgrounds) have only just resolved.
+            // Re-push the current selection so the secondary display picks up the
+            // now-available background — otherwise the initially-settled system
+            // (e.g. the 'All' virtual system) stays blank on the secondary until
+            // the user navigates and triggers a push.
+            // Skip while scanning so the background doesn't pop in over the scan
+            // display; the scan-settle branch below re-pushes once the scan ends.
+            if (!isScanning) _updateSecondaryScreenName();
           });
         }
+        // When the initial scan settles, re-push the settled selection so the
+        // secondary display reveals its background at the same moment the primary
+        // screen settles — not partway through the scan.
+        if (_wasScanning && !isScanning) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            _loadThemeAssetsForSystems();
+            _updateSecondaryScreenName();
+          });
+        }
+        _wasScanning = isScanning;
 
         Widget grid = Theme(
           data: _cachedThemeData ?? Theme.of(context),


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

# Description

Fixes stale artwork on the external/secondary display on app relaunch.

The secondary display runs in its own `FlutterEngine` whose cached engine group — and the native shared-state store behind it — survive a main-engine restart. On a **warm** relaunch (process kept alive, activity recreated) the second screen kept showing the **previous session's** system background *and* its name label throughout the startup scan, only correcting once the carousel settled on `All`. Cold relaunches only looked clean because the process death wiped the native store.

**Fix:** neutralise the persisted secondary state on the way *out*, in `SqliteConfigProvider.didChangeAppLifecycleState` on `detached` (fires on explicit exit / `SystemNavigator.pop` / OS reclaim, but **not** on the `paused` a game launch produces — so returning from a game keeps its art). `systemName` is reset to `WELCOME` alongside the art clear so the label matches cold start instead of showing the stale system name. An early clear at the top of `initialize()` is kept only as a net for the rare case the `detached` write doesn't flush before teardown.

Also fixes the original report where the settled `All` background never appeared on the secondary until an R1/L1 nav: the carousel and grid now re-push the settled selection when the initial scan completes (and once theme assets resolve), instead of only on user navigation.

Fixes # (no tracked issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [ ] **Gamepad support verified** (if applicable).

## Notes

- Verified on-device (AYN Thor) via `SECDBG` logcat: on warm relaunch the secondary's first received state is now neutral (`WELCOME`, no background) instead of the prior session's `bg=true`, and the label reads `WELCOME` during the scan before settling on `All`.
- Risk is confined to the Android secondary display; the worst realistic failure is a momentary `WELCOME` placeholder that self-heals on the next navigation. Primary display, DB/scan logic, non-Android platforms, and game launch/resume are untouched.
