### PR TITLE
fix(game_screen): restore analyze-clean by using null-aware list element

### DIFF
--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -2802,11 +2802,7 @@ class _SystemGamesListState extends State<SystemGamesList> {
         return Stack(
           fit: StackFit.expand,
           alignment: Alignment.center,
-          // ignore: use_null_aware_elements
-          children: [
-            ...previousChildren,
-            if (currentChild != null) currentChild,
-          ],
+          children: [...previousChildren, ?currentChild],
         );
       },
       transitionBuilder: (child, animation) {


### PR DESCRIPTION
> 🤖 This PR was prepared with [Claude Code](https://claude.com/claude-code).

# Description

Restores `flutter analyze` to clean on `main`. In `my_games_list.dart`, the `AnimatedSwitcher` `layoutBuilder` relied on an `// ignore: use_null_aware_elements` directive placed directly above a **single-line** list literal:

```dart
// ignore: use_null_aware_elements
children: [...previousChildren, if (currentChild != null) currentChild],
```

A later formatting pass reflowed that literal onto multiple lines, which moved the `if (currentChild != null)` element off the line the `// ignore` covers. The suppression silently stopped applying, so `flutter analyze` began reporting an `info` at `my_games_list.dart:2808`.

This replaces the conditional element with the null-aware element the lint was asking for and drops the now-unnecessary ignore:

```dart
children: [...previousChildren, ?currentChild],
```

Behaviour is identical — the element is included only when `currentChild` is non-null — and the form is stable under `dart format`, so the lint can't resurface via reformatting.

Fixes # (n/a)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors. (`No issues found!` project-wide.)
- [ ] I have added tests demonstrating that my fix or feature works. (N/A — behaviour-identical; full suite still 198/198.)
- [ ] I have updated the corresponding documentation. (N/A)
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. (No new assets.)
- [ ] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [ ] Android
- [x] **Gamepad support verified** (if applicable). (No logic change.)

## Screenshots (if applicable)

None — no visual change.
