### PR TITLE
fix(themes): daisyUI conversion follow-ups — brightness, outline, toggle, accent readability

### DIFF
--- a/lib/screens/neo_sync_screen/neo_sync_tab.dart
+++ b/lib/screens/neo_sync_screen/neo_sync_tab.dart
@@ -252,7 +252,10 @@ class _ProviderCardState extends State<_ProviderCard>
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final accent = theme.colorScheme.secondary;
+    // Use the theme's primary as the active accent: secondary is a pale/washed
+    // colour on several themes (retro mint, coffee, cyberpunk) and reads badly
+    // as a highlight. Text still uses onSurface below for guaranteed contrast.
+    final accent = theme.colorScheme.primary;
     final bool showActive = _isSelected && widget.isActive;
     final base = theme.scaffoldBackgroundColor;
 
@@ -332,9 +335,7 @@ class _ProviderCardState extends State<_ProviderCard>
                           style: theme.textTheme.titleMedium?.copyWith(
                             fontWeight: FontWeight.w600,
                             fontSize: 12.r,
-                            color: showActive
-                                ? accent
-                                : theme.colorScheme.onSurface,
+                            color: theme.colorScheme.onSurface,
                           ),
                           textAlign: TextAlign.center,
                         ),
@@ -389,7 +390,7 @@ class _ProviderCardState extends State<_ProviderCard>
                               'Select',
                               style: TextStyle(
                                 fontSize: 8.r,
-                                color: accent,
+                                color: theme.colorScheme.onSurface,
                                 fontWeight: FontWeight.w600,
                               ),
                             ),

--- a/lib/screens/scraper_screen/scraper_contents/account_content.dart
+++ b/lib/screens/scraper_screen/scraper_contents/account_content.dart
@@ -38,7 +38,7 @@ class AccountContent extends StatelessWidget {
     }
   }
 
-  Color _getContributionColor(String? contribution) {
+  Color _getContributionColor(String? contribution, Color fallback) {
     switch (contribution) {
       case '1':
         return const Color(0xFFCD7F32);
@@ -47,7 +47,9 @@ class AccountContent extends StatelessWidget {
       case '3':
         return const Color(0xFFFFD700);
       default:
-        return Colors.blueGrey;
+        // Base "Member" tier: follow the theme accent (like the RA tab's
+        // user-type pill) instead of an off-palette blue-grey.
+        return fallback;
     }
   }
 
@@ -132,13 +134,16 @@ class AccountContent extends StatelessWidget {
                         context,
                         userInfo!['contribution'],
                       ),
-                      color: _getContributionColor(userInfo!['contribution']),
+                      color: _getContributionColor(
+                        userInfo!['contribution'],
+                        theme.colorScheme.primary,
+                      ),
                     ),
                     _buildPill(
                       icon: Symbols.lan_rounded,
                       label:
                           '${AppLocale.maxThreads.getString(context)}: ${userInfo!['maxthreads'] ?? '1'}',
-                      color: theme.colorScheme.secondary,
+                      color: theme.colorScheme.primary,
                     ),
                   ],
                 ),

