### PR TITLE
fix(secondary-screen): stop preview video audio when device locks

### DIFF
--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -167,6 +167,16 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
       return;
     }
 
+    // Device asleep (lid closed / screen off): tear down the preview so its
+    // audio output device stops and the CPU can deep-sleep. This engine never
+    // receives Android lifecycle callbacks, so deviceScreenOn (bridged from the
+    // native ACTION_SCREEN_ON/OFF receiver) is the only reliable signal.
+    if (!state.deviceScreenOn) {
+      _stopVideo();
+      _currentVideoPath = null; // force a fresh start when the screen wakes
+      return;
+    }
+
     if (state.gameVideo != _currentVideoPath) {
       _currentVideoPath = state.gameVideo;
       _stopVideo();


### PR DESCRIPTION
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Description

On the AYN Thor (and any dual-screen handheld), selecting a game plays a gameplay-preview video on the bottom/secondary screen. Closing the lid (device sleep / screen off) left the preview's **audio still playing**, forcing the user to back out to the main menu before sleeping the device.

**Root cause:** the secondary screen runs in a separate `FlutterEngine` behind the sub-screen `Presentation`, so it never receives Android app-lifecycle callbacks. Its `VideoPlayerController` plays **unmuted by default** and was not gated on the only reliable "device asleep" signal available to this engine — `SecondaryDisplayStateData.deviceScreenOn` (bridged from the native `ACTION_SCREEN_ON/OFF` receiver). So on lid-close the looping preview kept playing with `volume = 1.0`.

**Fix:** in `_onStateChanged`, when `deviceScreenOn` is false, tear down the preview via the existing `_stopVideo()` and reset `_currentVideoPath` so it restarts cleanly on wake. Mirrors the existing background-music teardown-on-lock pattern.

Fixes # (no linked issue — reported via Discord, NeoStation 0.9.5, AYN Thor Max)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [ ] **Gamepad support verified** (if applicable).

## Verification

Deployed a dev build to an AYN Thor Max and exercised the real flow:

1. Selected a game → preview video plays with audio on the bottom screen.
2. Closed the lid / pressed power → **audio now stops immediately** (previously continued).
3. Woke the device → preview restarts and plays normally.
4. Deselected the game, slept/woke → no video restarts.

Confirmed by on-device CPU sampling: while locked, all `ExoPlayer`/`MediaCodec`/`AudioTrack` threads are released and process CPU drops to ~0.2% of a core (≈180× reduction vs. the awake baseline). The secondary-engine shader ticker was also checked and self-halts when the sub-display stops vsyncing, so no additional gating was needed.

## Screenshots (if applicable)

N/A — audio-behavior change, no visual difference.