### PR TITLE
fix: Linux RetroArch path resolution and ARM64 SoLoud audio deps

### DIFF
--- a/build-utils/build-linux.sh
+++ b/build-utils/build-linux.sh
@@ -131,17 +131,47 @@ if [ ! -d "$APPDIR/usr/bin/data" ]; then
     exit 1
 fi
 
-LIB_DIR="/usr/lib/x86_64-linux-gnu"
+# Library search paths for x86_64 across Debian/Ubuntu and Fedora/RHEL Linux
+LIB_SEARCH_PATHS=(
+  "/usr/lib/x86_64-linux-gnu"
+  "/usr/lib64"
+  "/usr/lib"
+  "/lib/x86_64-linux-gnu"
+  "/lib64"
+)
+
+copy_lib_to_appdir() {
+  local lib_pattern="$1"
+  local found=0
+  for search_dir in "${LIB_SEARCH_PATHS[@]}"; do
+    if [ -d "$search_dir" ]; then
+      while IFS= read -r lib_path; do
+        if [ -n "$lib_path" ] && [ -f "$lib_path" ]; then
+          cp -L "$lib_path" "$APPDIR/usr/lib/" 2>/dev/null || true
+          found=1
+        fi
+      done < <(find "$search_dir" -maxdepth 1 -name "$lib_pattern" 2>/dev/null)
+    fi
+  done
+  return $found
+}
 
 # Copy FFmpeg libraries
 echo "Copying FFmpeg libraries..."
 for lib in libavcodec.so.* libavformat.so.* libavutil.so.* libswscale.so.* libswresample.so.* libavfilter.so.*; do
-  find "$LIB_DIR" -name "$lib" -exec cp -L {} "$APPDIR/usr/lib/" \; 2>/dev/null || true
+  copy_lib_to_appdir "$lib" || true
 done
 
 # Copy SQLite3
-if [ -f "$LIB_DIR/libsqlite3.so.0" ]; then
-  cp -L "$LIB_DIR"/libsqlite3.so.* "$APPDIR/usr/lib/" 2>/dev/null || true
+SQLITE3_FOUND=0
+for search_dir in "${LIB_SEARCH_PATHS[@]}"; do
+  if [ -f "$search_dir/libsqlite3.so.0" ]; then
+    cp -L "$search_dir"/libsqlite3.so.* "$APPDIR/usr/lib/" 2>/dev/null || true
+    SQLITE3_FOUND=1
+    break
+  fi
+done
+if [ "$SQLITE3_FOUND" = "1" ]; then
   cd "$APPDIR/usr/lib/"
   for f in libsqlite3.so.0.*; do
     [ -f "$f" ] && ln -sf "$f" libsqlite3.so.0
@@ -154,14 +184,23 @@ fi
 # Copy X11 libraries
 echo "Copying X11 libraries..."
 for xlib in libX11.so.* libXau.so.* libXdmcp.so.* libXext.so.* libXfixes.so.* libXrender.so.* libXrandr.so.* libXi.so.* libXcursor.so.* libXdamage.so.* libXcomposite.so.* libXpresent.so.* libxcb.so.* libxcb-shm.so.* libxcb-render.so.*; do
-  find "$LIB_DIR" -name "$xlib" -exec cp -L {} "$APPDIR/usr/lib/" \; 2>/dev/null || true
+  copy_lib_to_appdir "$xlib" || true
 done
 
 # Copy SoLoud audio dependencies (loaded at runtime via DynamicLibrary.open — not caught by ldd on main binary)
 echo "Copying SoLoud audio libraries..."
 for audiolib in libFLAC.so.* libFLAC++.so.* libogg.so.* libvorbis.so.* libvorbisenc.so.* libvorbisfile.so.* libopus.so.*; do
-  find "$LIB_DIR" /usr/lib -name "$audiolib" -exec cp -L {} "$APPDIR/usr/lib/" \; 2>/dev/null || true
+  copy_lib_to_appdir "$audiolib" || true
 done
