### PR TITLE
refactor(systems-grid): extract pure grid_geometry helpers + unit tests

### DIFF
--- a/lib/screens/systems_screen/my_systems_section/grid_geometry.dart
+++ b/lib/screens/systems_screen/my_systems_section/grid_geometry.dart
@@ -1,0 +1,133 @@
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:neostation/models/my_systems.dart';
+
+/// Pure spatial-layout helpers for the systems grid.
+///
+/// These functions were extracted verbatim from `_MySystemsGridState` so the
+/// packing/geometry math can be unit-tested in isolation and reused without a
+/// live widget. They hold no state — the grid's memoization cache stays in the
+/// widget, which calls [buildVirtualGrid] and stores the result.
+
+/// Packs [cards] into a virtual spatial grid of [cols] columns.
+///
+/// Returns a row-major matrix where each cell holds the index of the card
+/// occupying it, or `-1` for an empty slot. 'Recent Games' cards (`isGame`)
+/// expand to a 3x2 block on wide displays (`cols >= 3`); every other card
+/// occupies a single cell. Cards are placed by a first-fit scan for the first
+/// spatial slot large enough to hold their span.
+List<List<int>> buildVirtualGrid(List<SystemInfo> cards, int cols) {
+  final List<List<int>> grid = [];
+
+  // 'Recent Games' cards expand to 3x2 on high-resolution displays.
+  int getSpanW(SystemInfo card) => (card.isGame && cols >= 3) ? 3 : 1;
+  int getSpanH(SystemInfo card) => (card.isGame && cols >= 3) ? 2 : 1;
+
+  for (int i = 0; i < cards.length; i++) {
+    final card = cards[i];
+    final w = getSpanW(card);
+    final h = getSpanH(card);
+
+    // Recursive scan for the first available spatial slot that fits the component spans.
+    int foundRow = 0;
+    int foundCol = 0;
+    bool fits = false;
+
+    while (!fits) {
+      while (grid.length <= foundRow + h - 1) {
+        grid.add(List<int>.filled(cols, -1));
+      }
+
+      if (foundCol + w <= cols) {
+        bool overlap = false;
+        for (int r = foundRow; r < foundRow + h; r++) {
+          for (int c = foundCol; c < foundCol + w; c++) {
+            if (grid[r][c] != -1) {
+              overlap = true;
+              break;
+            }
+          }
+          if (overlap) break;
+        }
+
+        if (!overlap) {
+          fits = true;
+        } else {
+          foundCol++;
+          if (foundCol >= cols) {
+            foundCol = 0;
+            foundRow++;
+          }
+        }
+      } else {
+        foundCol = 0;
+        foundRow++;
+      }
+    }
+
+    // Commit the spatial allocation to the grid matrix.
+    for (int r = foundRow; r < foundRow + h; r++) {
+      for (int c = foundCol; c < foundCol + w; c++) {
+        grid[r][c] = i;
+      }
+    }
+  }
+
+  return grid;
+}
+
+/// Spatial search for the nearest neighbor in a row with potential layout gaps.
+///
+/// Expands outward from [col] within [row] of [grid], returning the first
+/// occupied card index found, or `-1` if the row has no other occupant.
+int findNearestInRow(List<List<int>> grid, int row, int col) {
+  final rowItems = grid[row];
+  final cols = rowItems.length;
+
+  for (int dist = 1; dist < cols; dist++) {
+    if (col - dist >= 0 && rowItems[col - dist] != -1) {
+      return rowItems[col - dist];
+    }
+    if (col + dist < cols && rowItems[col + dist] != -1) {
+      return rowItems[col + dist];
+    }
+  }
+  return -1;
+}
+
+/// Dynamically computes grid layout dimensions based on viewport constraints.
+///
+/// [screenWidth] is the width available to the grid (already net of any outer
+/// inset), [cols] the column count, and [childAspectRatio] the card aspect
+/// ratio (a non-1 ratio denotes a system card, which gets extra height for its
+/// logo footer). Returns the item/row sizing and spacing map consumed by the
+/// grid delegate.
+Map<String, double> calculateGridDimensions({
+  required double screenWidth,
+  required int cols,
+  required double childAspectRatio,
+}) {
+  final crossAxisSpacing = 6.0.r;
+  final mainAxisSpacing = 6.0.r;
+
+  final totalSpacing = crossAxisSpacing * (cols - 1);
+  final availableWidth = screenWidth - totalSpacing;
+  final itemWidth = availableWidth / cols;
+
+  // For game cards (childAspectRatio = 1) use traditional square calculation.
+  // For system cards (childAspectRatio != 1) add extra height for logo footer.
+  final double itemHeight;
+  if (childAspectRatio != 1) {
+    itemHeight = itemWidth + 32.r;
+  } else {
+    itemHeight = itemWidth / childAspectRatio;
+  }
+  final rowHeight = itemHeight + mainAxisSpacing;
+
+  return {
+    'itemWidth': itemWidth,
+    'itemHeight': itemHeight,
+    'rowHeight': rowHeight,
+    'crossAxisSpacing': crossAxisSpacing,
+    'mainAxisSpacing': mainAxisSpacing,
+  };
+}