--- a/lib/themes/abyss_theme.dart
+++ b/lib/themes/abyss_theme.dart
@@ -33,7 +33,7 @@ const Color _onInfoColor = Color(0xFF042e49);
 
 final ThemeData abyssTheme = ThemeData(
   useMaterial3: true,
-  colorScheme: ColorScheme.light(
+  colorScheme: ColorScheme.dark(
     primary: _primaryColor,
     secondary: _secondaryColor,
     tertiary: _tertiaryColor,

--- a/lib/themes/cyberpunk_theme.dart
+++ b/lib/themes/cyberpunk_theme.dart
@@ -12,7 +12,7 @@ const Color _onTertiaryFixedColor = Color(0xFFfff248);
 const Color _surfaceColor = Color(0xFFfff248);
 const Color _onSurfaceColor = Color(0xFF000000);
 
-const Color _outlineColor = Color(0xFFFFF564);
+const Color _outlineColor = Color(0xFFe3d40e);
 const Color _shadowColor = Color(0xFF111a3b);
 
 const Color _backgroundColor = Color(0xFFe3d40e);
@@ -33,7 +33,7 @@ const Color _onInfoColor = Color(0xFF000000);
 
 final ThemeData cyberpunkTheme = ThemeData(
   useMaterial3: true,
-  colorScheme: ColorScheme.dark(
+  colorScheme: ColorScheme.light(
     primary: _primaryColor,
     secondary: _secondaryColor,
     tertiary: _tertiaryColor,

--- a/lib/themes/light_theme.dart
+++ b/lib/themes/light_theme.dart
@@ -12,7 +12,7 @@ const Color _onTertiaryFixedColor = Color(0xFFe4e4e7);
 const Color _surfaceColor = Color(0xFFffffff);
 const Color _onSurfaceColor = Color(0xFF18181b);
 
-const Color _outlineColor = Color(0xFFffffff);
+const Color _outlineColor = Color(0xFFeeeeee);
 const Color _shadowColor = Color(0xFF09090b);
 
 const Color _backgroundColor = Color(0xFFeeeeee);

--- a/lib/themes/nord_theme.dart
+++ b/lib/themes/nord_theme.dart
@@ -12,7 +12,7 @@ const Color _onTertiaryFixedColor = Color(0xFFd8dee9);
 const Color _surfaceColor = Color(0xFFeceff4);
 const Color _onSurfaceColor = Color(0xFF2e3440);
 
-const Color _outlineColor = Color(0xFFF7FAFF);
+const Color _outlineColor = Color(0xFFd8dee9);
 const Color _shadowColor = Color(0xFF2e3440);
 
 const Color _backgroundColor = Color(0xFFd8dee9);
@@ -33,7 +33,7 @@ const Color _onInfoColor = Color(0xFF0c070b);
 
 final ThemeData nordTheme = ThemeData(
   useMaterial3: true,
-  colorScheme: ColorScheme.dark(
+  colorScheme: ColorScheme.light(
     primary: _primaryColor,
     secondary: _secondaryColor,
     tertiary: _tertiaryColor,

--- a/lib/themes/palenight_theme.dart
+++ b/lib/themes/palenight_theme.dart
@@ -7,6 +7,8 @@ const Color _secondaryColor = Color(0xFFC3E88D);
 const Color _onSecondaryColor = Color(0xFF292D3E);
 const Color _tertiaryColor = Color(0xFF89DDFF);
 const Color _onTertiaryColor = Color(0xFF292D3E);
+const Color _tertiaryFixedColor = Color(0xFF444267);
+const Color _onTertiaryFixedColor = Color(0xFFA6ACCD);
 const Color _surfaceColor = Color(0xFF32374D);
 const Color _onSurfaceColor = Color(0xFFA6ACCD);
 const Color _errorColor = Color(0xFFF07178);
@@ -34,11 +36,13 @@ final ThemeData palenightTheme = ThemeData(
     primary: _primaryColor,
     secondary: _secondaryColor,
     tertiary: _tertiaryColor,
+    tertiaryFixed: _tertiaryFixedColor,
     surface: _surfaceColor,
 
     onPrimary: _onPrimaryColor,
     onSecondary: _onSecondaryColor,
     onTertiary: _onTertiaryColor,
+    onTertiaryFixed: _onTertiaryFixedColor,
     onSurface: _onSurfaceColor,
 
     error: _errorColor,

--- a/lib/themes/retro_theme.dart
+++ b/lib/themes/retro_theme.dart
@@ -12,7 +12,7 @@ const Color _onTertiaryFixedColor = Color(0xFFd4d0ce);
 const Color _surfaceColor = Color(0xFFece3ca);
 const Color _onSurfaceColor = Color(0xFF793205);
 
-const Color _outlineColor = Color(0xFFF8EFD4);
+const Color _outlineColor = Color(0xFFe4d8b4);
 const Color _shadowColor = Color(0xFF56524c);
 
 const Color _backgroundColor = Color(0xFFe4d8b4);

--- a/lib/themes/tokyo_night_theme.dart
+++ b/lib/themes/tokyo_night_theme.dart
@@ -7,6 +7,8 @@ const Color _secondaryColor = Color(0xFF9ECE6A);
 const Color _onSecondaryColor = Color(0xFF1A1B26);
 const Color _tertiaryColor = Color(0xFF7DCFFF);
 const Color _onTertiaryColor = Color(0xFF1A1B26);
+const Color _tertiaryFixedColor = Color(0xFF414868);
+const Color _onTertiaryFixedColor = Color(0xFFC0CAF5);
 const Color _surfaceColor = Color(0xFF24283B);
 const Color _onSurfaceColor = Color(0xFFC0CAF5);
 const Color _errorColor = Color(0xFFF7768E);
@@ -34,11 +36,13 @@ final ThemeData tokyoNightTheme = ThemeData(
     primary: _primaryColor,
     secondary: _secondaryColor,
     tertiary: _tertiaryColor,
+    tertiaryFixed: _tertiaryFixedColor,
     surface: _surfaceColor,
 
     onPrimary: _onPrimaryColor,
     onSecondary: _onSecondaryColor,
     onTertiary: _onTertiaryColor,
+    onTertiaryFixed: _onTertiaryFixedColor,
     onSurface: _onSurfaceColor,
 
     error: _errorColor,

--- a/lib/themes/valentine_theme.dart
+++ b/lib/themes/valentine_theme.dart
@@ -12,7 +12,7 @@ const Color _onTertiaryFixedColor = Color(0xFFf9cbe5);
 const Color _surfaceColor = Color(0xFFfcf2f7);
 const Color _onSurfaceColor = Color(0xFFc5005a);
 
-const Color _outlineColor = Color(0xFFFFF8FC);
+const Color _outlineColor = Color(0xFFf9e4f0);
 const Color _shadowColor = Color(0xFF830c41);
 
 const Color _backgroundColor = Color(0xFFf9e4f0);

--- a/lib/widgets/custom_toggle_switch.dart
+++ b/lib/widgets/custom_toggle_switch.dart
@@ -21,16 +21,22 @@ class CustomToggleSwitch extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final effectiveActiveColor = activeColor ?? theme.colorScheme.primary;
+    final scheme = theme.colorScheme;
+    final effectiveActiveColor = activeColor ?? scheme.primary;
 
-    Color onActiveColor;
-    if (activeColor == theme.colorScheme.secondary) {
-      onActiveColor = theme.colorScheme.onSecondary;
-    } else if (activeColor == theme.colorScheme.primary) {
-      onActiveColor = theme.colorScheme.onPrimary;
-    } else {
-      onActiveColor = theme.colorScheme.onPrimary;
-    }
+    // The full-saturation daisyUI primaries read as a gaudy slab when they
+    // flood the whole pill. Keep the accent on the moving indicator (thumb)
+    // and give the ON track only a soft tonal tint of that colour, layered
+    // over the surface — closer to how daisyUI uses primary as an accent.
+    final activeTrackColor = Color.alphaBlend(
+      effectiveActiveColor.withValues(alpha: 0.20),
+      scheme.surface,
+    );
+
+    // Colour sitting on top of the active (primary) indicator.
+    final onActiveIndicator = effectiveActiveColor == scheme.secondary
+        ? scheme.onSecondary
+        : scheme.onPrimary;
 
     final toggle = AnimatedToggleSwitch<bool>.dual(
       indicatorSize: Size(24.r, 24.r),
@@ -52,38 +58,26 @@ class CustomToggleSwitch extends StatelessWidget {
               onChanged?.call(T);
             },
       styleBuilder: (b) => ToggleStyle(
-        backgroundColor: b
-            ? effectiveActiveColor.withValues(alpha: disabled ? 0.4 : 1.0)
-            : theme.colorScheme.surface.withValues(alpha: disabled ? 0.4 : 1.0),
+        backgroundColor: b ? activeTrackColor : scheme.surface,
+        indicatorColor: b ? effectiveActiveColor : scheme.onSurfaceVariant,
       ),
       iconBuilder: (value) => Icon(
         value ? Symbols.check_rounded : Symbols.close_rounded,
         size: 12.r,
-        color: onActiveColor.withValues(alpha: disabled ? 0.4 : 1.0),
+        // Icon rides the indicator: contrast against the primary thumb when
+        // ON, against the neutral thumb when OFF.
+        color: value ? onActiveIndicator : scheme.surface,
       ),
-      textBuilder: (value) => value
-          ? Center(
-              child: Text(
-                'ON',
-                style: TextStyle(
-                  color: onActiveColor.withValues(alpha: disabled ? 0.4 : 1.0),
-                  fontSize: 8.r,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-            )
-          : Center(
-              child: Text(
-                'OFF',
-                style: TextStyle(
-                  color: theme.colorScheme.onSurfaceVariant.withValues(
-                    alpha: disabled ? 0.4 : 1.0,
-                  ),
-                  fontSize: 8.r,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-            ),
+      textBuilder: (value) => Center(
+        child: Text(
+          value ? 'ON' : 'OFF',
+          style: TextStyle(
+            color: scheme.onSurfaceVariant,
+            fontSize: 8.r,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ),
     );
 
     if (disabled) {


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code), reviewed and tested on-device before posting.

# Description

Follow-up fixes to the daisyUI theme conversion. A once-over of the ported themes surfaced a few concepts that were dropped or inverted in translation, plus two screens where an accent color was used in a way that fails on several themes. Colour/role only — no behaviour changes.

**Theme palette corrections** (`e6b42e5`)
- **Brightness base fixed** on three themes whose `ColorScheme` constructor was inverted vs. their palette (and daisyUI's own `color-scheme`): `abyss` is dark (was `ColorScheme.light`); `nord` and `cyberpunk` are light (were `ColorScheme.dark`). The wrong base inverted `Theme.of(context).brightness` — which the RA dashboard reads to pick washout-safe badge colors — and handed unspecified roles opposite-mode Material defaults.
- **Outline contrast fixed** on the light themes (`light`, `nord`, `valentine`, `retro`, `cyberpunk`): `outline` was set *lighter* than `surface`, so borders/dividers vanished into white. Now a step darker (base-300), daisyUI-style.
- **Toggle switch** reworked so the vivid daisyUI `primary` sits on the small indicator (thumb) with a soft tonal track, instead of flooding the whole pill and reading as a gaudy slab.
- **Neutral slot** (`tertiaryFixed`/`onTertiaryFixed`) added to `palenight` and `tokyo_night`, which were falling back to Material's off-palette default.

**Sync / scraper accent readability** (`10f00df`)
- The sync provider card and scraper account pills used `colorScheme.secondary` as foreground text/icon on a surface background — unreadable, washed-out on themes with a light/clashing secondary (retro mint, coffee, cyberpunk, nord).
- Sync provider card now uses `primary` as the active accent with `onSurface` title/label text.
- Scraper "Max Threads" pill and base "Member" tier now use `primary`, matching the RA dashboard pills; contribution medal tiers (bronze/silver/gold) unchanged.

Fixes # (no linked issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works. *(visual/theme change — no unit test surface)*
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. *(no new assets)*
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android *(AYN Thor, dev build)*
- [x] **Gamepad support verified** — navigated the sync/scraper/RA screens on-device.

## Screenshots (if applicable)

*Toggle switch (before/after),*
<img width="1555" height="421" alt="00-oled" src="https://github.com/user-attachments/assets/512bd474-63fa-48a8-abe7-a562a2b78eba" />
<img width="1553" height="427" alt="00-light" src="https://github.com/user-attachments/assets/5db890ce-4d42-49ca-b862-a79fbe465b90" />


sync provider card on retro (before/after)
<img width="1544" height="426" alt="00retro-sync" src="https://github.com/user-attachments/assets/1645dd05-6c84-494e-87e1-7edd223fb077" />