+
+# Verify critical audio libraries were bundled. Fedora/RHEL places them under /usr/lib64,
+# while Debian/Ubuntu uses /usr/lib/x86_64-linux-gnu. If the build machine lacks the
+# -devel/-dev package, CMake may link against a versioned SONAME that we then fail to ship.
+if [ ! -f "$APPDIR/usr/lib/libFLAC.so.12" ] && [ ! -f "$APPDIR/usr/lib/libFLAC.so.14" ]; then
+  echo "ERROR: libFLAC was not bundled. Ensure libflac/libflac-dev is installed and found in one of:"
+  printf '  %s\n' "${LIB_SEARCH_PATHS[@]}"
+  exit 1
+fi
 
 # Analyze and copy additional binary dependencies
 # Run ldd on main binary AND all bundled .so plugins to catch transitive/runtime-loaded deps

--- a/build-utils/build-linuxarm.sh
+++ b/build-utils/build-linuxarm.sh
@@ -162,17 +162,47 @@ if [ ! -d "$APPDIR/usr/bin/data" ]; then
     exit 1
 fi
 
-LIB_DIR="/usr/lib/aarch64-linux-gnu"
+# Library search paths for ARM64 across Debian/Ubuntu and Fedora/RHEL/Asahi Linux
+LIB_SEARCH_PATHS=(
+  "/usr/lib/aarch64-linux-gnu"
+  "/usr/lib64"
+  "/usr/lib"
+  "/lib/aarch64-linux-gnu"
+  "/lib64"
+)
+
+copy_lib_to_appdir() {
+  local lib_pattern="$1"
+  local found=0
+  for search_dir in "${LIB_SEARCH_PATHS[@]}"; do
+    if [ -d "$search_dir" ]; then
+      while IFS= read -r lib_path; do
+        if [ -n "$lib_path" ] && [ -f "$lib_path" ]; then
+          cp -L "$lib_path" "$APPDIR/usr/lib/" 2>/dev/null || true
+          found=1
+        fi
+      done < <(find "$search_dir" -maxdepth 1 -name "$lib_pattern" 2>/dev/null)
+    fi
+  done
+  return $found
+}
 
 # Copy FFmpeg libraries
 echo "Copying FFmpeg libraries..."
 for lib in libavcodec.so.* libavformat.so.* libavutil.so.* libswscale.so.* libswresample.so.* libavfilter.so.*; do
-  find "$LIB_DIR" -name "$lib" -exec cp -L {} "$APPDIR/usr/lib/" \; 2>/dev/null || true
+  copy_lib_to_appdir "$lib" || true
 done
 
 # Copy SQLite3
-if [ -f "$LIB_DIR/libsqlite3.so.0" ]; then
-  cp -L "$LIB_DIR"/libsqlite3.so.* "$APPDIR/usr/lib/" 2>/dev/null || true
+SQLITE3_FOUND=0
+for search_dir in "${LIB_SEARCH_PATHS[@]}"; do
+  if [ -f "$search_dir/libsqlite3.so.0" ]; then
+    cp -L "$search_dir"/libsqlite3.so.* "$APPDIR/usr/lib/" 2>/dev/null || true
+    SQLITE3_FOUND=1
+    break
+  fi
+done
+if [ "$SQLITE3_FOUND" = "1" ]; then
   cd "$APPDIR/usr/lib/"
   for f in libsqlite3.so.0.*; do
     [ -f "$f" ] && ln -sf "$f" libsqlite3.so.0
@@ -185,14 +215,23 @@ fi
 # Copy X11 libraries
 echo "Copying X11 libraries..."
 for xlib in libX11.so.* libXau.so.* libXdmcp.so.* libXext.so.* libXfixes.so.* libXrender.so.* libXrandr.so.* libXi.so.* libXcursor.so.* libXdamage.so.* libXcomposite.so.* libXpresent.so.* libxcb.so.* libxcb-shm.so.* libxcb-render.so.*; do
