### PR TITLE
refactor(secondary-screen): promote achievement comments page to a widget

### DIFF
--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -18,6 +18,7 @@ import '../../services/retro_achievements_service.dart';
 import '../../utils/no_glow_scroll_behavior.dart';
 import 'background_builders.dart';
 import 'now_playing_helpers.dart';
+import 'widgets/achievement_comments.dart';
 import 'widgets/achievement_panel.dart';
 import 'widgets/app_dock.dart';
 import 'widgets/now_playing_panel.dart';
@@ -27,27 +28,6 @@ class SecondaryScreen extends StatefulWidget {
 
   @override
   State<SecondaryScreen> createState() => _SecondaryScreenState();
-}
-
-class _AchievementCommentsState {
-  final List<RetroAchievementComment> comments;
-  final int total;
-
-  /// Number of *raw* API results consumed so far (system comments included).
-  /// The API pages over the unfiltered set, so the next fetch offset must be
-  /// based on this, not on the filtered [comments] length — otherwise paging
-  /// re-requests already-seen rows and "load more" appears to do nothing.
-  final int loadedRaw;
-  final bool isLoading;
-  final String? error;
-
-  const _AchievementCommentsState({
-    required this.comments,
-    required this.total,
-    this.loadedRaw = 0,
-    this.isLoading = false,
-    this.error,
-  });
 }
 
 class _SecondaryScreenState extends State<SecondaryScreen> {
@@ -80,7 +60,7 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
   /// resets to 0 on each new launch.
   int _inGamePanelPage = 0;
   SecondaryAchievementItem? _selectedAchievement;
-  final Map<int, _AchievementCommentsState> _commentsCache = {};
+  final Map<int, AchievementCommentsState> _commentsCache = {};
   int _commentsRequestGeneration = 0;
   bool _wasNowPlayingActive = false;
   String? _panelGameId;
@@ -290,7 +270,7 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
     final rateLimitedMessage = AppLocale.raRateLimited.getString(ctx);
     final couldNotLoadMessage = AppLocale.raCommentsCouldNotLoad.getString(ctx);
     setState(() {
-      _commentsCache[achievementId] = _AchievementCommentsState(
+      _commentsCache[achievementId] = AchievementCommentsState(
         comments: reset ? const [] : (current?.comments ?? const []),
         total: reset ? 0 : (current?.total ?? 0),
         loadedRaw: reset ? 0 : (current?.loadedRaw ?? 0),
@@ -327,7 +307,7 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
       final loadedRaw = offset + consumedRaw;
       final reachedEnd = consumedRaw < pageSize;
       setState(() {
-        _commentsCache[achievementId] = _AchievementCommentsState(
+        _commentsCache[achievementId] = AchievementCommentsState(
           comments: byKey.values.toList(),
           total: reachedEnd ? loadedRaw : page.total,
           loadedRaw: loadedRaw,
@@ -343,7 +323,7 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
           ? rateLimitedMessage
           : couldNotLoadMessage;
       setState(() {
-        _commentsCache[achievementId] = _AchievementCommentsState(
+        _commentsCache[achievementId] = AchievementCommentsState(
           comments: reset ? const [] : (current?.comments ?? const []),
           total: reset ? 0 : (current?.total ?? 0),
           loadedRaw: reset ? 0 : (current?.loadedRaw ?? 0),
@@ -1034,7 +1014,12 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
             child: KeyedSubtree(
               key: ValueKey('in-game-page-$page'),
               child: page == 2
-                  ? _buildAchievementCommentsPage(_selectedAchievement!)
+                  ? AchievementCommentsPage(
+                      achievement: _selectedAchievement!,
+                      state: _commentsCache[_selectedAchievement!.id],
+                      l10nContext: _l10nContext,
+                      onLoadComments: _loadAchievementComments,
+                    )
                   : page == 1
                   ? AchievementPanel(
                       value: value,
@@ -1258,211 +1243,6 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
           '${s.toString().padLeft(2, '0')}s';
     }
     return '${m}m ${s.toString().padLeft(2, '0')}s';
-  }
-
-  Widget _buildAchievementCommentsPage(SecondaryAchievementItem achievement) {
-    final state = _commentsCache[achievement.id];
-    final comments = (state?.comments ?? const <RetroAchievementComment>[])
-        .where((comment) => !comment.isSystemComment)
-        .toList();
-    final hasMore = state != null && state.loadedRaw < state.total;
-
-    return Container(
-      color: Colors.black,
-      padding: EdgeInsets.fromLTRB(58.r, 20.r, 24.r, 20.r),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              buildAchievementBadge(achievement, isNew: false),
-              SizedBox(width: 14.r),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      children: [
-                        Expanded(
-                          child: Text(
-                            achievement.title,
-                            style: TextStyle(
-                              color: Colors.white,
-                              fontSize: 18.r,
-                              fontWeight: FontWeight.bold,
-                              fontFamily: 'Anta',
-                            ),
-                          ),
-                        ),
-                        if (achievement.isMissable)
-                          Center(
-                            child: buildMissablePill(
-                              context,
-                              l10nContext: _l10nContext,
-                            ),
-                          ),
-                        SizedBox(width: 10.r),
-                        Text(
-                          '${achievement.points}p',
-                          style: TextStyle(
-                            color: const Color(0xFFFFC107),
-                            fontSize: 15.r,
-                            fontWeight: FontWeight.bold,
-                            fontFamily: 'Anta',
-                          ),
-                        ),
-                      ],
-                    ),
-                    if (achievement.description.isNotEmpty) ...[
-                      SizedBox(height: 4.r),
-                      Text(
-                        achievement.description,
-                        style: TextStyle(color: Colors.white60, fontSize: 12.r),
-                      ),
-                    ],
-                  ],
-                ),
-              ),
-            ],
-          ),
-          SizedBox(height: 16.r),
-          Text(
-            AppLocale.raComments.getString(_l10nContext ?? context),
-            style: TextStyle(
-              color: Colors.white70,
-              fontSize: 12.r,
-              fontWeight: FontWeight.bold,
-              letterSpacing: 1.2.r,
-              fontFamily: 'Anta',
-            ),
-          ),
-          SizedBox(height: 8.r),
-          Expanded(
-            child: state == null || (state.isLoading && comments.isEmpty)
-                ? const Center(child: CircularProgressIndicator())
-                : state.error != null && comments.isEmpty
-                ? _buildCommentsMessage(
-                    AppLocale.raCommentsCouldNotLoad.getString(
-                      _l10nContext ?? context,
-                    ),
-                    actionLabel: AppLocale.retry
-                        .getString(_l10nContext ?? context)
-                        .toUpperCase(),
-                    onAction: () =>
-                        _loadAchievementComments(achievement.id, reset: true),
-                  )
-                : comments.isEmpty
-                ? _buildCommentsMessage(
-                    AppLocale.raNoCommentsYet.getString(
-                      _l10nContext ?? context,
-                    ),
-                  )
-                : ListView.separated(
-                    itemCount: comments.length + (hasMore ? 1 : 0),
-                    separatorBuilder: (_, _) => SizedBox(height: 8.r),
-                    itemBuilder: (context, index) {
-                      if (index == comments.length) {
-                        return _buildLoadMoreComments(achievement.id, state);
-                      }
-                      return _buildCommentCard(comments[index]);
-                    },
-                  ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildCommentCard(RetroAchievementComment comment) {
-    return Container(
-      padding: EdgeInsets.all(10.r),
-      decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.06),
-        borderRadius: BorderRadius.circular(10.r),
-        border: Border.all(color: Colors.white10),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Expanded(
-                child: Text(
-                  comment.user.isEmpty
-                      ? AppLocale.unknownUser.getString(_l10nContext ?? context)
-                      : comment.user,
-                  style: TextStyle(
-                    color: const Color(0xFFFFC107),
-                    fontSize: 12.r,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-              ),
-              if (comment.submitted != null)
-                Text(
-                  _formatCommentDate(comment.submitted!),
-                  style: TextStyle(color: Colors.white38, fontSize: 10.r),
-                ),
-            ],
-          ),
-          SizedBox(height: 5.r),
-          Text(
-            comment.commentText,
-            style: TextStyle(color: Colors.white70, fontSize: 12.r),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildLoadMoreComments(
-    int achievementId,
-    _AchievementCommentsState state,
-  ) {
-    if (state.isLoading) {
-      return Padding(
-        padding: EdgeInsets.all(12.r),
-        child: const Center(child: CircularProgressIndicator()),
-      );
-    }
-    return _buildCommentsMessage(
-      state.error ??
-          AppLocale.raOlderCommentsAvailable.getString(_l10nContext ?? context),
-      actionLabel: state.error == null
-          ? AppLocale.raLoadMore.getString(_l10nContext ?? context)
-          : AppLocale.retry.getString(_l10nContext ?? context).toUpperCase(),
-      onAction: () => _loadAchievementComments(achievementId, reset: false),
-    );
-  }
-
-  Widget _buildCommentsMessage(
-    String message, {
-    String? actionLabel,
-    VoidCallback? onAction,
-  }) {
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(
-            message,
-            style: TextStyle(color: Colors.white54, fontSize: 13.r),
-          ),
-          if (actionLabel != null && onAction != null) ...[
-            SizedBox(height: 10.r),
-            TextButton(onPressed: onAction, child: Text(actionLabel)),
-          ],
-        ],
-      ),
-    );
-  }
-
-  String _formatCommentDate(DateTime date) {
-    final local = date.toLocal();
-    String two(int value) => value.toString().padLeft(2, '0');
-    return '${local.year}-${two(local.month)}-${two(local.day)} '
-        '${two(local.hour)}:${two(local.minute)}';
   }
 
   Widget _buildScrapingOverlay(SecondaryDisplayStateData value) {

--- a/lib/screens/secondary_screen/widgets/achievement_comments.dart
+++ b/lib/screens/secondary_screen/widgets/achievement_comments.dart
@@ -1,0 +1,271 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localization/flutter_localization.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import '../../../l10n/app_locale.dart';
+import '../../../models/retro_achievement_comment.dart';
+import '../../../models/secondary_achievement_item.dart';
+import 'achievement_panel.dart';
+
+/// The comment-loading state for a single achievement's comments page: the
+/// filtered comment list plus paging bookkeeping and load status.
+class AchievementCommentsState {
+  final List<RetroAchievementComment> comments;
+  final int total;
+
+  /// Number of *raw* API results consumed so far (system comments included).
+  /// The API pages over the unfiltered set, so the next fetch offset must be
+  /// based on this, not on the filtered [comments] length — otherwise paging
+  /// re-requests already-seen rows and "load more" appears to do nothing.
+  final int loadedRaw;
+  final bool isLoading;
+  final String? error;
+
+  const AchievementCommentsState({
+    required this.comments,
+    required this.total,
+    this.loadedRaw = 0,
+    this.isLoading = false,
+    this.error,
+  });
+}
+
+/// The achievement detail / comments page shown on the secondary display when a
+/// badge is tapped: the achievement header (badge + title / points / missable
+/// pill / description) above a scrollable comment thread with load-more paging.
+///
+/// Pure, input-driven subtree — the owning [SecondaryScreen] passes the current
+/// [achievement], its cached [state] snapshot, and the load callback, so the
+/// page re-reads no state of its own.
+class AchievementCommentsPage extends StatelessWidget {
+  const AchievementCommentsPage({
+    super.key,
+    required this.achievement,
+    required this.state,
+    required this.l10nContext,
+    required this.onLoadComments,
+  });
+
+  final SecondaryAchievementItem achievement;
+
+  /// The cached comment-loading state for [achievement], or null before the
+  /// first fetch completes.
+  final AchievementCommentsState? state;
+
+  /// BuildContext captured under the MaterialApp for localized strings; falls
+  /// back to the widget's own context when null.
+  final BuildContext? l10nContext;
+
+  /// Loads (or reloads, when `reset`) the comment page for `achievementId`.
+  final void Function(int achievementId, {required bool reset}) onLoadComments;
+
+  @override
+  Widget build(BuildContext context) {
+    final state = this.state;
+    final comments = (state?.comments ?? const <RetroAchievementComment>[])
+        .where((comment) => !comment.isSystemComment)
+        .toList();
+    final hasMore = state != null && state.loadedRaw < state.total;
+
+    return Container(
+      color: Colors.black,
+      padding: EdgeInsets.fromLTRB(58.r, 20.r, 24.r, 20.r),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              buildAchievementBadge(achievement, isNew: false),
+              SizedBox(width: 14.r),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            achievement.title,
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 18.r,
+                              fontWeight: FontWeight.bold,
+                              fontFamily: 'Anta',
+                            ),
+                          ),
+                        ),
+                        if (achievement.isMissable)
+                          Center(
+                            child: buildMissablePill(
+                              context,
+                              l10nContext: l10nContext,
+                            ),
+                          ),
+                        SizedBox(width: 10.r),
+                        Text(
+                          '${achievement.points}p',
+                          style: TextStyle(
+                            color: const Color(0xFFFFC107),
+                            fontSize: 15.r,
+                            fontWeight: FontWeight.bold,
+                            fontFamily: 'Anta',
+                          ),
+                        ),
+                      ],
+                    ),
+                    if (achievement.description.isNotEmpty) ...[
+                      SizedBox(height: 4.r),
+                      Text(
+                        achievement.description,
+                        style: TextStyle(color: Colors.white60, fontSize: 12.r),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ),
+          SizedBox(height: 16.r),
+          Text(
+            AppLocale.raComments.getString(l10nContext ?? context),
+            style: TextStyle(
+              color: Colors.white70,
+              fontSize: 12.r,
+              fontWeight: FontWeight.bold,
+              letterSpacing: 1.2.r,
+              fontFamily: 'Anta',
+            ),
+          ),
+          SizedBox(height: 8.r),
+          Expanded(
+            child: state == null || (state.isLoading && comments.isEmpty)
+                ? const Center(child: CircularProgressIndicator())
+                : state.error != null && comments.isEmpty
+                ? _buildCommentsMessage(
+                    AppLocale.raCommentsCouldNotLoad.getString(
+                      l10nContext ?? context,
+                    ),
+                    actionLabel: AppLocale.retry
+                        .getString(l10nContext ?? context)
+                        .toUpperCase(),
+                    onAction: () => onLoadComments(achievement.id, reset: true),
+                  )
+                : comments.isEmpty
+                ? _buildCommentsMessage(
+                    AppLocale.raNoCommentsYet.getString(l10nContext ?? context),
+                  )
+                : ListView.separated(
+                    itemCount: comments.length + (hasMore ? 1 : 0),
+                    separatorBuilder: (_, _) => SizedBox(height: 8.r),
+                    itemBuilder: (context, index) {
+                      if (index == comments.length) {
+                        return _buildLoadMoreComments(
+                          context,
+                          achievement.id,
+                          state,
+                        );
+                      }
+                      return _buildCommentCard(context, comments[index]);
+                    },
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCommentCard(
+    BuildContext context,
+    RetroAchievementComment comment,
+  ) {
+    return Container(
+      padding: EdgeInsets.all(10.r),
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(10.r),
+        border: Border.all(color: Colors.white10),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  comment.user.isEmpty
+                      ? AppLocale.unknownUser.getString(l10nContext ?? context)
+                      : comment.user,
+                  style: TextStyle(
+                    color: const Color(0xFFFFC107),
+                    fontSize: 12.r,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+              if (comment.submitted != null)
+                Text(
+                  _formatCommentDate(comment.submitted!),
+                  style: TextStyle(color: Colors.white38, fontSize: 10.r),
+                ),
+            ],
+          ),
+          SizedBox(height: 5.r),
+          Text(
+            comment.commentText,
+            style: TextStyle(color: Colors.white70, fontSize: 12.r),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildLoadMoreComments(
+    BuildContext context,
+    int achievementId,
+    AchievementCommentsState state,
+  ) {
+    if (state.isLoading) {
+      return Padding(
+        padding: EdgeInsets.all(12.r),
+        child: const Center(child: CircularProgressIndicator()),
+      );
+    }
+    return _buildCommentsMessage(
+      state.error ??
+          AppLocale.raOlderCommentsAvailable.getString(l10nContext ?? context),
+      actionLabel: state.error == null
+          ? AppLocale.raLoadMore.getString(l10nContext ?? context)
+          : AppLocale.retry.getString(l10nContext ?? context).toUpperCase(),
+      onAction: () => onLoadComments(achievementId, reset: false),
+    );
+  }
+
+  Widget _buildCommentsMessage(
+    String message, {
+    String? actionLabel,
+    VoidCallback? onAction,
+  }) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            message,
+            style: TextStyle(color: Colors.white54, fontSize: 13.r),
+          ),
+          if (actionLabel != null && onAction != null) ...[
+            SizedBox(height: 10.r),
+            TextButton(onPressed: onAction, child: Text(actionLabel)),
+          ],
+        ],
+      ),
+    );
+  }
+
+  String _formatCommentDate(DateTime date) {
+    final local = date.toLocal();
+    String two(int value) => value.toString().padLeft(2, '0');
+    return '${local.year}-${two(local.month)}-${two(local.day)} '
+        '${two(local.hour)}:${two(local.minute)}';
+  }
+}


### PR DESCRIPTION
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Description

Part of the secondary_screen refactor campaign (splitting the ~2.5k-line `secondary_screen.dart` into focused, input-driven widgets — zero behavior change, no public-API change). Follows #136 (backgrounds), #137 (now-playing helpers), #139 (app dock), #140 (now-playing panel) and #141 (achievement panel).

This one extracts the **achievement comments / detail page** — the last remaining panel in `_SecondaryScreenState`. `_buildAchievementCommentsPage` and its `_buildCommentCard` / `_buildLoadMoreComments` / `_buildCommentsMessage` / `_formatCommentDate` sub-builders move into a new `const`-ctor `AchievementCommentsPage` under `secondary_screen/widgets/`.

The host passes the selected achievement, its cached comment-state snapshot, the l10n context, and the load callback down — the child re-reads no state of its own (the established guardrail for these promotions). The private `_AchievementCommentsState` loading-state holder is promoted to a public `AchievementCommentsState` in the same file, which the host's `_commentsCache` / `_loadAchievementComments` construct and reference.

Bodies moved **verbatim** aside from the intentional `_l10nContext` → `l10nContext` and `_loadAchievementComments` → `onLoadComments` substitutions. Host: **231 lines removed, 11 added**. `flutter analyze` clean project-wide, `dart format` clean, **207/207** tests.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [ ] **Gamepad support verified** (if applicable).

## Screenshots (if applicable)

No visual change — pure widget extraction. Verified on-device (AYN Thor, `--clean`): tap a badge → comments page opens; header (badge / title / points / missable pill / description), comment thread, load-more paging, and empty / error / retry states all render identically.