### PR TITLE
refactor(secondary-screen): promote Now Playing panel to a widget

### DIFF
--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -19,6 +19,7 @@ import '../../utils/no_glow_scroll_behavior.dart';
 import 'background_builders.dart';
 import 'now_playing_helpers.dart';
 import 'widgets/app_dock.dart';
+import 'widgets/now_playing_panel.dart';
 
 class SecondaryScreen extends StatefulWidget {
   const SecondaryScreen({super.key});
@@ -1035,7 +1036,17 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                   ? _buildAchievementCommentsPage(_selectedAchievement!)
                   : page == 1
                   ? _buildAchievementPanel(value)
-                  : _buildNowPlayingPanel(value),
+                  : NowPlayingPanel(
+                      value: value,
+                      sessionRunning: _sessionWatch.isRunning,
+                      sessionTime: _formatSessionTime(),
+                      onRequestScreenshot: _requestScreenshot,
+                      onLaunchApp: _launchDockApp,
+                      onPickSlot: _openAppPicker,
+                      onClearSlot: _clearSlot,
+                      onOpenLauncher: _openAppLauncher,
+                      onOpenAccessibilitySettings: _openAccessibilitySettings,
+                    ),
             ),
           ),
         ),
@@ -1084,220 +1095,6 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
             ),
           ),
         ),