-  find "$LIB_DIR" -name "$xlib" -exec cp -L {} "$APPDIR/usr/lib/" \; 2>/dev/null || true
+  copy_lib_to_appdir "$xlib" || true
 done
 
 # Copy SoLoud audio dependencies (loaded at runtime via DynamicLibrary.open — not caught by ldd on main binary)
 echo "Copying SoLoud audio libraries..."
 for audiolib in libFLAC.so.* libFLAC++.so.* libogg.so.* libvorbis.so.* libvorbisenc.so.* libvorbisfile.so.* libopus.so.*; do
-  find "$LIB_DIR" /usr/lib -name "$audiolib" -exec cp -L {} "$APPDIR/usr/lib/" \; 2>/dev/null || true
+  copy_lib_to_appdir "$audiolib" || true
 done
+
+# Verify critical audio libraries were bundled. Fedora/Asahi places them under /usr/lib64,
+# while Debian/Ubuntu uses /usr/lib/aarch64-linux-gnu. If the build machine lacks the
+# -devel/-dev package, CMake may link against a versioned SONAME that we then fail to ship.
+if [ ! -f "$APPDIR/usr/lib/libFLAC.so.12" ] && [ ! -f "$APPDIR/usr/lib/libFLAC.so.14" ]; then
+  echo "ERROR: libFLAC was not bundled. Ensure libflac/libflac-dev is installed and found in one of:"
+  printf '  %s\n' "${LIB_SEARCH_PATHS[@]}"
+  exit 1
+fi
 
 # Analyze and copy additional binary dependencies
 # Run ldd on main binary AND all bundled .so plugins to catch transitive/runtime-loaded deps

