### PR TITLE
refactor(games-list): extract data-loading into a part file

### DIFF
--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -44,6 +44,7 @@ import '../../themes/corner_radii.dart';
 
 part 'my_games_list/gamepad_nav.dart';
 part 'my_games_list/favorites_reorder.dart';
+part 'my_games_list/data_loading.dart';
 
 /// A high-fidelity list component for browsing games within a specific system.
 ///
@@ -851,56 +852,6 @@ class _SystemGamesListState extends State<SystemGamesList> {
     });
   }
 
-  /// Retrieves localized game descriptions directly from the SQLite database.
-  void _loadLocalizedDescription() async {
-    if (_selectedGame == null) return;
-
-    try {
-      String? systemId;
-
-      // In 'Global Library' mode, resolve the game's native hardware system ID.
-      if ((widget.system.folderName == 'all' ||
-              widget.system.folderName == SystemFolderNames.favorites) &&
-          _selectedGame!.systemFolderName != null) {
-        final originalSystem = await SystemRepository.getSystemByFolderName(
-          _selectedGame!.systemFolderName!,
-        );
-        systemId = originalSystem?.id;
-      } else {
-        systemId = widget.system.id;
-      }
-
-      if (systemId == null) {
-        if (mounted) {
-          setState(() {
-            _localizedDescription = null;
-          });
-        }
-        return;
-      }
-
-      final description = await GameRepository.getLocalizedDescription(
-        _selectedGame!.romname,
-        systemId,
-      );
-
-      if (mounted &&
-          _selectedGame != null &&
-          _selectedGame!.romname == _selectedGame!.romname) {
-        setState(() {
-          _localizedDescription = description;
-        });
-      }
-    } catch (e) {
-      _log.e('Localized description loading failed: $e');
-      if (mounted) {
-        setState(() {
-          _localizedDescription = null;
-        });
-      }
-    }
-  }
-
   bool _isNavigatingBack = false;
 
   /// Orchestrates a graceful exit from the game list, synchronizing state with previous screens.
@@ -1513,99 +1464,6 @@ class _SystemGamesListState extends State<SystemGamesList> {
         GamepadNavigationManager.popLayer('random_dialog');
       }
     });
-  }
-
-  Future<void> _loadGames() async {
-    if (!mounted || _isLoadingGames) return;
-    _isLoadingGames = true;
-
-    final isInitialLoad = _games.isEmpty;
-    if (isInitialLoad) {
-      setState(() => _isLoading = true);
-    }
-
-    try {
-      final games = await GameService.loadGamesForSystem(widget.system);
-      if (!mounted) return;
-
-      _log.i(
-        'SystemGamesList: Loaded ${games.length} games for ${widget.system.folderName}',
-      );
-      if (widget.system.folderName == 'music' && games.isNotEmpty) {
-        _log.i(
-          'SystemGamesList: First 3 music tracks: ${games.take(3).map((g) => g.name).toList()}',
-        );
-      }
-      setState(() {
-        _games = games;
-        _gameIndexMap = {for (int i = 0; i < games.length; i++) games[i]: i};
-
-        // Music system specialization: Anchor initial focus to the currently active track.
-        if (widget.system.folderName == 'music') {
-          final musicService = MusicPlayerService();
-          if (musicService.isStarted && musicService.currentTrack != null) {
-            final playingTrackPath = musicService.currentTrack?.romPath;
-            final playingIndex = games.indexWhere(
-              (g) => g.romPath == playingTrackPath,
-            );
-
-            if (playingIndex != -1) {
-              _selectedGameIndex = playingIndex;
-              _selectedGame = games[playingIndex];
-              _log.i(
-                'SystemGamesList: Initial focus set to playing track at index $playingIndex',
-              );
-            }
-          }
-        }
-
-        if (widget.initialRomPath != null &&
-            widget.initialRomPath!.isNotEmpty) {
-          final initialIndex = games.indexWhere(
-            (game) => game.romPath == widget.initialRomPath,
-          );
-          if (initialIndex != -1) {
-            _selectedGameIndex = initialIndex;
-            _selectedGame = games[initialIndex];
-          } else {
-            _selectedGameIndex = 0;
-            _selectedGame = games.isNotEmpty ? games.first : null;
-          }
-        } else if (_selectedGame != null &&
-            widget.system.folderName != 'music') {
-          // Persistent Selection Logic: Retain current index if the game still exists post-reload.
-          final selectedIndex = games.indexWhere(
-            (game) => game.romname == _selectedGame!.romname,
-          );
-          if (selectedIndex != -1) {
-            _selectedGameIndex = selectedIndex;
-            _selectedGame = games[selectedIndex];
-          } else {
-            _selectedGameIndex = 0;
-            _selectedGame = games.isNotEmpty ? games.first : null;
-          }
-        } else if (_selectedGame == null) {
-          _selectedGameIndex = 0;
-          _selectedGame = games.isNotEmpty ? games.first : null;
-        }
-        _isLoading = false;
-      });
-
-      // Trigger deferred media and background tasks after initial UI render.
-      if (_selectedGame != null) {
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          _startVideoTimer();
-          _performBackgroundOperationsForSelectedGame();
-        });
-      }
-    } catch (e) {
-      _log.e('Error loading games: $e');
-    } finally {
-      if (mounted) {
-        setState(() => _isLoading = false);
-        _isLoadingGames = false;
-      }
-    }
   }
 
   /// Selects a game via interaction (touch or click) and triggers resource resolution.

