### PR TITLE
style: dart format 5 drifted files to restore release format gate

### DIFF
--- a/lib/screens/game_screen/game_details_card/game_details_card_list.dart
+++ b/lib/screens/game_screen/game_details_card/game_details_card_list.dart
@@ -106,8 +106,6 @@ class GameDetailsCardList extends StatefulWidget {
   final bool isNavigatingFast;
   final VoidCallback? onBack;
 
- 
-
   const GameDetailsCardList({
     super.key,
     required this.game,
@@ -785,89 +783,89 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
     return Card(
       color: Colors.transparent,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(0.r)),
-        shadowColor: Colors.transparent,
-        child: Stack(
-          fit: StackFit.expand,
-          children: [
-            // Header Layer: Tab navigation and system status.
-            Positioned(
-              left: 0.r,
-              right: 0.r,
-              top: 0.r,
-              child: GameDetailsTabsHeader(
-                isGameInfoHidden: _isGameInfoHidden,
-                hasRetroAchievements: _hasRetroAchievements,
-                showSettings: _effectiveSystem.folderName != 'android',
-                currentTab: _currentTab,
-                onTabChanged: (tab) => _setTab(tab),
-              ),
+      shadowColor: Colors.transparent,
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          // Header Layer: Tab navigation and system status.
+          Positioned(
+            left: 0.r,
+            right: 0.r,
+            top: 0.r,
+            child: GameDetailsTabsHeader(
+              isGameInfoHidden: _isGameInfoHidden,
+              hasRetroAchievements: _hasRetroAchievements,
+              showSettings: _effectiveSystem.folderName != 'android',
+              currentTab: _currentTab,
+              onTabChanged: (tab) => _setTab(tab),
             ),
+          ),
 
-            // Footer Layer: Action bar and synchronization status.
-            GameDetailsFooter(
+          // Footer Layer: Action bar and synchronization status.
+          GameDetailsFooter(
+            system: _effectiveSystem,
+            game: _game,
+            isMusicSystem: _effectiveSystem.folderName == 'music',
+            hasScreenScraper: _hasScreenScraper,
+            isSecondaryScreenActive: widget.isSecondaryScreenActive,
+            cloudSyncEnabled: _cloudSyncEnabled,
+            syncProvider: widget.syncProvider,
+            syncIconController: _syncIconController,
+            onPlayGame: () => widget.onPlayGame?.call(),
+            onShowAchievements: () => _setTab(DetailTab.achievements),
+            hasRetroAchievements: _hasRetroAchievements,
+            isLoadingAchievements: _isLoadingAchievements,
+            currentGameInfo: _currentGameInfo,
+          ),
+
+          // Dynamic Content Layer: Selected Tab View.
+          if (_currentTab == DetailTab.general)
+            GameDetailsGeneralTab(
               system: _effectiveSystem,
               game: _game,
-              isMusicSystem: _effectiveSystem.folderName == 'music',
-              hasScreenScraper: _hasScreenScraper,
-              isSecondaryScreenActive: widget.isSecondaryScreenActive,
-              cloudSyncEnabled: _cloudSyncEnabled,
-              syncProvider: widget.syncProvider,
-              syncIconController: _syncIconController,
-              onPlayGame: () => widget.onPlayGame?.call(),
-              onShowAchievements: () => _setTab(DetailTab.achievements),
-              hasRetroAchievements: _hasRetroAchievements,
-              isLoadingAchievements: _isLoadingAchievements,
-              currentGameInfo: _currentGameInfo,
+              fileProvider: widget.fileProvider,
+              androidAppIconFuture: _androidAppIconFuture,
             ),
-
-            // Dynamic Content Layer: Selected Tab View.
-            if (_currentTab == DetailTab.general)
-              GameDetailsGeneralTab(
-                system: _effectiveSystem,
-                game: _game,
-                fileProvider: widget.fileProvider,
-                androidAppIconFuture: _androidAppIconFuture,
-              ),
-            if (_currentTab == DetailTab.gameInfo)
-              GameDetailsGameInfoTab(
-                system: _effectiveSystem,
-                game: _game,
-                fileProvider: widget.fileProvider,
-                description:
-                    widget.localizedDescription ??
-                    (_game.getDescriptionForLanguage('en').isEmpty
-                        ? AppLocale.noDescription.getString(context)
-                        : _game.getDescriptionForLanguage('en')),
-                screenshotPath: screenshotPath,
-                isScrapingGame: _isScrapingGame || widget.isExternallyScraping,
-                scrapeProgress: _scrapeProgress,
-                scrapeStatus: _scrapeStatus,
-                isSecondaryScreenActive: widget.isSecondaryScreenActive,
-                isVideoDelayActive: _isVideoDelayActive,
-                videoController: widget.videoController,
-                imageVersion: _imageVersion,
-                onToggleVideoMute: _toggleVideoMute,
-                onScrapeGame: _onScrapeGameCompact,
-              ),
-            if (_currentTab == DetailTab.settings)
-              GameDetailsSettingsTab(
-                key: _settingsTabKey,
-                game: _game,
-                system: _effectiveSystem,
-                syncProvider: widget.syncProvider,
-                isAllMode: widget.isAllMode,
-                onGameUpdated: widget.onGameUpdated,
-                onGameDeleted: widget.onGameDeleted,
-              ),
-            if (_currentTab == DetailTab.achievements)
-              GameDetailsAchievementsTab(
-                key: _achievementsTabKey,
-                gameInfo: _currentGameInfo,
-                isLoading: _isLoadingAchievements,
-                onRefresh: refreshAchievements,
-              ),
-          ],
-        ),
+          if (_currentTab == DetailTab.gameInfo)
+            GameDetailsGameInfoTab(
+              system: _effectiveSystem,
+              game: _game,
+              fileProvider: widget.fileProvider,
+              description:
+                  widget.localizedDescription ??
+                  (_game.getDescriptionForLanguage('en').isEmpty
+                      ? AppLocale.noDescription.getString(context)
+                      : _game.getDescriptionForLanguage('en')),
+              screenshotPath: screenshotPath,
+              isScrapingGame: _isScrapingGame || widget.isExternallyScraping,
+              scrapeProgress: _scrapeProgress,
+              scrapeStatus: _scrapeStatus,
+              isSecondaryScreenActive: widget.isSecondaryScreenActive,
+              isVideoDelayActive: _isVideoDelayActive,
+              videoController: widget.videoController,
+              imageVersion: _imageVersion,
+              onToggleVideoMute: _toggleVideoMute,
+              onScrapeGame: _onScrapeGameCompact,
+            ),
+          if (_currentTab == DetailTab.settings)
+            GameDetailsSettingsTab(
+              key: _settingsTabKey,
+              game: _game,
+              system: _effectiveSystem,
+              syncProvider: widget.syncProvider,
+              isAllMode: widget.isAllMode,
+              onGameUpdated: widget.onGameUpdated,
+              onGameDeleted: widget.onGameDeleted,
+            ),
+          if (_currentTab == DetailTab.achievements)
+            GameDetailsAchievementsTab(
+              key: _achievementsTabKey,
+              gameInfo: _currentGameInfo,
+              isLoading: _isLoadingAchievements,
+              onRefresh: refreshAchievements,
+            ),
+        ],
+      ),
     );
   }
 
@@ -892,7 +890,6 @@ class _GameDetailsCardListState extends State<GameDetailsCardList>
   }
 
   /// Renders the background fanart with smooth cross-fades and scale animations.