--- a/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
@@ -21,6 +21,7 @@ import '../../../providers/file_provider.dart';
 import '../../../widgets/system_scan_progress_widget.dart';
 import '../../game_screen/my_games_list.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'grid_geometry.dart';
 import 'my_systems_carousel.dart';
 import 'package:neostation/widgets/custom_notification.dart';
 import 'package:neostation/widgets/system_emulator_settings_dialog.dart';
@@ -1154,6 +1155,9 @@ class _SystemCardGridViewState extends State<SystemCardGridView> {
   /// directional navigation across items with varying spans.
   ///
   /// Returns a matrix where each cell [row][col] points to the item index.
+  /// Memoized wrapper around the pure [buildVirtualGrid]: caches the last
+  /// packed grid so repeated navigation/scroll passes over an unchanged card
+  /// set skip the recompute.
   List<List<int>> _buildVirtualGrid(List<SystemInfo> cards, int cols) {
     if (_cachedVirtualGrid != null &&
         _cachedGridCols == cols &&
@@ -1161,61 +1165,7 @@ class _SystemCardGridViewState extends State<SystemCardGridView> {
       return _cachedVirtualGrid!;
     }
 
-    final List<List<int>> grid = [];
-
-    // 'Recent Games' cards expand to 3x2 on high-resolution displays.
-    int getSpanW(SystemInfo card) => (card.isGame && cols >= 3) ? 3 : 1;
-    int getSpanH(SystemInfo card) => (card.isGame && cols >= 3) ? 2 : 1;
-
-    for (int i = 0; i < cards.length; i++) {
-      final card = cards[i];
-      final w = getSpanW(card);
-      final h = getSpanH(card);
-
-      // Recursive scan for the first available spatial slot that fits the component spans.
-      int foundRow = 0;
-      int foundCol = 0;
-      bool fits = false;
-
-      while (!fits) {
-        while (grid.length <= foundRow + h - 1) {
-          grid.add(List<int>.filled(cols, -1));
-        }
-
-        if (foundCol + w <= cols) {
-          bool overlap = false;
-          for (int r = foundRow; r < foundRow + h; r++) {
-            for (int c = foundCol; c < foundCol + w; c++) {
-              if (grid[r][c] != -1) {
-                overlap = true;
-                break;
-              }
-            }
-            if (overlap) break;
-          }
-
-          if (!overlap) {
-            fits = true;
-          } else {
-            foundCol++;
-            if (foundCol >= cols) {
-              foundCol = 0;
-              foundRow++;
-            }
-          }
-        } else {
-          foundCol = 0;
-          foundRow++;
-        }
-      }
-
-      // Commit the spatial allocation to the grid matrix.
-      for (int r = foundRow; r < foundRow + h; r++) {
-        for (int c = foundCol; c < foundCol + w; c++) {
-          grid[r][c] = i;
-        }
-      }
-    }
+    final grid = buildVirtualGrid(cards, cols);
 
     _cachedVirtualGrid = grid;
     _cachedGridCols = cols;
@@ -1256,7 +1206,7 @@ class _SystemCardGridViewState extends State<SystemCardGridView> {
           targetRow = (targetRow - 1 + grid.length) % grid.length;
           idx = grid[targetRow][curCol.clamp(0, cols - 1)];
           if (idx == -1) {
-            idx = _findNearestInRow(grid, targetRow, curCol.clamp(0, cols - 1));
+            idx = findNearestInRow(grid, targetRow, curCol.clamp(0, cols - 1));
           }
           safety++;
         }
@@ -1269,7 +1219,7 @@ class _SystemCardGridViewState extends State<SystemCardGridView> {
           targetRow = (targetRow + 1) % grid.length;
           idx = grid[targetRow][curCol.clamp(0, cols - 1)];
           if (idx == -1) {
-            idx = _findNearestInRow(grid, targetRow, curCol.clamp(0, cols - 1));
+            idx = findNearestInRow(grid, targetRow, curCol.clamp(0, cols - 1));
           }
           safety++;
         }
@@ -1315,50 +1265,17 @@ class _SystemCardGridViewState extends State<SystemCardGridView> {
     }
   }
 
-  /// Spatial search for the nearest neighbor in a row with potential layout gaps.
-  int _findNearestInRow(List<List<int>> grid, int row, int col) {
-    final rowItems = grid[row];
-    final cols = rowItems.length;
-
-    for (int dist = 1; dist < cols; dist++) {
-      if (col - dist >= 0 && rowItems[col - dist] != -1) {
-        return rowItems[col - dist];
-      }
-      if (col + dist < cols && rowItems[col + dist] != -1) {
-        return rowItems[col + dist];
-      }
-    }
-    return -1;
-  }
-
-  /// Dynamically computes grid layout dimensions based on viewport constraints.
+  /// Resolves the live viewport width (net of the outer inset) and delegates to
+  /// the pure [calculateGridDimensions]. [customWidth], when supplied (e.g. from
+  /// a `LayoutBuilder`'s constraints), is used as-is without the inset.
   Map<String, double> _calculateGridDimensions([double? customWidth]) {
     final screenWidth =
         customWidth ?? (MediaQuery.of(context).size.width - 12.0.r);
-    final crossAxisSpacing = 6.0.r;
-    final mainAxisSpacing = 6.0.r;
-
-    final totalSpacing = crossAxisSpacing * (_cols - 1);
-    final availableWidth = screenWidth - totalSpacing;
-    final itemWidth = availableWidth / _cols;
-
-    // For game cards (childAspectRatio = 1) use traditional square calculation.
-    // For system cards (childAspectRatio != 1) add extra height for logo footer.
-    final double itemHeight;
-    if (widget.childAspectRatio != 1) {
-      itemHeight = itemWidth + 32.r;
-    } else {
-      itemHeight = itemWidth / widget.childAspectRatio;
-    }
-    final rowHeight = itemHeight + mainAxisSpacing;
-
-    return {
-      'itemWidth': itemWidth,
-      'itemHeight': itemHeight,
-      'rowHeight': rowHeight,
-      'crossAxisSpacing': crossAxisSpacing,
-      'mainAxisSpacing': mainAxisSpacing,
-    };
+    return calculateGridDimensions(
+      screenWidth: screenWidth,
+      cols: _cols,
+      childAspectRatio: widget.childAspectRatio,
+    );
   }
 
   /// Automatically adjusts scroll position to keep the selected item centered in the viewport.

--- a/test/grid_geometry_test.dart
+++ b/test/grid_geometry_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/models/my_systems.dart';
+import 'package:neostation/screens/systems_screen/my_systems_section/grid_geometry.dart';
+
+/// Net-new coverage for the pure grid-layout helpers extracted from
+/// `_MySystemsGridState`. These lock in the spatial-packing and
+/// nearest-neighbor behavior so future refactors can't silently drift it.
+void main() {
+  SystemInfo system() => SystemInfo();
+  SystemInfo game() => SystemInfo(isGame: true);
+
+  List<SystemInfo> systems(int n) => List.generate(n, (_) => system());
+
+  group('buildVirtualGrid', () {
+    test('empty card list produces an empty grid', () {
+      expect(buildVirtualGrid(const [], 4), isEmpty);
+    });
+
+    test(
+      'single-cell cards fill row-major with -1 padding on the last row',
+      () {
+        final grid = buildVirtualGrid(systems(6), 4);
+        expect(grid, [
+          [0, 1, 2, 3],
+          [4, 5, -1, -1],
+        ]);
+      },
+    );
+
+    test('exact multiple of cols leaves no padding', () {
+      final grid = buildVirtualGrid(systems(4), 2);
+      expect(grid, [
+        [0, 1],
+        [2, 3],
+      ]);
+    });
+
+    test('game card expands to a 3x2 block when cols >= 3', () {
+      final grid = buildVirtualGrid([game()], 3);
+      expect(grid, [
+        [0, 0, 0],
+        [0, 0, 0],
+      ]);
+    });
+
+    test('game card stays 1x1 when cols < 3', () {
+      final grid = buildVirtualGrid([game(), system()], 2);
+      expect(grid, [
+        [0, 1],
+      ]);
+    });
+
+    test('first-fit stacks single cells below a leading game block', () {
+      // Game occupies rows 0-1 fully (cols 0-2); the systems can't fit beside
+      // it so they land on row 2 onward.
+      final grid = buildVirtualGrid([game(), system(), system()], 3);
+      expect(grid, [
+        [0, 0, 0],
+        [0, 0, 0],
+        [1, 2, -1],
+      ]);
+    });
+  });
+
+  group('findNearestInRow', () {
+    test('finds the nearest occupant expanding outward from col', () {
+      final grid = [
+        [-1, 5, -1, 7],
+      ];
+      expect(findNearestInRow(grid, 0, 0), 5);
+    });
+
+    test('prefers the left neighbor on a distance tie', () {
+      final grid = [
+        [3, -1, 9, -1],
+      ];
+      expect(findNearestInRow(grid, 0, 1), 3);
+    });
+
+    test('returns -1 for a fully empty row', () {
+      final grid = [
+        [-1, -1, -1],
+      ];
+      expect(findNearestInRow(grid, 0, 1), -1);
+    });
+  });
+}


### PR DESCRIPTION
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Description

Phase 2 of the oversized-file refactor campaign (follows #128/#129/#130/#131). Extracts the pure spatial-layout math out of the 1,800-line `_MySystemsGridState` into a standalone, unit-testable module — **zero behavior change, no public-API change.**

`_MySystemsGridState` mixes gamepad grid navigation, pinch-zoom, pull-to-refresh, theming, and the underlying **grid geometry** (virtual-grid packing, nearest-neighbour search, item/row dimensions). That math was only reachable through a live widget, so it had no test coverage. This moves it to top-level pure functions and adds that coverage.

**Changes**
- New `my_systems_section/grid_geometry.dart` with three top-level pure functions, bodies copied verbatim from the state class:
  - `buildVirtualGrid(cards, cols)` — the first-fit spatial packer (game cards span 3×2 on wide grids).
  - `findNearestInRow(grid, row, col)` — nearest-occupant search across layout gaps.
  - `calculateGridDimensions({screenWidth, cols, childAspectRatio})` — item/row sizing.
- Host `my_systems_grid.dart`:
  - `_buildVirtualGrid` stays as a **thin memoized wrapper** — the `_cachedVirtualGrid`/`_cachedGridCols`/`_cachedGridSystemCount` cache remains in the widget, delegating the compute to `buildVirtualGrid`.
  - `_calculateGridDimensions([customWidth])` resolves the live `MediaQuery`/`_cols`/`childAspectRatio` (preserving the exact inset-vs-custom-width behaviour) then delegates.
  - The two `_findNearestInRow(...)` call sites now call the top-level function; the private copy is removed.
- New `test/grid_geometry_test.dart` — **9 net-new tests** pinning row-major fill + `-1` padding, the game-card 3×2 span (`cols >= 3`) vs 1×1 fallback, first-fit stacking below a leading game block, and the nearest-in-row tie/empty cases.

Host `my_systems_grid.dart`: **1,804 → 1,721 lines**. No call site outside the wrappers changed; gamepad nav, pinch-zoom, pull-to-refresh, and theming paths are untouched.

Fixes # (issue): n/a

## Type of Change

- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors. (*No issues found* project-wide)
- [x] I have added tests demonstrating that my fix or feature works. (9 net-new geometry tests; full suite **207/207**)
- [ ] I have updated the corresponding documentation. (n/a — no behaviour/API change)
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. (n/a — no assets)
- [ ] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [ ] Android
- [x] **Gamepad support verified** (if applicable). (nav logic unchanged; grid-nav smoke pending on-device)

## Screenshots (if applicable)

n/a — no visual change (pure logic extraction).