--- a/lib/screens/game_screen/my_games_list/data_loading.dart
+++ b/lib/screens/game_screen/my_games_list/data_loading.dart
@@ -1,0 +1,154 @@
+part of '../my_games_list.dart';
+
+/// Data-loading for the system games list.
+///
+/// Fetches the game collection for the active system and the localized
+/// description for the selected game. All state lives on the host [State]; this
+/// extension only moves the methods out of the monolith — behaviour is
+/// unchanged. `setState` calls route through the host [rebuild] bridge
+/// (`State.setState` is `@protected` and can't be invoked from an extension),
+/// and the host's static `_log` is qualified as `_SystemGamesListState._log`.
+extension _DataLoading on _SystemGamesListState {
+  /// Retrieves localized game descriptions directly from the SQLite database.
+  void _loadLocalizedDescription() async {
+    if (_selectedGame == null) return;
+
+    try {
+      String? systemId;
+
+      // In 'Global Library' mode, resolve the game's native hardware system ID.
+      if ((widget.system.folderName == 'all' ||
+              widget.system.folderName == SystemFolderNames.favorites) &&
+          _selectedGame!.systemFolderName != null) {
+        final originalSystem = await SystemRepository.getSystemByFolderName(
+          _selectedGame!.systemFolderName!,
+        );
+        systemId = originalSystem?.id;
+      } else {
+        systemId = widget.system.id;
+      }
+
+      if (systemId == null) {
+        if (mounted) {
+          rebuild(() {
+            _localizedDescription = null;
+          });
+        }
+        return;
+      }
+
+      final description = await GameRepository.getLocalizedDescription(
+        _selectedGame!.romname,
+        systemId,
+      );
+
+      if (mounted &&
+          _selectedGame != null &&
+          _selectedGame!.romname == _selectedGame!.romname) {
+        rebuild(() {
+          _localizedDescription = description;
+        });
+      }
+    } catch (e) {
+      _SystemGamesListState._log.e('Localized description loading failed: $e');
+      if (mounted) {
+        rebuild(() {
+          _localizedDescription = null;
+        });
+      }
+    }
+  }
+
+  Future<void> _loadGames() async {
+    if (!mounted || _isLoadingGames) return;
+    _isLoadingGames = true;
+
+    final isInitialLoad = _games.isEmpty;
+    if (isInitialLoad) {
+      rebuild(() => _isLoading = true);
+    }
+
+    try {
+      final games = await GameService.loadGamesForSystem(widget.system);
+      if (!mounted) return;
+
+      _SystemGamesListState._log.i(
+        'SystemGamesList: Loaded ${games.length} games for ${widget.system.folderName}',
+      );
+      if (widget.system.folderName == 'music' && games.isNotEmpty) {
+        _SystemGamesListState._log.i(
+          'SystemGamesList: First 3 music tracks: ${games.take(3).map((g) => g.name).toList()}',
+        );
+      }
+      rebuild(() {
+        _games = games;
+        _gameIndexMap = {for (int i = 0; i < games.length; i++) games[i]: i};
+
+        // Music system specialization: Anchor initial focus to the currently active track.
+        if (widget.system.folderName == 'music') {
+          final musicService = MusicPlayerService();
+          if (musicService.isStarted && musicService.currentTrack != null) {
+            final playingTrackPath = musicService.currentTrack?.romPath;
+            final playingIndex = games.indexWhere(
+              (g) => g.romPath == playingTrackPath,
+            );
+
+            if (playingIndex != -1) {
+              _selectedGameIndex = playingIndex;
+              _selectedGame = games[playingIndex];
+              _SystemGamesListState._log.i(
+                'SystemGamesList: Initial focus set to playing track at index $playingIndex',
+              );
+            }
+          }
+        }
+
+        if (widget.initialRomPath != null &&
+            widget.initialRomPath!.isNotEmpty) {
+          final initialIndex = games.indexWhere(
+            (game) => game.romPath == widget.initialRomPath,
+          );
+          if (initialIndex != -1) {
+            _selectedGameIndex = initialIndex;
+            _selectedGame = games[initialIndex];
+          } else {
+            _selectedGameIndex = 0;
+            _selectedGame = games.isNotEmpty ? games.first : null;
+          }
+        } else if (_selectedGame != null &&
+            widget.system.folderName != 'music') {
+          // Persistent Selection Logic: Retain current index if the game still exists post-reload.
+          final selectedIndex = games.indexWhere(
+            (game) => game.romname == _selectedGame!.romname,
+          );
+          if (selectedIndex != -1) {
+            _selectedGameIndex = selectedIndex;
+            _selectedGame = games[selectedIndex];
+          } else {
+            _selectedGameIndex = 0;
+            _selectedGame = games.isNotEmpty ? games.first : null;
+          }
+        } else if (_selectedGame == null) {
+          _selectedGameIndex = 0;
+          _selectedGame = games.isNotEmpty ? games.first : null;
+        }
+        _isLoading = false;
+      });
+
+      // Trigger deferred media and background tasks after initial UI render.
+      if (_selectedGame != null) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          _startVideoTimer();
+          _performBackgroundOperationsForSelectedGame();
+        });
+      }
+    } catch (e) {
+      _SystemGamesListState._log.e('Error loading games: $e');
+    } finally {
+      if (mounted) {
+        rebuild(() => _isLoading = false);
+        _isLoadingGames = false;
+      }
+    }
+  }
+}


### PR DESCRIPTION
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Description

Continues the Phase 3 / A part-split of `my_games_list.dart`. Moves the two data-loading methods of `_SystemGamesListState` — `_loadGames` and `_loadLocalizedDescription` — verbatim into a new `my_games_list/data_loading.dart` part as `extension _DataLoading on _SystemGamesListState`.

Mechanism **(a)** part/extension split: behaviour-preserving, **no public-API change**. All state stays on the host `State`; only methods move. Per the established (a)-split kit:
- `setState(...)` calls route through the host `rebuild()` bridge (`State.setState` is `@protected`, uninvokable from an extension).
- the host's static `_log` is qualified as `_SystemGamesListState._log` (unqualified static access from an extension is an analyze error).

Host **2905 → 2763**; new part file 154 lines. Host diff is a pure move — 143 deletions + the single `part` directive.

Fixes # (issue) — n/a

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [ ] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [ ] Android
- [ ] **Gamepad support verified** (if applicable).

## Notes

🟢 **local-gate only** (pure (a) move, per the selective device-testing policy). Verified locally: `dart format --set-exit-if-changed .` clean, `flutter analyze` **No issues found** project-wide, **207/207** tests pass, host diff = pure move.