### PR TITLE
refactor(settings): extract reusable SettingRow widget

### DIFF
--- a/lib/screens/settings_screen/new_settings_options/general_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/general_settings_content.dart
@@ -17,6 +17,7 @@ import 'package:neostation/utils/gamepad_nav.dart';
 import '../../../providers/sqlite_config_provider.dart';
 import '../../../widgets/custom_toggle_switch.dart';
 import 'settings_title.dart';
+import 'widgets/setting_row.dart';
 import '../../../services/permission_service.dart';
 
 /// A specialized content panel for system-wide configuration, including platform-specific orchestration (Windows/Android/Linux).
@@ -328,68 +329,21 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
           // Setting: Scan on Startup.
           () {
             final index = currentItemIdx++;
-            return Container(
+            return SettingRow(
               key: _itemKeys[index],
-              padding: EdgeInsets.only(
-                left: 12.r,
-                right: 12.r,
-                top: 6.r,
-                bottom: 6.r,
-              ),
-              decoration: BoxDecoration(
-                color: theme.colorScheme.surface.withValues(alpha: 0.5),
-                borderRadius: BorderRadius.circular(8.r),
-                border: Border.all(
-                  color:
-                      widget.isContentFocused &&
-                          widget.selectedContentIndex == index
-                      ? theme.colorScheme.primary
-                      : Colors.transparent,
-                  width: 2,
-                ),
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          AppLocale.scanOnStartup.getString(context),
-                          style: theme.textTheme.bodyLarge?.copyWith(
-                            fontSize: 12.r,
-                            fontWeight: FontWeight.w500,
-                            color:
-                                widget.isContentFocused &&
-                                    widget.selectedContentIndex == index
-                                ? theme.colorScheme.primary
-                                : theme.colorScheme.onSurface,
-                          ),
-                        ),
-                        SizedBox(height: 4.r),
-                        Text(
-                          AppLocale.scanOnStartupSubtitle.getString(context),
-                          style: theme.textTheme.bodyMedium?.copyWith(
-                            fontSize: 9.r,
-                            color: theme.colorScheme.onSurface.withValues(
-                              alpha: 0.6,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  CustomToggleSwitch(
-                    value: config.scanOnStartup,
-                    onChanged: (value) {
-                      context.read<SqliteConfigProvider>().updateScanOnStartup(
-                        value,
-                      );
-                    },
-                    activeColor: theme.colorScheme.primary,
-                  ),
-                ],
+              focused:
+                  widget.isContentFocused &&
+                  widget.selectedContentIndex == index,
+              title: AppLocale.scanOnStartup.getString(context),
+              subtitle: AppLocale.scanOnStartupSubtitle.getString(context),
+              trailing: CustomToggleSwitch(
+                value: config.scanOnStartup,
+                onChanged: (value) {
+                  context.read<SqliteConfigProvider>().updateScanOnStartup(
+                    value,
+                  );
+                },
+                activeColor: theme.colorScheme.primary,
               ),
             );
           }(),
@@ -398,70 +352,21 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
           SizedBox(height: 12.r),
           () {
             final index = currentItemIdx++;
-            return Container(
+            return SettingRow(
               key: _itemKeys[index],
-              padding: EdgeInsets.only(
-                left: 12.r,
-                right: 12.r,
-                top: 6.r,
-                bottom: 6.r,
-              ),
-              decoration: BoxDecoration(
-                color: theme.colorScheme.surface.withValues(alpha: 0.5),
-                borderRadius: BorderRadius.circular(8.r),
-                border: Border.all(
-                  color:
-                      widget.isContentFocused &&
-                          widget.selectedContentIndex == index
-                      ? theme.colorScheme.primary
-                      : Colors.transparent,
-                  width: 2,
-                ),
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          AppLocale.ignoreHiddenFiles.getString(context),
-                          style: theme.textTheme.bodyLarge?.copyWith(
-                            fontSize: 12.r,
-                            fontWeight: FontWeight.w500,
-                            color:
-                                widget.isContentFocused &&
-                                    widget.selectedContentIndex == index
-                                ? theme.colorScheme.primary
-                                : theme.colorScheme.onSurface,
-                          ),
-                        ),
-                        SizedBox(height: 4.r),
-                        Text(
-                          AppLocale.ignoreHiddenFilesSubtitle.getString(
-                            context,
-                          ),
-                          style: theme.textTheme.bodyMedium?.copyWith(
-                            fontSize: 9.r,
-                            color: theme.colorScheme.onSurface.withValues(
-                              alpha: 0.6,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  CustomToggleSwitch(
-                    value: config.ignoreHiddenFiles,
-                    onChanged: (value) {
-                      context
-                          .read<SqliteConfigProvider>()
-                          .updateIgnoreHiddenFiles(value);
-                    },
-                    activeColor: theme.colorScheme.primary,
-                  ),
-                ],
+              focused:
+                  widget.isContentFocused &&
+                  widget.selectedContentIndex == index,
+              title: AppLocale.ignoreHiddenFiles.getString(context),
+              subtitle: AppLocale.ignoreHiddenFilesSubtitle.getString(context),
+              trailing: CustomToggleSwitch(
+                value: config.ignoreHiddenFiles,
+                onChanged: (value) {
+                  context.read<SqliteConfigProvider>().updateIgnoreHiddenFiles(
+                    value,
+                  );
+                },
+                activeColor: theme.colorScheme.primary,
               ),
             );
           }(),
@@ -470,68 +375,21 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
           SizedBox(height: 12.r),
           () {
             final index = currentItemIdx++;
-            return Container(
+            return SettingRow(
               key: _itemKeys[index],
-              padding: EdgeInsets.only(
-                left: 12.r,
-                right: 12.r,
-                top: 6.r,
-                bottom: 6.r,
-              ),
-              decoration: BoxDecoration(
-                color: theme.colorScheme.surface.withValues(alpha: 0.5),
-                borderRadius: BorderRadius.circular(8.r),
-                border: Border.all(
-                  color:
-                      widget.isContentFocused &&
-                          widget.selectedContentIndex == index
-                      ? theme.colorScheme.primary
-                      : Colors.transparent,
-                  width: 2,
-                ),
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          AppLocale.autoUpdateApp.getString(context),
-                          style: theme.textTheme.bodyLarge?.copyWith(
-                            fontSize: 12.r,
-                            fontWeight: FontWeight.w500,
-                            color:
-                                widget.isContentFocused &&
-                                    widget.selectedContentIndex == index
-                                ? theme.colorScheme.primary
-                                : theme.colorScheme.onSurface,
-                          ),
-                        ),
-                        SizedBox(height: 4.r),
-                        Text(
-                          AppLocale.autoUpdateAppSubtitle.getString(context),
-                          style: theme.textTheme.bodyMedium?.copyWith(
-                            fontSize: 9.r,
-                            color: theme.colorScheme.onSurface.withValues(
-                              alpha: 0.6,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  CustomToggleSwitch(
-                    value: config.autoUpdateApp,
-                    onChanged: (value) {
-                      context.read<SqliteConfigProvider>().updateAutoUpdateApp(
-                        value,
-                      );
-                    },
-                    activeColor: theme.colorScheme.primary,
-                  ),
-                ],
+              focused:
+                  widget.isContentFocused &&
+                  widget.selectedContentIndex == index,
+              title: AppLocale.autoUpdateApp.getString(context),
+              subtitle: AppLocale.autoUpdateAppSubtitle.getString(context),
+              trailing: CustomToggleSwitch(
+                value: config.autoUpdateApp,
+                onChanged: (value) {
+                  context.read<SqliteConfigProvider>().updateAutoUpdateApp(
+                    value,
+                  );
+                },
+                activeColor: theme.colorScheme.primary,
               ),
             );
           }(),
@@ -540,70 +398,21 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
           SizedBox(height: 12.r),
           () {
             final index = currentItemIdx++;
-            return Container(
+            return SettingRow(
               key: _itemKeys[index],
-              padding: EdgeInsets.only(
-                left: 12.r,
-                right: 12.r,
-                top: 6.r,
-                bottom: 6.r,
-              ),
-              decoration: BoxDecoration(
-                color: theme.colorScheme.surface.withValues(alpha: 0.5),
-                borderRadius: BorderRadius.circular(8.r),
-                border: Border.all(
-                  color:
-                      widget.isContentFocused &&
-                          widget.selectedContentIndex == index
-                      ? theme.colorScheme.primary
-                      : Colors.transparent,
-                  width: 2,
-                ),
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          AppLocale.autoUpdateSystems.getString(context),
-                          style: theme.textTheme.bodyLarge?.copyWith(
-                            fontSize: 12.r,
-                            fontWeight: FontWeight.w500,
-                            color:
-                                widget.isContentFocused &&
-                                    widget.selectedContentIndex == index
-                                ? theme.colorScheme.primary
-                                : theme.colorScheme.onSurface,
-                          ),
-                        ),
-                        SizedBox(height: 4.r),
-                        Text(
-                          AppLocale.autoUpdateSystemsSubtitle.getString(
-                            context,
-                          ),
-                          style: theme.textTheme.bodyMedium?.copyWith(
-                            fontSize: 9.r,
-                            color: theme.colorScheme.onSurface.withValues(
-                              alpha: 0.6,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  CustomToggleSwitch(
-                    value: config.autoUpdateSystems,
-                    onChanged: (value) {
-                      context
-                          .read<SqliteConfigProvider>()
-                          .updateAutoUpdateSystems(value);
-                    },
-                    activeColor: theme.colorScheme.primary,
-                  ),
-                ],
+              focused:
+                  widget.isContentFocused &&
+                  widget.selectedContentIndex == index,
+              title: AppLocale.autoUpdateSystems.getString(context),
+              subtitle: AppLocale.autoUpdateSystemsSubtitle.getString(context),
+              trailing: CustomToggleSwitch(
+                value: config.autoUpdateSystems,
+                onChanged: (value) {
+                  context.read<SqliteConfigProvider>().updateAutoUpdateSystems(
+                    value,
+                  );
+                },
+                activeColor: theme.colorScheme.primary,
               ),
             );
           }(),
@@ -612,68 +421,19 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
           SizedBox(height: 12.r),
           () {
             final index = currentItemIdx++;
-            return Container(
+            return SettingRow(
               key: _itemKeys[index],
-              padding: EdgeInsets.only(
-                left: 12.r,
-                right: 12.r,
-                top: 6.r,
-                bottom: 6.r,
-              ),
-              decoration: BoxDecoration(
-                color: theme.colorScheme.surface.withValues(alpha: 0.5),
-                borderRadius: BorderRadius.circular(8.r),
-                border: Border.all(
-                  color:
-                      widget.isContentFocused &&
-                          widget.selectedContentIndex == index
-                      ? theme.colorScheme.primary
-                      : Colors.transparent,
-                  width: 2,
-                ),
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          AppLocale.sfxSounds.getString(context),
-                          style: theme.textTheme.bodyLarge?.copyWith(
-                            fontSize: 12.r,
-                            fontWeight: FontWeight.w500,
-                            color:
-                                widget.isContentFocused &&
-                                    widget.selectedContentIndex == index
-                                ? theme.colorScheme.primary
-                                : theme.colorScheme.onSurface,
-                          ),
-                        ),
-                        SizedBox(height: 4.r),
-                        Text(
-                          AppLocale.sfxSoundsSubtitle.getString(context),
-                          style: theme.textTheme.bodyMedium?.copyWith(
-                            fontSize: 9.r,
-                            color: theme.colorScheme.onSurface.withValues(
-                              alpha: 0.6,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  CustomToggleSwitch(
-                    value: config.sfxEnabled,
-                    onChanged: (value) {
-                      context.read<SqliteConfigProvider>().updateSfxEnabled(
-                        value,
-                      );
-                    },
-                    activeColor: theme.colorScheme.primary,
-                  ),
-                ],
+              focused:
+                  widget.isContentFocused &&
+                  widget.selectedContentIndex == index,
+              title: AppLocale.sfxSounds.getString(context),
+              subtitle: AppLocale.sfxSoundsSubtitle.getString(context),
+              trailing: CustomToggleSwitch(
+                value: config.sfxEnabled,
+                onChanged: (value) {
+                  context.read<SqliteConfigProvider>().updateSfxEnabled(value);
+                },
+                activeColor: theme.colorScheme.primary,
               ),
             );
           }(),
@@ -682,68 +442,21 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
           SizedBox(height: 12.r),
           () {
             final index = currentItemIdx++;
-            return Container(
+            return SettingRow(
               key: _itemKeys[index],
-              padding: EdgeInsets.only(
-                left: 12.r,
-                right: 12.r,
-                top: 6.r,
-                bottom: 6.r,
-              ),
-              decoration: BoxDecoration(
-                color: theme.colorScheme.surface.withValues(alpha: 0.5),
-                borderRadius: BorderRadius.circular(8.r),
-                border: Border.all(
-                  color:
-                      widget.isContentFocused &&
-                          widget.selectedContentIndex == index
-                      ? theme.colorScheme.primary
-                      : Colors.transparent,
-                  width: 2,
-                ),
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          AppLocale.use12HourClock.getString(context),
-                          style: theme.textTheme.bodyLarge?.copyWith(
-                            fontSize: 12.r,
-                            fontWeight: FontWeight.w500,
-                            color:
-                                widget.isContentFocused &&
-                                    widget.selectedContentIndex == index
-                                ? theme.colorScheme.primary
-                                : theme.colorScheme.onSurface,
-                          ),
-                        ),
-                        SizedBox(height: 4.r),
-                        Text(
-                          AppLocale.use12HourClockSubtitle.getString(context),
-                          style: theme.textTheme.bodyMedium?.copyWith(
-                            fontSize: 9.r,
-                            color: theme.colorScheme.onSurface.withValues(
-                              alpha: 0.6,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  CustomToggleSwitch(
-                    value: config.use12HourClock,
-                    onChanged: (value) {
-                      context.read<SqliteConfigProvider>().updateUse12HourClock(
-                        value,
-                      );
-                    },
-                    activeColor: theme.colorScheme.primary,
-                  ),
-                ],
+              focused:
+                  widget.isContentFocused &&
+                  widget.selectedContentIndex == index,
+              title: AppLocale.use12HourClock.getString(context),
+              subtitle: AppLocale.use12HourClockSubtitle.getString(context),
+              trailing: CustomToggleSwitch(
+                value: config.use12HourClock,
+                onChanged: (value) {
+                  context.read<SqliteConfigProvider>().updateUse12HourClock(
+                    value,
+                  );
+                },
+                activeColor: theme.colorScheme.primary,
               ),
             );
           }(),
@@ -752,100 +465,49 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
           SizedBox(height: 12.r),
           () {
             final index = currentItemIdx++;
-            return Container(
+            return SettingRow(
               key: _itemKeys[index],
-              padding: EdgeInsets.only(
-                left: 12.r,
-                right: 12.r,
-                top: 6.r,
-                bottom: 6.r,
-              ),
-              decoration: BoxDecoration(
-                color: theme.colorScheme.surface.withValues(alpha: 0.5),
-                borderRadius: BorderRadius.circular(8.r),
-                border: Border.all(
-                  color:
-                      widget.isContentFocused &&
-                          widget.selectedContentIndex == index
-                      ? theme.colorScheme.primary
-                      : Colors.transparent,
-                  width: 2,
+              focused:
+                  widget.isContentFocused &&
+                  widget.selectedContentIndex == index,
+              title: AppLocale.language.getString(context),
+              subtitle: AppLocale.languageSub.getString(context),
+              trailing: GestureDetector(
+                onTap: () => _showLanguagePicker(context, _itemKeys[index]),
+                child: Container(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: 10.r,
+                    vertical: 6.r,
+                  ),
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.primary.withValues(alpha: 0.15),
+                    borderRadius: BorderRadius.circular(6.r),
+                    border: Border.all(
+                      color: theme.colorScheme.primary.withValues(alpha: 0.4),
+                      width: 0.5.r,
+                    ),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        AppLocale.supportedLanguages[config.appLanguage] ??
+                            config.appLanguage,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          fontSize: 9.r,
+                          fontWeight: FontWeight.w400,
+                          color: theme.colorScheme.primary,
+                        ),
+                      ),
+                      SizedBox(width: 2.r),
+                      Icon(
+                        Symbols.arrow_drop_down_rounded,
+                        size: 14.r,
+                        color: theme.colorScheme.primary,
+                      ),
+                    ],
+                  ),
                 ),
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          AppLocale.language.getString(context),
-                          style: theme.textTheme.bodyLarge?.copyWith(
-                            fontSize: 12.r,
-                            fontWeight: FontWeight.w500,
-                            color:
-                                widget.isContentFocused &&
-                                    widget.selectedContentIndex == index
-                                ? theme.colorScheme.primary
-                                : theme.colorScheme.onSurface,
-                          ),
-                        ),
-                        SizedBox(height: 4.r),
-                        Text(
-                          AppLocale.languageSub.getString(context),
-                          style: theme.textTheme.bodyMedium?.copyWith(
-                            fontSize: 9.r,
-                            color: theme.colorScheme.onSurface.withValues(
-                              alpha: 0.6,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  GestureDetector(
-                    onTap: () => _showLanguagePicker(context, _itemKeys[index]),
-                    child: Container(
-                      padding: EdgeInsets.symmetric(
-                        horizontal: 10.r,
-                        vertical: 6.r,
-                      ),
-                      decoration: BoxDecoration(
-                        color: theme.colorScheme.primary.withValues(
-                          alpha: 0.15,
-                        ),
-                        borderRadius: BorderRadius.circular(6.r),
-                        border: Border.all(
-                          color: theme.colorScheme.primary.withValues(
-                            alpha: 0.4,
-                          ),
-                          width: 0.5.r,
-                        ),
-                      ),
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Text(
-                            AppLocale.supportedLanguages[config.appLanguage] ??
-                                config.appLanguage,
-                            style: theme.textTheme.bodyMedium?.copyWith(
-                              fontSize: 9.r,
-                              fontWeight: FontWeight.w400,
-                              color: theme.colorScheme.primary,
-                            ),
-                          ),
-                          SizedBox(width: 2.r),
-                          Icon(
-                            Symbols.arrow_drop_down_rounded,
-                            size: 14.r,
-                            color: theme.colorScheme.primary,
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                ],
               ),
             );
           }(),
@@ -856,62 +518,18 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
             SizedBox(height: 12.r),
             () {
               final index = currentItemIdx++;
-              return Container(
+              return SettingRow(
                 key: _itemKeys[index],
-                padding: EdgeInsets.only(
-                  left: 12.r,
-                  right: 12.r,
-                  top: 6.r,
-                  bottom: 6.r,
-                ),
-                decoration: BoxDecoration(
-                  color: theme.colorScheme.surface.withValues(alpha: 0.5),
-                  borderRadius: BorderRadius.circular(8.r),
-                  border: Border.all(
-                    color:
-                        widget.isContentFocused &&
-                            widget.selectedContentIndex == index
-                        ? theme.colorScheme.primary
-                        : Colors.transparent,
-                    width: 2,
-                  ),
-                ),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          AppLocale.fullscreenMode.getString(context),
-                          style: theme.textTheme.bodyLarge?.copyWith(
-                            fontSize: 12.r,
-                            fontWeight: FontWeight.w500,
-                            color:
-                                widget.isContentFocused &&
-                                    widget.selectedContentIndex == index
-                                ? theme.colorScheme.primary
-                                : theme.colorScheme.onSurface,
-                          ),
-                        ),
-                        SizedBox(height: 4.r),
-                        Text(
-                          AppLocale.fullscreenModeSubtitle.getString(context),
-                          style: theme.textTheme.bodyMedium?.copyWith(
-                            fontSize: 9.r,
-                            color: theme.colorScheme.onSurface.withValues(
-                              alpha: 0.6,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                    CustomToggleSwitch(
-                      value: provider.isFullscreen,
-                      onChanged: _toggleFullscreen,
-                      activeColor: theme.colorScheme.primary,
-                    ),
-                  ],
+                expandTitle: false,
+                focused:
+                    widget.isContentFocused &&
+                    widget.selectedContentIndex == index,
+                title: AppLocale.fullscreenMode.getString(context),
+                subtitle: AppLocale.fullscreenModeSubtitle.getString(context),
+                trailing: CustomToggleSwitch(
+                  value: provider.isFullscreen,
+                  onChanged: _toggleFullscreen,
+                  activeColor: theme.colorScheme.primary,
                 ),
               );
             }(),
@@ -1002,68 +620,19 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
 
             () {
               final index = currentItemIdx++;
-              return Container(
+              return SettingRow(
                 key: _itemKeys[index],
-                padding: EdgeInsets.only(
-                  left: 12.r,
-                  right: 12.r,
-                  top: 6.r,
-                  bottom: 6.r,
-                ),
-                decoration: BoxDecoration(
-                  color: theme.colorScheme.surface.withValues(alpha: 0.5),
-                  borderRadius: BorderRadius.circular(8.r),
-                  border: Border.all(
-                    color:
-                        widget.isContentFocused &&
-                            widget.selectedContentIndex == index
-                        ? theme.colorScheme.primary
-                        : Colors.transparent,
-                    width: 2,
-                  ),
-                ),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            AppLocale.defaultLauncher.getString(context),
-                            style: theme.textTheme.bodyLarge?.copyWith(
-                              fontSize: 12.r,
-                              fontWeight: FontWeight.w500,
-                              color:
-                                  widget.isContentFocused &&
-                                      widget.selectedContentIndex == index
-                                  ? theme.colorScheme.primary
-                                  : theme.colorScheme.onSurface,
-                            ),
-                          ),
-                          SizedBox(height: 4.r),
-                          Text(
-                            _isDefaultLauncher
-                                ? AppLocale.isDefaultLauncher.getString(context)
-                                : AppLocale.setAsDefaultLauncher.getString(
-                                    context,
-                                  ),
-                            style: theme.textTheme.bodyMedium?.copyWith(
-                              fontSize: 9.r,
-                              color: theme.colorScheme.onSurface.withValues(
-                                alpha: 0.6,
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                    CustomToggleSwitch(
-                      value: _isDefaultLauncher,
-                      onChanged: _toggleLauncher,
-                      activeColor: theme.colorScheme.primary,
-                    ),
-                  ],
+                focused:
+                    widget.isContentFocused &&
+                    widget.selectedContentIndex == index,
+                title: AppLocale.defaultLauncher.getString(context),
+                subtitle: _isDefaultLauncher
+                    ? AppLocale.isDefaultLauncher.getString(context)
+                    : AppLocale.setAsDefaultLauncher.getString(context),
+                trailing: CustomToggleSwitch(
+                  value: _isDefaultLauncher,
+                  onChanged: _toggleLauncher,
+                  activeColor: theme.colorScheme.primary,
                 ),
               );
             }(),
@@ -1074,72 +643,24 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
           if (Platform.isAndroid) ...[
             () {
               final index = currentItemIdx++;
-              return Container(
+              return SettingRow(
                 key: _itemKeys[index],
-                padding: EdgeInsets.only(
-                  left: 12.r,
-                  right: 12.r,
-                  top: 6.r,
-                  bottom: 6.r,
+                focused:
+                    widget.isContentFocused &&
+                    widget.selectedContentIndex == index,
+                title: AppLocale.disableSecondaryScreen.getString(context),
+                subtitle: AppLocale.disableSecondaryScreenSub.getString(
+                  context,
                 ),
-                decoration: BoxDecoration(
-                  color: theme.colorScheme.surface.withValues(alpha: 0.5),
-                  borderRadius: BorderRadius.circular(8.r),
-                  border: Border.all(
-                    color:
-                        widget.isContentFocused &&
-                            widget.selectedContentIndex == index
-                        ? theme.colorScheme.primary
-                        : Colors.transparent,
-                    width: 2,
-                  ),
-                ),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            AppLocale.disableSecondaryScreen.getString(context),
-                            style: theme.textTheme.bodyLarge?.copyWith(
-                              fontSize: 12.r,
-                              fontWeight: FontWeight.w500,
-                              color:
-                                  widget.isContentFocused &&
-                                      widget.selectedContentIndex == index
-                                  ? theme.colorScheme.primary
-                                  : theme.colorScheme.onSurface,
-                            ),
-                          ),
-                          SizedBox(height: 4.r),
-                          Text(
-                            AppLocale.disableSecondaryScreenSub.getString(
-                              context,
-                            ),
-                            style: theme.textTheme.bodyMedium?.copyWith(
-                              fontSize: 9.r,
-                              color: theme.colorScheme.onSurface.withValues(
-                                alpha: 0.6,
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                    CustomToggleSwitch(
-                      value: config.hideBottomScreen,
-                      onChanged: (value) {
-                        provider.updateHideBottomScreen(
-                          value,
-                          backgroundColor: theme.scaffoldBackgroundColor
-                              .toARGB32(),
-                        );
-                      },
-                      activeColor: theme.colorScheme.primary,
-                    ),
-                  ],
+                trailing: CustomToggleSwitch(
+                  value: config.hideBottomScreen,
+                  onChanged: (value) {
+                    provider.updateHideBottomScreen(
+                      value,
+                      backgroundColor: theme.scaffoldBackgroundColor.toARGB32(),
+                    );
+                  },
+                  activeColor: theme.colorScheme.primary,
                 ),
               );
             }(),
@@ -1150,69 +671,21 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
             SizedBox(height: 12.r),
             () {
               final index = currentItemIdx++;
-              return Container(
+              return SettingRow(
                 key: _itemKeys[index],
-                padding: EdgeInsets.only(
-                  left: 12.r,
-                  right: 12.r,
-                  top: 6.r,
-                  bottom: 6.r,
-                ),
-                decoration: BoxDecoration(
-                  color: theme.colorScheme.surface.withValues(alpha: 0.5),
-                  borderRadius: BorderRadius.circular(8.r),
-                  border: Border.all(
-                    color:
-                        widget.isContentFocused &&
-                            widget.selectedContentIndex == index
-                        ? theme.colorScheme.primary
-                        : Colors.transparent,
-                    width: 2,
-                    strokeAlign: BorderSide.strokeAlignInside,
-                  ),
-                ),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            AppLocale.bartopShutdown.getString(context),
-                            style: theme.textTheme.bodyLarge?.copyWith(
-                              fontSize: 12.r,
-                              fontWeight: FontWeight.w500,
-                              color:
-                                  widget.isContentFocused &&
-                                      widget.selectedContentIndex == index
-                                  ? theme.colorScheme.primary
-                                  : theme.colorScheme.onSurface,
-                            ),
-                          ),
-                          SizedBox(height: 4.r),
-                          Text(
-                            AppLocale.bartopShutdownSubtitle.getString(context),
-                            style: theme.textTheme.bodyMedium?.copyWith(
-                              fontSize: 9.r,
-                              color: theme.colorScheme.onSurface.withValues(
-                                alpha: 0.6,
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                    CustomToggleSwitch(
-                      value: config.bartopExitPoweroff,
-                      onChanged: (value) {
-                        context
-                            .read<SqliteConfigProvider>()
-                            .updateBartopExitPoweroff(value);
-                      },
-                      activeColor: theme.colorScheme.primary,
-                    ),
-                  ],
+                focused:
+                    widget.isContentFocused &&
+                    widget.selectedContentIndex == index,
+                title: AppLocale.bartopShutdown.getString(context),
+                subtitle: AppLocale.bartopShutdownSubtitle.getString(context),
+                trailing: CustomToggleSwitch(
+                  value: config.bartopExitPoweroff,
+                  onChanged: (value) {
+                    context
+                        .read<SqliteConfigProvider>()
+                        .updateBartopExitPoweroff(value);
+                  },
+                  activeColor: theme.colorScheme.primary,
                 ),
               );
             }(),

--- a/lib/screens/settings_screen/new_settings_options/widgets/setting_row.dart
+++ b/lib/screens/settings_screen/new_settings_options/widgets/setting_row.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+/// A single focus-bordered settings row: a title/subtitle block paired with a
+/// trailing control (toggle, dropdown, etc.).
+///
+/// Encapsulates the shared chrome — surface background, rounded border that
+/// highlights in the theme's primary colour while focused, and the standard
+/// title/subtitle typography — so individual settings only declare their
+/// label, description, and trailing widget.
+class SettingRow extends StatelessWidget {
+  /// Primary label text.
+  final String title;
+
+  /// Secondary description text shown beneath the title.
+  final String subtitle;
+
+  /// The control rendered at the trailing edge of the row.
+  final Widget trailing;
+
+  /// Whether this row currently owns gamepad focus (drives the border and
+  /// title colour).
+  final bool focused;
+
+  /// Whether the title/subtitle block is wrapped in an [Expanded]. Defaults to
+  /// `true`; a small number of legacy rows lay out without it.
+  final bool expandTitle;
+
+  const SettingRow({
+    super.key,
+    required this.title,
+    required this.subtitle,
+    required this.trailing,
+    required this.focused,
+    this.expandTitle = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    final titleColumn = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: theme.textTheme.bodyLarge?.copyWith(
+            fontSize: 12.r,
+            fontWeight: FontWeight.w500,
+            color: focused
+                ? theme.colorScheme.primary
+                : theme.colorScheme.onSurface,
+          ),
+        ),
+        SizedBox(height: 4.r),
+        Text(
+          subtitle,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            fontSize: 9.r,
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+          ),
+        ),
+      ],
+    );
+
+    return Container(
+      padding: EdgeInsets.only(left: 12.r, right: 12.r, top: 6.r, bottom: 6.r),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface.withValues(alpha: 0.5),
+        borderRadius: BorderRadius.circular(8.r),
+        border: Border.all(
+          color: focused ? theme.colorScheme.primary : Colors.transparent,
+          width: 2,
+        ),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          expandTitle ? Expanded(child: titleColumn) : titleColumn,
+          trailing,
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Description

Part of the ongoing file-splitting / clean-code campaign. `general_settings_content.dart` had ~11 near-identical inline setting rows — each a focus-bordered surface `Container` wrapping a title/subtitle `Column` and a trailing control — repeated verbatim except for label, description, and value/callback.

This extracts that shared chrome into a single reusable **`SettingRow`** widget and rewrites each row to declare only what differs. **No behaviour or public-API change.**

- New `lib/screens/settings_screen/new_settings_options/widgets/setting_row.dart` — reproduces the exact surface background, focus-driven border + title colour, title/subtitle typography, padding, and `spaceBetween` layout.
- 11 rows now collapse to a `title`/`subtitle`/`trailing` declaration: the six startup/scan/update/sfx/clock toggles, the language dropdown, fullscreen, launcher, secondary-display suppression, and BarTOP shutdown.
- **Fullscreen** keeps its original non-`Expanded` title layout via `expandTitle: false`.
- **BarTOP**'s explicit `strokeAlign: BorderSide.strokeAlignInside` is the framework default (verified in `painting/borders.dart`), so it is dropped with zero visual change.
- **All Files Access** is intentionally left inline — its coloured permission-status line plus smaller sub-subtitle don't fit the single-string subtitle shape.

`general_settings_content.dart` shrinks **1482 → 950 lines**. `getItemCount()`/`selectItem()` index ordering is untouched, so gamepad navigation indices are identical.

Fixes # (n/a)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [ ] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [ ] Android
- [ ] **Gamepad support verified** (if applicable).

## Notes

Pure refactor, no new behaviour to test, so no new automated tests were added. Verified locally: `dart format` clean, `flutter analyze` reports no issues project-wide, and **198/198** existing tests pass. On-device smoke (toggle each row + open the language picker + focus-border rendering) still pending; the widget tree is reproduced exactly so no visual change is expected.