### PR TITLE
refactor(systems-grid): promote grid loading/empty states to widgets

### DIFF
--- a/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 import 'dart:async';
 import 'package:flutter/material.dart';
-import 'package:material_symbols_icons/symbols.dart';
 import 'package:neostation/l10n/app_locale.dart';
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:neostation/responsive.dart';
@@ -22,6 +21,8 @@ import '../../../widgets/system_scan_progress_widget.dart';
 import '../../game_screen/my_games_list.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'grid_geometry.dart';
+import 'widgets/grid_loading_state.dart';
+import 'widgets/grid_empty_state.dart';
 import 'my_systems_carousel.dart';
 import 'package:neostation/widgets/custom_notification.dart';
 import 'package:neostation/widgets/system_emulator_settings_dialog.dart';
@@ -70,12 +71,12 @@ class MySystems extends StatelessWidget {
           // PHASE 1: Blocking Initialization.
           // If a high-priority system scan is active (e.g., first run), show a blocking status.
           if (configProvider.isGlobalScanning) {
-            return _buildLoadingState(context);
+            return const GridLoadingState();
           }
 
           // PHASE 2: Empty Library State.
           if (!configProvider.hasDetectedSystems) {
-            return _buildEmptyState(context, configProvider);
+            return GridEmptyState(configProvider: configProvider);
           }
 
           // PHASE 3: Content Presentation.
@@ -130,232 +131,6 @@ class MySystems extends StatelessWidget {
 
           return systemsWidget;
         },
-      ),
-    );
-  }
-
-  /// Renders a premium loading interface for the initial library setup.
-  Widget _buildLoadingState(BuildContext context) {
-    return Center(
-      child: Container(
-        constraints: const BoxConstraints(maxWidth: 400),
-        padding: const EdgeInsets.all(32),
-        margin: const EdgeInsets.symmetric(horizontal: 16),
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            colors: [
-              Theme.of(context).colorScheme.surface,
-              Theme.of(context).colorScheme.surface.withValues(alpha: 0.95),
-            ],
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-          ),
-          borderRadius: BorderRadius.circular(14.r),
-          border: Border.all(
-            color: Theme.of(
-              context,
-            ).colorScheme.primary.withValues(alpha: 0.15),
-            width: 1,
-          ),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withValues(alpha: 0.1),
-              blurRadius: 16.r,
-              offset: const Offset(0, 4),
-            ),
-          ],
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            // Dynamic branding icon with atmospheric glow.
-            Container(
-              padding: EdgeInsets.all(14),
-              decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.primary,
-                borderRadius:
-                    Theme.of(
-                      context,
-                    ).extension<CornerRadii>()?.radiusInternal ??
-                    BorderRadius.circular(12.r),
-                boxShadow: [
-                  BoxShadow(
-                    color: Theme.of(
-                      context,
-                    ).colorScheme.primary.withValues(alpha: 0.3),
-                    blurRadius: 12,
-                    offset: const Offset(0, 2),
-                  ),
-                ],
-              ),
-              child: const Icon(
-                Symbols.sync_rounded,
-                color: Colors.white,
-                size: 32,
-              ),
-            ),
-            const SizedBox(height: 24),
-            Text(
-              AppLocale.settingUpLibrary.getString(context),
-              style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                fontWeight: FontWeight.bold,
-                color: Theme.of(context).colorScheme.onSurface,
-              ),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 8),
-            Text(
-              AppLocale.detectingSystems.getString(context),
-              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                color: Theme.of(
-                  context,
-                ).colorScheme.onSurface.withValues(alpha: 0.7),
-              ),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 24),
-            SystemScanProgressWidget(),
-          ],
-        ),
-      ),
-    );
-  }
-
-  /// Renders the 'Empty State' view with clear CTA for library configuration.
-  Widget _buildEmptyState(
-    BuildContext context,
-    SqliteConfigProvider configProvider,
-  ) {
-    return Center(
-      child: Container(
-        constraints: const BoxConstraints(maxWidth: 400),
-        padding: const EdgeInsets.all(32),
-        margin: const EdgeInsets.symmetric(horizontal: 16),
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            colors: [
-              Theme.of(context).colorScheme.surface,
-              Theme.of(context).colorScheme.surface.withValues(alpha: 0.95),
-            ],
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-          ),
-          borderRadius: BorderRadius.circular(16.r),
-          border: Border.all(
-            color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
-            width: 1,
-          ),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withValues(alpha: 0.1),
-              blurRadius: 16,
-              offset: const Offset(0, 4),
-            ),
-          ],
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Container(
-              padding: const EdgeInsets.all(16),
-              decoration: BoxDecoration(
-                color: Theme.of(
-                  context,
-                ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
-                borderRadius: BorderRadius.circular(12.r),
-              ),
-              child: SizedBox(
-                width: 48,
-                height: 48,
-                child: Image.asset(
-                  'assets/images/icons/folder-add-bulk.png',
-                  color: Theme.of(
-                    context,
-                  ).colorScheme.onSurface.withValues(alpha: 0.5),
-                ),
-              ),
-            ),
-            const SizedBox(height: 24),
-            Text(
-              configProvider.hasRomFolders
-                  ? AppLocale.noSystemsFoundTitle.getString(context)
-                  : AppLocale.welcomeNeoStation.getString(context),
-              style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                fontWeight: FontWeight.bold,
-                color: Theme.of(context).colorScheme.onSurface,
-              ),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 8),
-            Text(
-              configProvider.hasRomFolders
-                  ? AppLocale.noSystemsFoundDesc.getString(context)
-                  : AppLocale.selectRomFolderDescShort.getString(context),
-              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                color: Theme.of(
-                  context,
-                ).colorScheme.onSurface.withValues(alpha: 0.7),
-              ),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 24),
-            // Primary Call to Action Button.
-            Container(
-              decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.primary,
-                borderRadius: BorderRadius.circular(8.r),
-                boxShadow: [
-                  BoxShadow(
-                    color: Theme.of(
-                      context,
-                    ).colorScheme.primary.withValues(alpha: 0.3),
-                    blurRadius: 8,
-                    offset: const Offset(0, 2),
-                  ),
-                ],
-              ),
-              child: Material(
-                color: Colors.transparent,
-                child: InkWell(
-                  canRequestFocus: false,
-                  focusColor: Colors.transparent,
-                  hoverColor: Colors.transparent,
-                  highlightColor: Colors.transparent,
-                  splashColor: Colors.transparent,
-                  borderRadius: BorderRadius.circular(8.r),
-                  onTap: () {
-                    SfxService().playEnterSound();
-                    configProvider.selectRomFolder(context: context);
-                  },
-                  child: Container(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 20,
-                      vertical: 12,
-                    ),
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        const Icon(
-                          Symbols.folder_rounded,
-                          color: Colors.white,
-                          size: 20,
-                        ),
-                        const SizedBox(width: 8),
-                        Text(
-                          AppLocale.selectRomFolderButton.getString(context),
-                          style: const TextStyle(
-                            color: Colors.white,
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
       ),
     );
   }

--- a/lib/screens/systems_screen/my_systems_section/widgets/grid_empty_state.dart
+++ b/lib/screens/systems_screen/my_systems_section/widgets/grid_empty_state.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
+import 'package:flutter_localization/flutter_localization.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:neostation/l10n/app_locale.dart';
+import 'package:neostation/services/sfx_service.dart';
+import '../../../../providers/sqlite_config_provider.dart';
+
+/// Renders the 'Empty State' view with a clear CTA for library configuration.
+///
+/// Extracted verbatim from `MySystems._buildEmptyState` so the systems grid
+/// host stays lean; behavior and layout are unchanged. The [configProvider] is
+/// passed in (already read by the host) rather than re-resolved here.
+class GridEmptyState extends StatelessWidget {
+  const GridEmptyState({super.key, required this.configProvider});
+
+  final SqliteConfigProvider configProvider;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Container(
+        constraints: const BoxConstraints(maxWidth: 400),
+        padding: const EdgeInsets.all(32),
+        margin: const EdgeInsets.symmetric(horizontal: 16),
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            colors: [
+              Theme.of(context).colorScheme.surface,
+              Theme.of(context).colorScheme.surface.withValues(alpha: 0.95),
+            ],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+          borderRadius: BorderRadius.circular(16.r),
+          border: Border.all(
+            color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
+            width: 1,
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.1),
+              blurRadius: 16,
+              offset: const Offset(0, 4),
+            ),
+          ],
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: Theme.of(
+                  context,
+                ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
+                borderRadius: BorderRadius.circular(12.r),
+              ),
+              child: SizedBox(
+                width: 48,
+                height: 48,
+                child: Image.asset(
+                  'assets/images/icons/folder-add-bulk.png',
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.onSurface.withValues(alpha: 0.5),
+                ),
+              ),
+            ),
+            const SizedBox(height: 24),
+            Text(
+              configProvider.hasRomFolders
+                  ? AppLocale.noSystemsFoundTitle.getString(context)
+                  : AppLocale.welcomeNeoStation.getString(context),
+              style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: Theme.of(context).colorScheme.onSurface,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              configProvider.hasRomFolders
+                  ? AppLocale.noSystemsFoundDesc.getString(context)
+                  : AppLocale.selectRomFolderDescShort.getString(context),
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: Theme.of(
+                  context,
+                ).colorScheme.onSurface.withValues(alpha: 0.7),
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            // Primary Call to Action Button.
+            Container(
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.primary,
+                borderRadius: BorderRadius.circular(8.r),
+                boxShadow: [
+                  BoxShadow(
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.primary.withValues(alpha: 0.3),
+                    blurRadius: 8,
+                    offset: const Offset(0, 2),
+                  ),
+                ],
+              ),
+              child: Material(
+                color: Colors.transparent,
+                child: InkWell(
+                  canRequestFocus: false,
+                  focusColor: Colors.transparent,
+                  hoverColor: Colors.transparent,
+                  highlightColor: Colors.transparent,
+                  splashColor: Colors.transparent,
+                  borderRadius: BorderRadius.circular(8.r),
+                  onTap: () {
+                    SfxService().playEnterSound();
+                    configProvider.selectRomFolder(context: context);
+                  },
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 20,
+                      vertical: 12,
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        const Icon(
+                          Symbols.folder_rounded,
+                          color: Colors.white,
+                          size: 20,
+                        ),
+                        const SizedBox(width: 8),
+                        Text(
+                          AppLocale.selectRomFolderButton.getString(context),
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/systems_screen/my_systems_section/widgets/grid_loading_state.dart
+++ b/lib/screens/systems_screen/my_systems_section/widgets/grid_loading_state.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
+import 'package:flutter_localization/flutter_localization.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:neostation/l10n/app_locale.dart';
+import 'package:neostation/widgets/system_scan_progress_widget.dart';
+import '../../../../themes/corner_radii.dart';
+
+/// Renders a premium loading interface for the initial library setup.
+///
+/// Extracted verbatim from `MySystems._buildLoadingState` so the systems grid
+/// host stays lean; behavior and layout are unchanged.
+class GridLoadingState extends StatelessWidget {
+  const GridLoadingState({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Container(
+        constraints: const BoxConstraints(maxWidth: 400),
+        padding: const EdgeInsets.all(32),
+        margin: const EdgeInsets.symmetric(horizontal: 16),
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            colors: [
+              Theme.of(context).colorScheme.surface,
+              Theme.of(context).colorScheme.surface.withValues(alpha: 0.95),
+            ],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+          borderRadius: BorderRadius.circular(14.r),
+          border: Border.all(
+            color: Theme.of(
+              context,
+            ).colorScheme.primary.withValues(alpha: 0.15),
+            width: 1,
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.1),
+              blurRadius: 16.r,
+              offset: const Offset(0, 4),
+            ),
+          ],
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Dynamic branding icon with atmospheric glow.
+            Container(
+              padding: EdgeInsets.all(14),
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.primary,
+                borderRadius:
+                    Theme.of(
+                      context,
+                    ).extension<CornerRadii>()?.radiusInternal ??
+                    BorderRadius.circular(12.r),
+                boxShadow: [
+                  BoxShadow(
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.primary.withValues(alpha: 0.3),
+                    blurRadius: 12,
+                    offset: const Offset(0, 2),
+                  ),
+                ],
+              ),
+              child: const Icon(
+                Symbols.sync_rounded,
+                color: Colors.white,
+                size: 32,
+              ),
+            ),
+            const SizedBox(height: 24),
+            Text(
+              AppLocale.settingUpLibrary.getString(context),
+              style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: Theme.of(context).colorScheme.onSurface,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              AppLocale.detectingSystems.getString(context),
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                color: Theme.of(
+                  context,
+                ).colorScheme.onSurface.withValues(alpha: 0.7),
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            SystemScanProgressWidget(),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Description

Phase 2 (widget promotions) continuation of the oversized-file refactor campaign. Extracts the two clean, input-driven UI subtrees from `MySystems` in `my_systems_grid.dart` into reusable `const` widgets under `my_systems_section/widgets/`:

- **`GridLoadingState`** — the initial-library-setup loading card (was `MySystems._buildLoadingState`, no inputs).
- **`GridEmptyState`** — the empty-library CTA card (was `MySystems._buildEmptyState`); takes the already-read `configProvider` passed down from the host rather than re-resolving it, so Provider/context semantics are byte-for-byte identical.

Widget bodies are copied **verbatim** — pure cut/paste. Host `my_systems_grid.dart` shrinks **1721 → 1496 lines** and drops the now-unused `material_symbols_icons` import. No public-API or behavior change.

Fixes # (issue) — N/A (code-health refactor)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors. (No issues found, project-wide)
- [ ] I have added tests demonstrating that my fix or feature works. (N/A — pure UI-subtree move, no logic change; full suite stays green at 207/207)
- [ ] I have updated the corresponding documentation. (N/A)
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses. (no new assets)
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable). (grid nav unaffected — these are non-focusable state cards; see smoke below)

## Screenshots (if applicable)

No visual change — identical render.

---

### Verification

- `dart format --set-exit-if-changed .` — clean (touched files).
- `flutter analyze` — **No issues found** project-wide.
- `flutter test` — **207/207** pass.
- On-device smoke: pending (empty state = fresh/no-ROM library; loading state = first-run scan).