-  
 
   /// Directs primary gamepad inputs (A Button) based on the currently active tab.
   void _handleTriggerAction() {

--- a/lib/screens/game_screen/game_details_card/tabs/game_details_general_tab.dart
+++ b/lib/screens/game_screen/game_details_card/tabs/game_details_general_tab.dart
@@ -64,7 +64,9 @@ class GameDetailsGeneralTab extends StatelessWidget {
                           filterQuality: FilterQuality.low,
                           cacheWidth: 256,
                           isAntiAlias: false,
-                          color: Theme.of(context).colorScheme.shadow.withValues(alpha: 0.5),
+                          color: Theme.of(
+                            context,
+                          ).colorScheme.shadow.withValues(alpha: 0.5),
                           height: 140.r,
                           width: 280.r,
                         )
@@ -80,7 +82,9 @@ class GameDetailsGeneralTab extends StatelessWidget {
                                 snapshot.data!,
                                 fit: BoxFit.contain,
                                 filterQuality: FilterQuality.low,
-                                color: Theme.of(context).colorScheme.shadow.withValues(alpha: 0.7),
+                                color: Theme.of(
+                                  context,
+                                ).colorScheme.shadow.withValues(alpha: 0.7),
                                 cacheWidth: 32,
                                 height: 60.r,
                                 width: 60.r,

--- a/lib/screens/game_screen/game_details_card/widgets/game_details_footer.dart
+++ b/lib/screens/game_screen/game_details_card/widgets/game_details_footer.dart
@@ -461,10 +461,9 @@ class GameDetailsFooter extends StatelessWidget {
         ? theme.colorScheme.onSurface
         : Colors.orange;
 
-    final String? gameIconUrl =
-        currentGameInfo?.imageIcon.isNotEmpty == true
-            ? 'https://media.retroachievements.org${currentGameInfo!.imageIcon}'
-            : null;
+    final String? gameIconUrl = currentGameInfo?.imageIcon.isNotEmpty == true
+        ? 'https://media.retroachievements.org${currentGameInfo!.imageIcon}'
+        : null;
 
     return Material(
       color: Colors.transparent,
@@ -546,8 +545,9 @@ class GameDetailsFooter extends StatelessWidget {
                           minHeight: 5.r,
                           backgroundColor: theme.colorScheme.onSurface
                               .withValues(alpha: 0.1),
-                          valueColor:
-                              AlwaysStoppedAnimation<Color>(statusColor),
+                          valueColor: AlwaysStoppedAnimation<Color>(
+                            statusColor,
+                          ),
                         ),
                       ),
                     ],

--- a/lib/screens/game_screen/game_details_card/widgets/game_details_tabs_header.dart
+++ b/lib/screens/game_screen/game_details_card/widgets/game_details_tabs_header.dart
@@ -65,11 +65,16 @@ class GameDetailsTabsHeader extends StatelessWidget {
               padding: EdgeInsets.symmetric(horizontal: 8.r),
               decoration: BoxDecoration(
                 color: theme.colorScheme.surface,
-                borderRadius: Theme.of(context).extension<CornerRadii>()?.radiusExternal ??
-                BorderRadius.circular(12.r),
+                borderRadius:
+                    Theme.of(
+                      context,
+                    ).extension<CornerRadii>()?.radiusExternal ??
+                    BorderRadius.circular(12.r),
                 boxShadow: [
                   BoxShadow(
-                    color: Theme.of(context).colorScheme.shadow.withValues(alpha: 0.25),
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.shadow.withValues(alpha: 0.25),
                     blurRadius: 2.r,
                     offset: Offset(2.0.r, 2.0.r),
                   ),
@@ -103,8 +108,10 @@ class GameDetailsTabsHeader extends StatelessWidget {
                               decoration: BoxDecoration(
                                 color: theme.colorScheme.primary,
                                 borderRadius:
-                                  Theme.of(context).extension<CornerRadii>()?.radiusInternal ??
-                                  BorderRadius.circular(14.r),
+                                    Theme.of(context)
+                                        .extension<CornerRadii>()
+                                        ?.radiusInternal ??
+                                    BorderRadius.circular(14.r),
                               ),
                             ),
                           ),

--- a/lib/widgets/header.dart
+++ b/lib/widgets/header.dart
@@ -70,7 +70,9 @@ class HeaderState extends State<Header> {
   /// Subscribes to real-time battery state changes (charging/discharging/full).
   void _listenToBatteryState() {
     try {
-      _batteryStateSubscription = _battery.onBatteryStateChanged.listen((state) {
+      _batteryStateSubscription = _battery.onBatteryStateChanged.listen((
+        state,
+      ) {
         if (mounted) {
           setState(() => _batteryState = state);
         }


### PR DESCRIPTION
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Description

Restores the release **format gate** to green. The release `lint` job runs `dart format --set-exit-if-changed .`, and `build` `needs: lint` — so an unformatted file blocks the next release build. Five files had drifted unformatted onto `main` via recent merges:

- `lib/screens/game_screen/game_details_card/game_details_card_list.dart`
- `lib/screens/game_screen/game_details_card/tabs/game_details_general_tab.dart`
- `lib/screens/game_screen/game_details_card/widgets/game_details_footer.dart`
- `lib/screens/game_screen/game_details_card/widgets/game_details_tabs_header.dart`
- `lib/widgets/header.dart`

This runs `dart format` on exactly those five files; no other file changes, and the repo-wide `dart format --set-exit-if-changed .` now passes.

**Safety:** every non-whitespace change is pure formatter reflow — multi-line wrapping of `Theme.of(context)` chains and single-arg calls, plus removal of stray blank lines. No semantic change. None of the five carried a line-scoped `// ignore` directive (the failure mode from #128→#130), so reflow can't silently break a suppression. `flutter analyze` is clean project-wide and the suite is **198/198**.

Fixes # (issue): n/a — release-gate hygiene.

## Type of Change

- [x] Code refactoring (formatting only)

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works. (n/a — formatting only; suite stays 198/198)
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. (n/a)
- [ ] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [ ] Android (n/a — no runtime change)
- [x] **Gamepad support verified** (if applicable). (n/a — no behavior change)

## Screenshots (if applicable)

n/a — whitespace-only change.