--- a/lib/services/game_service.dart
+++ b/lib/services/game_service.dart
@@ -1437,16 +1437,20 @@ class GameService {
     try {
       String executable = launchCmd['executable'].toString();
 
-      if ((Platform.isWindows || Platform.isLinux) &&
-          !await File(executable).exists()) {
+      if ((Platform.isWindows || Platform.isLinux)) {
         final detected = await EmulatorRepository.getUserDetectedEmulators();
 
         if (executable.toLowerCase().contains('retroarch')) {
           final ra = detected['RetroArch'];
-          if (ra != null) {
+          if (ra != null && ra.path.isNotEmpty) {
+            if (executable != ra.path) {
+              _log.i(
+                'Resolving RetroArch executable from "$executable" to user-configured path: ${ra.path}',
+              );
+            }
             executable = ra.path;
           }
-        } else {
+        } else if (!await File(executable).exists()) {
           String? resolvedPath;
           final uniqueId = launchCmd['unique_id']?.toString();
           if (uniqueId != null) {
@@ -1478,7 +1482,12 @@ class GameService {
           executable.toLowerCase().contains('retroarch')) {
         final detected = await EmulatorRepository.getUserDetectedEmulators();
         final ra = detected['RetroArch'];
-        if (ra != null) {
+        if (ra != null && ra.path.isNotEmpty) {
+          if (executable != ra.path) {
+            _log.i(
+              'Resolving RetroArch executable on macOS from "$executable" to user-configured path: ${ra.path}',
+            );
+          }
           executable = ra.path;
           if (executable.endsWith('.app')) {
             executable = path.join(

--- a/test/database_test_helper.dart
+++ b/test/database_test_helper.dart
@@ -147,7 +147,9 @@ class DatabaseTestHelper {
       CREATE TABLE user_emulator_config (
         emulator_unique_id TEXT PRIMARY KEY,
         emulator_path TEXT,
-        is_user_default INTEGER
+        is_user_default INTEGER,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT DEFAULT CURRENT_TIMESTAMP
       )
     ''');
 

--- a/test/emulator_repository_test.dart
+++ b/test/emulator_repository_test.dart
@@ -70,6 +70,54 @@ void main() {
       expect(path, 'C:/retroarch/retroarch.exe');
     });
 
+    test('saveDetectedEmulatorPath persists RetroArch path under ra unique id',
+        () async {
+      await EmulatorRepository.saveDetectedEmulatorPath(
+        emulatorName: 'RetroArch',
+        emulatorPath: '/usr/bin/retroarch',
+      );
+
+      final detected = await EmulatorRepository.getUserDetectedEmulators();
+      expect(detected['RetroArch'], isNotNull);
+      expect(detected['RetroArch']!.path, '/usr/bin/retroarch');
+    });
+
+    test(
+      'saveDetectedEmulatorPath updates an existing RetroArch path',
+      () async {
+        await EmulatorRepository.saveDetectedEmulatorPath(
+          emulatorName: 'RetroArch',
+          emulatorPath: '/old/path/RetroArch.AppImage',
+        );
+        await EmulatorRepository.saveDetectedEmulatorPath(
+          emulatorName: 'RetroArch',
+          emulatorPath: '/usr/bin/retroarch',
+        );
+
+        final detected = await EmulatorRepository.getUserDetectedEmulators();
+        expect(detected['RetroArch']!.path, '/usr/bin/retroarch');
+      },
+    );
+
+    test(
+      'getUserDetectedEmulators prefers ra entry over standalone RetroArch entry',
+      () async {
+        await db.execute(
+          "INSERT INTO app_emulators (system_id, os_id, name, unique_identifier, is_standalone) VALUES ('snes', 3, 'RetroArch', 'retroarch.snes', 1)",
+        );
+        await db.execute(
+          "INSERT INTO user_emulator_config (emulator_unique_id, emulator_path) VALUES ('retroarch.snes', '/home/user/Applications/RetroArch-Linux-x86_64.AppImage')",
+        );
+        await EmulatorRepository.saveDetectedEmulatorPath(
+          emulatorName: 'RetroArch',
+          emulatorPath: '/usr/bin/retroarch',
+        );
+
+        final detected = await EmulatorRepository.getUserDetectedEmulators();
+        expect(detected['RetroArch']!.path, '/usr/bin/retroarch');
+      },
+    );
+
     test(
       'getSystemsWithStandaloneEmulators throws when OS is missing',
       () async {


### PR DESCRIPTION
## Summary

Fixes two issues reported by an Asahi Linux (ARM64) user:

1. **RetroArch path changes were ignored at launch.** The game launcher only fell back to the user-configured RetroArch executable when the JSON-configured executable did not exist as a file. This was fragile and could leave a stale AppImage path in use. Now the launcher always resolves to the user-configured RetroArch path when the executable is RetroArch.

2. **ARM64 AppImage builds missed libFLAC.so.12 (and related SoLoud audio deps).** The build scripts only searched Debian/Ubuntu library paths (/usr/lib/aarch64-linux-gnu). On Fedora/Asahi these libraries live under /usr/lib64, so they were never bundled. The scripts now search a cross-distro set of paths and fail the build if libFLAC cannot be bundled.

## Changes

- lib/services/game_service.dart: Always prefer the user-configured RetroArch path for RetroArch executables on Windows/Linux/macOS.
-  Test/emulator_repository_test.dart + est/database_test_helper.dart: Add tests for saving and resolving the RetroArch path.
- Build-utils/build-linuxarm.sh + Build-utils/build-linux.sh: Search multiple library paths (Debian and Fedora/RHEL layouts) and verify libFLAC is bundled.

## Notes

- The libFLAC.so.12 error is separate from the RetroArch issue but appears in the same log. It is caused by the ARM64 build not shipping the audio libraries that flutter_soloud links against when TRY_SYSTEM_LIBS_FIRST=1 is set.