### PR TITLE
refactor(games-list): extract gamepad-nav input handlers into a part file

### DIFF
--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -42,6 +42,8 @@ import '../../widgets/game_view_mode_dropdown.dart';
 import '../../constants/system_folder_names.dart';
 import '../../themes/corner_radii.dart';
 
+part 'my_games_list/gamepad_nav.dart';
+
 /// A high-fidelity list component for browsing games within a specific system.
 ///
 /// Handles complex navigation, media previews (video/audio), secondary display
@@ -417,107 +419,10 @@ class _SystemGamesListState extends State<SystemGamesList> {
     MusicPlayerService().setDucked(false);
   }
 
-  /// Handles Right Bumper (RB) interactions for tab navigation or scraping.
-  Future<void> _handleRightBumper() async {
-    if (_tabNavigationAction != null && _tabNavigationAction!(true)) {
-      return;
-    }
-    _secondaryOverlayAction?.call();
-  }
-
-  /// Handles Left Bumper (LB) interactions for tab navigation.
-  Future<void> _handleLeftBumper() async {
-    if (_tabNavigationAction != null && _tabNavigationAction!(false)) {
-      return;
-    }
-  }
-
-  /// Registers gamepad and keyboard input mappings for the screen.
-  void _initializeGamepad() {
-    _gamepadNav = GamepadNavigation(
-      onNavigateUp: _navigateUp,
-      onNavigateDown: _navigateDown,
-      onNavigateLeft: _navigateLeft, // Page Up (10 items).
-      onNavigateRight: _navigateRight, // Page Down (10 items).
-      onSelectItem: _selectCurrentGame,
-      onBack: _goBack,
-      onFavorite: _toggleFavorite, // Button Y.
-      onXButton: () {
-        GameViewModeDropdown.globalKey.currentState?.showDropdown();
-      }, // Button X - View mode.
-      onSettings: _handleStartButton, // Button Start.
-      onLeftStickClick: () {
-        if (widget.system.folderName == 'music') {
-          final service = MusicPlayerService();
-          service.toggleShuffle();
-          AppNotification.showNotification(
-            context,
-            service.isShuffle
-                ? AppLocale.shuffleEnabled.getString(context)
-                : AppLocale.shuffleDisabled.getString(context),
-            type: NotificationType.info,
-          );
-        } else {
-          _showRandomGameDialog();
-        }
-      }, // L3 - Random.
-      onRightStickClick: null,
-      onSelectButton: () {
-        if (widget.system.folderName == 'music') {
-          final service = MusicPlayerService();
-          final isLooping = service.isCurrentTrackLooping;
-          if (!isLooping) {
-            if (_selectedGame != null) {
-              setState(() {
-                _games.removeAt(_selectedGameIndex);
-                _games.insert(0, _selectedGame!);
-                _selectedGameIndex = 0;
-              });
-              service.setPlaylist(_games);
-              service.setLoop(true, trackPath: _selectedGame!.romPath);
-              _scrollToSelectedItem();
-              AppNotification.showNotification(
-                context,
-                AppLocale.loopActivated.getString(context),
-                type: NotificationType.success,
-              );
-            }
-          } else {
-            service.setLoop(false);
-            AppNotification.showNotification(
-              context,
-              AppLocale.loopDeactivated.getString(context),
-              type: NotificationType.info,
-            );
-          }
-          return;
-        }
-        // Scrape the selected game directly, matching the grid/carousel views.
-        // Routing through the details card's secondary action early-returns when
-        // the secondary display is active (e.g. AYN Thor), so scraping never ran.
-        _onScrapeCurrentGame();
-      }, // Select - Scrape.
-      onLeftBumper: _handleLeftBumper,
-      onRightBumper: _handleRightBumper,
-      onPreviousTab: _handleLeftBumper, // Key Q.
-      onNextTab: _handleRightBumper, // Key E.
-    );
-
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _gamepadNav.initialize();
-      GamepadNavigationManager.pushLayer(
-        'system_games_list',
-        onActivate: () => _gamepadNav.activate(),
-        onDeactivate: () => _gamepadNav.deactivate(),
-      );
-    });
-  }
-
-  void _handleStartButton() {
-    if (_startActionCallback != null) {
-      _startActionCallback!();
-    }
-  }
+  /// Bridge so `part` extension files (e.g. gamepad nav) can request a
+  /// rebuild — [State.setState] is `@protected` and cannot be invoked from an
+  /// extension. Behaviourally identical to calling `setState` directly.
+  void rebuild(VoidCallback fn) => setState(fn);
 
   /// Hard reset of the video preview system.
   void _resetVideoState() {
@@ -583,62 +488,6 @@ class _SystemGamesListState extends State<SystemGamesList> {
     if (mounted) {
       context.read<SystemBackgroundProvider>().clear();
     }
-  }
-
-  /// Moves focus to the previous game in the list.
-  void _navigateUp() {
-    if (_games.isEmpty) return;
-
-    if (_isAchievementsOpen != null && _isAchievementsOpen!()) {
-      _moveAchievementUp?.call();
-      return;
-    }
-
-    _resetVideoState();
-    _updateSelectedGame(
-      (_selectedGameIndex - 1 + _games.length) % _games.length,
-    );
-  }
-
-  /// Moves focus to the next game in the list.
-  void _navigateDown() {
-    if (_games.isEmpty) return;
-
-    if (_isAchievementsOpen != null && _isAchievementsOpen!()) {
-      _moveAchievementDown?.call();
-      return;
-    }
-
-    _resetVideoState();
-    _updateSelectedGame((_selectedGameIndex + 1) % _games.length);
-  }
-
-  /// Jumps back by 10 games (Page Up logic).
-  void _navigateLeft() {
-    if (_games.isEmpty) return;
-
-    if (_isAchievementsOpen != null && _isAchievementsOpen!()) {
-      _moveAchievementLeft?.call();
-      return;
-    }
-
-    _resetVideoState();
-    final newIndex = (_selectedGameIndex - 10 + _games.length) % _games.length;
-    _updateSelectedGame(newIndex);
-  }
-
-  /// Jumps forward by 10 games (Page Down logic).
-  void _navigateRight() {
-    if (_games.isEmpty) return;
-
-    if (_isAchievementsOpen != null && _isAchievementsOpen!()) {
-      _moveAchievementRight?.call();
-      return;
-    }
-
-    _resetVideoState();
-    final newIndex = (_selectedGameIndex + 10) % _games.length;
-    _updateSelectedGame(newIndex);
   }
 
   /// Core logic for updating selection and managing rapid-scrolling UI state.

--- a/lib/screens/game_screen/my_games_list/gamepad_nav.dart
+++ b/lib/screens/game_screen/my_games_list/gamepad_nav.dart
@@ -1,0 +1,170 @@
+part of '../my_games_list.dart';
+
+/// Gamepad / keyboard input handling for the system games list.
+///
+/// Registers the [GamepadNavigation] input mappings and implements the
+/// navigation-dispatch handlers (D-pad move, page jump, bumpers, Start). All
+/// state lives on the host [State]; this extension only moves the methods out
+/// of the monolith — behaviour is unchanged.
+extension _GamepadNav on _SystemGamesListState {
+  /// Handles Right Bumper (RB) interactions for tab navigation or scraping.
+  Future<void> _handleRightBumper() async {
+    if (_tabNavigationAction != null && _tabNavigationAction!(true)) {
+      return;
+    }
+    _secondaryOverlayAction?.call();
+  }
+
+  /// Handles Left Bumper (LB) interactions for tab navigation.
+  Future<void> _handleLeftBumper() async {
+    if (_tabNavigationAction != null && _tabNavigationAction!(false)) {
+      return;
+    }
+  }
+
+  /// Registers gamepad and keyboard input mappings for the screen.
+  void _initializeGamepad() {
+    _gamepadNav = GamepadNavigation(
+      onNavigateUp: _navigateUp,
+      onNavigateDown: _navigateDown,
+      onNavigateLeft: _navigateLeft, // Page Up (10 items).
+      onNavigateRight: _navigateRight, // Page Down (10 items).
+      onSelectItem: _selectCurrentGame,
+      onBack: _goBack,
+      onFavorite: _toggleFavorite, // Button Y.
+      onXButton: () {
+        GameViewModeDropdown.globalKey.currentState?.showDropdown();
+      }, // Button X - View mode.
+      onSettings: _handleStartButton, // Button Start.
+      onLeftStickClick: () {
+        if (widget.system.folderName == 'music') {
+          final service = MusicPlayerService();
+          service.toggleShuffle();
+          AppNotification.showNotification(
+            context,
+            service.isShuffle
+                ? AppLocale.shuffleEnabled.getString(context)
+                : AppLocale.shuffleDisabled.getString(context),
+            type: NotificationType.info,
+          );
+        } else {
+          _showRandomGameDialog();
+        }
+      }, // L3 - Random.
+      onRightStickClick: null,
+      onSelectButton: () {
+        if (widget.system.folderName == 'music') {
+          final service = MusicPlayerService();
+          final isLooping = service.isCurrentTrackLooping;
+          if (!isLooping) {
+            if (_selectedGame != null) {
+              // setState is @protected and cannot be called from an extension,
+              // so route through the host's [rebuild] bridge (behaviourally
+              // identical).
+              rebuild(() {
+                _games.removeAt(_selectedGameIndex);
+                _games.insert(0, _selectedGame!);
+                _selectedGameIndex = 0;
+              });
+              service.setPlaylist(_games);
+              service.setLoop(true, trackPath: _selectedGame!.romPath);
+              _scrollToSelectedItem();
+              AppNotification.showNotification(
+                context,
+                AppLocale.loopActivated.getString(context),
+                type: NotificationType.success,
+              );
+            }
+          } else {
+            service.setLoop(false);
+            AppNotification.showNotification(
+              context,
+              AppLocale.loopDeactivated.getString(context),
+              type: NotificationType.info,
+            );
+          }
+          return;
+        }
+        // Scrape the selected game directly, matching the grid/carousel views.
+        // Routing through the details card's secondary action early-returns when
+        // the secondary display is active (e.g. AYN Thor), so scraping never ran.
+        _onScrapeCurrentGame();
+      }, // Select - Scrape.
+      onLeftBumper: _handleLeftBumper,
+      onRightBumper: _handleRightBumper,
+      onPreviousTab: _handleLeftBumper, // Key Q.
+      onNextTab: _handleRightBumper, // Key E.
+    );
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _gamepadNav.initialize();
+      GamepadNavigationManager.pushLayer(
+        'system_games_list',
+        onActivate: () => _gamepadNav.activate(),
+        onDeactivate: () => _gamepadNav.deactivate(),
+      );
+    });
+  }
+
+  void _handleStartButton() {
+    if (_startActionCallback != null) {
+      _startActionCallback!();
+    }
+  }
+
+  /// Moves focus to the previous game in the list.
+  void _navigateUp() {
+    if (_games.isEmpty) return;
+
+    if (_isAchievementsOpen != null && _isAchievementsOpen!()) {
+      _moveAchievementUp?.call();
+      return;
+    }
+
+    _resetVideoState();
+    _updateSelectedGame(
+      (_selectedGameIndex - 1 + _games.length) % _games.length,
+    );
+  }
+
+  /// Moves focus to the next game in the list.
+  void _navigateDown() {
+    if (_games.isEmpty) return;
+
+    if (_isAchievementsOpen != null && _isAchievementsOpen!()) {
+      _moveAchievementDown?.call();
+      return;
+    }
+
+    _resetVideoState();
+    _updateSelectedGame((_selectedGameIndex + 1) % _games.length);
+  }
+
+  /// Jumps back by 10 games (Page Up logic).
+  void _navigateLeft() {
+    if (_games.isEmpty) return;
+
+    if (_isAchievementsOpen != null && _isAchievementsOpen!()) {
+      _moveAchievementLeft?.call();
+      return;
+    }
+
+    _resetVideoState();
+    final newIndex = (_selectedGameIndex - 10 + _games.length) % _games.length;
+    _updateSelectedGame(newIndex);
+  }
+
+  /// Jumps forward by 10 games (Page Down logic).
+  void _navigateRight() {
+    if (_games.isEmpty) return;
+
+    if (_isAchievementsOpen != null && _isAchievementsOpen!()) {
+      _moveAchievementRight?.call();
+      return;
+    }
+
+    _resetVideoState();
+    final newIndex = (_selectedGameIndex + 10) % _games.length;
+    _updateSelectedGame(newIndex);
+  }
+}


### PR DESCRIPTION
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Description

**Phase 3 / A start** of the oversized-file refactor campaign: split the first slice of `_SystemGamesListState` out of the `my_games_list.dart` monolith using the in-repo **part/extension** pattern (mirrors `providers/neo_sync_provider.dart`). **Zero behaviour change, zero public-API change.**

Moved **verbatim** into new `lib/screens/game_screen/my_games_list/gamepad_nav.dart` as `extension _GamepadNav on _SystemGamesListState`:
- `_initializeGamepad` (gamepad/keyboard input mappings)
- `_handleStartButton`, `_handleLeftBumper`, `_handleRightBumper`
- `_navigateUp` / `_navigateDown` / `_navigateLeft` / `_navigateRight`

All state stays on the host `State` (extensions can't declare fields). The single `setState` in the moved code routes through a new host `rebuild()` bridge — `State.setState` is `@protected` and can't be called from an extension, so this mirrors `neo_sync_provider`'s `notify()` idiom. Behaviourally identical.

Host diff: **6 insertions** (part directive + `rebuild` bridge) / **157 deletions** — reads as a pure move.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable).

## Screenshots (if applicable)

N/A — pure source reorganization, no visual change.