-      ),
-    );
-  }
-
-  /// Renders the "Now Playing" page: boxart, title, system, total play time
-  /// and last-played. Shown for every launched game (page 0). View-only.
-  Widget _buildNowPlayingPanel(SecondaryDisplayStateData value) {
-    final title = (value.gameTitle != null && value.gameTitle!.isNotEmpty)
-        ? value.gameTitle!
-        : value.systemName;
-    final scheme = panelScheme(value);
-
-    return Container(
-      width: double.infinity,
-      height: double.infinity,
-      color: scheme.surface,
-      child: Stack(
-        children: [
-          Padding(
-            padding: EdgeInsets.fromLTRB(44.r, 32.r, 44.r, 96.r),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                buildNowPlayingBoxart(value.gameBoxart),
-                SizedBox(width: 32.r),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Text(
-                        'NOW PLAYING',
-                        style: TextStyle(
-                          color: scheme.primary,
-                          fontSize: 14.r,
-                          fontWeight: FontWeight.w600,
-                          letterSpacing: 3.r,
-                        ),
-                      ),
-                      SizedBox(height: 12.r),
-                      Text(
-                        title,
-                        maxLines: 2,
-                        overflow: TextOverflow.ellipsis,
-                        style: TextStyle(
-                          color: scheme.onSurface,
-                          fontSize: 30.r,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                      SizedBox(height: 8.r),
-                      Text(
-                        value.systemName.toUpperCase(),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: TextStyle(
-                          color: scheme.onSurface.withValues(alpha: 0.7),
-                          fontSize: 16.r,
-                          letterSpacing: 1.5.r,
-                        ),
-                      ),
-                      SizedBox(height: 26.r),
-                      buildNowPlayingStat(
-                        scheme: scheme,
-                        icon: Symbols.schedule_rounded,
-                        label: 'PLAY TIME',
-                        text: formatPlayTime(value.playTimeSeconds),
-                      ),
-                      if (_sessionWatch.isRunning) ...[
-                        SizedBox(height: 12.r),
-                        buildNowPlayingStat(
-                          scheme: scheme,
-                          icon: Symbols.timer_rounded,
-                          label: 'SESSION',
-                          text: _formatSessionTime(),
-                        ),
-                      ],
-                      SizedBox(height: 12.r),
-                      buildNowPlayingStat(
-                        scheme: scheme,
-                        icon: Symbols.history_rounded,
-                        label: 'LAST PLAYED',
-                        text: formatLastPlayed(value.lastPlayedMillis),
-                      ),
-                      if (value.screenshotAccessEnabled) ...[
-                        SizedBox(height: 28.r),
-                        _buildScreenshotButton(scheme),
-                      ],
-                    ],
-                  ),
-                ),
-              ],
-            ),
-          ),
-          Positioned(
-            left: 0,
-            right: 0,
-            bottom: 0,
-            child: AppDock(
-              value: value,
-              onLaunchApp: _launchDockApp,
-              onPickSlot: _openAppPicker,
-              onClearSlot: _clearSlot,
-            ),
-          ),
-          // All-apps launcher pinned to the bottom-left corner.
-          if (value.dockEnabled)
-            Positioned(
-              left: 16.r,
-              bottom: 16.r,
-              child: _buildLauncherButton(value),
-            ),
-        ],
-      ),
-    );
-  }
-
-  /// Tappable pill that asks the main engine to capture a system screenshot of
-  /// the main screen.
-  Widget _buildScreenshotButton(ColorScheme scheme) {
-    return GestureDetector(
-      onTap: _requestScreenshot,
-      child: Container(
-        padding: EdgeInsets.symmetric(horizontal: 20.r, vertical: 12.r),
-        decoration: BoxDecoration(
-          color: scheme.onSurface.withValues(alpha: 0.08),
-          borderRadius: BorderRadius.circular(12.r),
-          border: Border.all(color: scheme.onSurface.withValues(alpha: 0.18)),
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(
-              Symbols.photo_camera_rounded,
-              color: scheme.onSurface,
-              size: 22.r,
-            ),
-            SizedBox(width: 12.r),
-            Text(
-              'SCREENSHOT',
-              style: TextStyle(
-                color: scheme.onSurface,
-                fontSize: 14.r,
-                fontWeight: FontWeight.w600,
-                letterSpacing: 2.r,
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  /// The app dock pinned to the bottom of the Now Playing page: a centered row
-  /// of [SecondaryDisplayStateData.dockSlotCount] slots (user setting). Tap a
-  /// filled slot to launch it, tap an empty slot to pick an app, long-press a
-  /// filled slot to clear it. Hidden entirely when the dock is disabled.
-  /// The all-apps launcher, pinned to the bottom-left of the Now Playing
-  /// screen. Normally opens the app picker in launch mode. When the Screen
-  /// Return accessibility service isn't enabled, it's highlighted with an
-  /// accent border + warning badge and instead opens accessibility settings —
-  /// launching an app without that service would strand the user with no way
-  /// back to Now Playing.
-  Widget _buildLauncherButton(SecondaryDisplayStateData value) {
-    final scheme = panelScheme(value);
-    final accessOk = value.screenshotAccessEnabled;
-    return GestureDetector(
-      onTap: accessOk ? _openAppLauncher : _openAccessibilitySettings,
-      child: Stack(
-        clipBehavior: Clip.none,
-        children: [
-          Container(
-            width: 56.r,
-            height: 56.r,
-            decoration: BoxDecoration(
-              color: accessOk
-                  ? scheme.onSurface.withValues(alpha: 0.05)
-                  : scheme.primary.withValues(alpha: 0.15),
-              borderRadius: BorderRadius.circular(14.r),
-              border: Border.all(
-                color: accessOk
-                    ? scheme.onSurface.withValues(alpha: 0.14)
-                    : scheme.primary,
-                width: accessOk ? 1.r : 2.r,
-              ),
-            ),
-            child: Icon(
-              Symbols.apps_rounded,
-              color: accessOk
-                  ? scheme.onSurface.withValues(alpha: 0.65)
-                  : scheme.primary,
-              size: 28.r,
-            ),
-          ),
-          if (!accessOk)
-            Positioned(
-              top: -4.r,
-              right: -4.r,
-              child: Container(
-                width: 20.r,
-                height: 20.r,
-                decoration: BoxDecoration(
-                  color: scheme.primary,
-                  shape: BoxShape.circle,
-                  border: Border.all(color: scheme.surface, width: 2.r),
-                ),
-                child: Icon(
-                  Symbols.priority_high_rounded,
-                  size: 12.r,
-                  color: scheme.onPrimary,
-                ),
-              ),
-            ),
-        ],
       ),
     );
   }

--- a/lib/screens/secondary_screen/widgets/now_playing_panel.dart
+++ b/lib/screens/secondary_screen/widgets/now_playing_panel.dart
@@ -1,0 +1,264 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:material_symbols_icons/symbols.dart';
+import '../../../models/secondary_display_state.dart';
+import '../now_playing_helpers.dart';
+import 'app_dock.dart';
+
+/// The Now Playing page shown on the secondary display: boxart + game/system
+/// title + play-time / session / last-played stats, the app dock, and the
+/// all-apps launcher button.
+///
+/// Pure, input-driven subtree — the owning [SecondaryScreen] passes the current
+/// state snapshot, the live session readout ([sessionRunning] / [sessionTime]),
+/// and the action callbacks, so the panel re-reads no state of its own.
+class NowPlayingPanel extends StatelessWidget {
+  const NowPlayingPanel({
+    super.key,
+    required this.value,
+    required this.sessionRunning,
+    required this.sessionTime,
+    required this.onRequestScreenshot,
+    required this.onLaunchApp,
+    required this.onPickSlot,
+    required this.onClearSlot,
+    required this.onOpenLauncher,
+    required this.onOpenAccessibilitySettings,
+  });
+
+  final SecondaryDisplayStateData value;
+
+  /// Whether a play session is currently being timed (drives the SESSION stat).
+  final bool sessionRunning;
+
+  /// Pre-formatted elapsed session time (`HH:MM:SS`); only shown when
+  /// [sessionRunning].
+  final String sessionTime;
+
+  /// Asks the main engine to capture a screenshot of the main screen.
+  final VoidCallback onRequestScreenshot;
+
+  /// Launches the docked app in `package` (prefers the bottom display).
+  final void Function(String package) onLaunchApp;
+
+  /// Opens the app picker to assign an app to the empty slot `index`.
+  final void Function(int index) onPickSlot;
+
+  /// Clears the app assigned to slot `index`.
+  final void Function(int index) onClearSlot;
+
+  /// Opens the app picker in launch mode (all-apps launcher).
+  final VoidCallback onOpenLauncher;
+
+  /// Opens Android accessibility settings to enable the Screen Return service.
+  final VoidCallback onOpenAccessibilitySettings;
+
+  @override
+  Widget build(BuildContext context) {
+    final title = (value.gameTitle != null && value.gameTitle!.isNotEmpty)
+        ? value.gameTitle!
+        : value.systemName;
+    final scheme = panelScheme(value);
+
+    return Container(
+      width: double.infinity,
+      height: double.infinity,
+      color: scheme.surface,
+      child: Stack(
+        children: [
+          Padding(
+            padding: EdgeInsets.fromLTRB(44.r, 32.r, 44.r, 96.r),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                buildNowPlayingBoxart(value.gameBoxart),
+                SizedBox(width: 32.r),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(
+                        'NOW PLAYING',
+                        style: TextStyle(
+                          color: scheme.primary,
+                          fontSize: 14.r,
+                          fontWeight: FontWeight.w600,
+                          letterSpacing: 3.r,
+                        ),
+                      ),
+                      SizedBox(height: 12.r),
+                      Text(
+                        title,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          color: scheme.onSurface,
+                          fontSize: 30.r,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      SizedBox(height: 8.r),
+                      Text(
+                        value.systemName.toUpperCase(),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          color: scheme.onSurface.withValues(alpha: 0.7),
+                          fontSize: 16.r,
+                          letterSpacing: 1.5.r,
+                        ),
+                      ),
+                      SizedBox(height: 26.r),
+                      buildNowPlayingStat(
+                        scheme: scheme,
+                        icon: Symbols.schedule_rounded,
+                        label: 'PLAY TIME',
+                        text: formatPlayTime(value.playTimeSeconds),
+                      ),
+                      if (sessionRunning) ...[
+                        SizedBox(height: 12.r),
+                        buildNowPlayingStat(
+                          scheme: scheme,
+                          icon: Symbols.timer_rounded,
+                          label: 'SESSION',
+                          text: sessionTime,
+                        ),
+                      ],
+                      SizedBox(height: 12.r),
+                      buildNowPlayingStat(
+                        scheme: scheme,
+                        icon: Symbols.history_rounded,
+                        label: 'LAST PLAYED',
+                        text: formatLastPlayed(value.lastPlayedMillis),
+                      ),
+                      if (value.screenshotAccessEnabled) ...[
+                        SizedBox(height: 28.r),
+                        _buildScreenshotButton(scheme),
+                      ],
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 0,
+            child: AppDock(
+              value: value,
+              onLaunchApp: onLaunchApp,
+              onPickSlot: onPickSlot,
+              onClearSlot: onClearSlot,
+            ),
+          ),
+          // All-apps launcher pinned to the bottom-left corner.
+          if (value.dockEnabled)
+            Positioned(
+              left: 16.r,
+              bottom: 16.r,
+              child: _buildLauncherButton(value),
+            ),
+        ],
+      ),
+    );
+  }
+
+  /// Tappable pill that asks the main engine to capture a system screenshot of
+  /// the main screen.
+  Widget _buildScreenshotButton(ColorScheme scheme) {
+    return GestureDetector(
+      onTap: onRequestScreenshot,
+      child: Container(
+        padding: EdgeInsets.symmetric(horizontal: 20.r, vertical: 12.r),
+        decoration: BoxDecoration(
+          color: scheme.onSurface.withValues(alpha: 0.08),
+          borderRadius: BorderRadius.circular(12.r),
+          border: Border.all(color: scheme.onSurface.withValues(alpha: 0.18)),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Symbols.photo_camera_rounded,
+              color: scheme.onSurface,
+              size: 22.r,
+            ),
+            SizedBox(width: 12.r),
+            Text(
+              'SCREENSHOT',
+              style: TextStyle(
+                color: scheme.onSurface,
+                fontSize: 14.r,
+                fontWeight: FontWeight.w600,
+                letterSpacing: 2.r,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// The all-apps launcher, pinned to the bottom-left of the Now Playing
+  /// screen. Normally opens the app picker in launch mode. When the Screen
+  /// Return accessibility service isn't enabled, it's highlighted with an
+  /// accent border + warning badge and instead opens accessibility settings —
+  /// launching an app without that service would strand the user with no way
+  /// back to Now Playing.
+  Widget _buildLauncherButton(SecondaryDisplayStateData value) {
+    final scheme = panelScheme(value);
+    final accessOk = value.screenshotAccessEnabled;
+    return GestureDetector(
+      onTap: accessOk ? onOpenLauncher : onOpenAccessibilitySettings,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Container(
+            width: 56.r,
+            height: 56.r,
+            decoration: BoxDecoration(
+              color: accessOk
+                  ? scheme.onSurface.withValues(alpha: 0.05)
+                  : scheme.primary.withValues(alpha: 0.15),
+              borderRadius: BorderRadius.circular(14.r),
+              border: Border.all(
+                color: accessOk
+                    ? scheme.onSurface.withValues(alpha: 0.14)
+                    : scheme.primary,
+                width: accessOk ? 1.r : 2.r,
+              ),
+            ),
+            child: Icon(
+              Symbols.apps_rounded,
+              color: accessOk
+                  ? scheme.onSurface.withValues(alpha: 0.65)
+                  : scheme.primary,
+              size: 28.r,
+            ),
+          ),
+          if (!accessOk)
+            Positioned(
+              top: -4.r,
+              right: -4.r,
+              child: Container(
+                width: 20.r,
+                height: 20.r,
+                decoration: BoxDecoration(
+                  color: scheme.primary,
+                  shape: BoxShape.circle,
+                  border: Border.all(color: scheme.surface, width: 2.r),
+                ),
+                child: Icon(
+                  Symbols.priority_high_rounded,
+                  size: 12.r,
+                  color: scheme.onPrimary,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Description

Continues the secondary-screen refactor (follows #136, #137, #139). Extracts `_buildNowPlayingPanel` — plus its `_buildScreenshotButton` and `_buildLauncherButton` sub-builders — out of `_SecondaryScreenState` into a new `const`-constructor `NowPlayingPanel` widget under `secondary_screen/widgets/`.

Now that the app dock is its own widget (#139), the panel is a clean, input-driven subtree. The host passes:
- the current `SecondaryDisplayStateData` snapshot,
- the live session readout (`sessionRunning` + pre-formatted `sessionTime`, both still derived from the host-owned `_sessionWatch`),
- six action callbacks (request-screenshot, three dock-slot callbacks, open-launcher, open-accessibility-settings).

The widget re-reads no state of its own (guardrail: pass read values/callbacks down, don't re-read Provider in the child). Bodies moved verbatim — the only edits are the session/callback parameter substitutions. Host `secondary_screen.dart` shrinks ~215 lines. No behavior or public-API change.

Fixes # (issue) — N/A

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable).

## Screenshots (if applicable)

No visual change — pure refactor; the Now Playing panel renders identically.