### PR TITLE
refactor(settings-dialog): extract gamepad-nav into a part file

### DIFF
--- a/lib/widgets/system_emulator_settings_dialog.dart
+++ b/lib/widgets/system_emulator_settings_dialog.dart
@@ -30,6 +30,8 @@ import '../widgets/core_footer.dart';
 import '../services/permission_service.dart';
 import '../widgets/tv_directory_picker.dart';
 
+part 'system_emulator_settings_dialog/gamepad_nav.dart';
+
 /// Steam-style dialog to configure emulators/cores for a system
 class SystemEmulatorSettingsDialog extends StatefulWidget {
   final SystemModel system;
@@ -144,177 +146,9 @@ class _SystemEmulatorSettingsDialogState
     super.dispose();
   }
 
-  void _initializeGamepad() {
-    _gamepadNav = GamepadNavigation(
-      onNavigateUp: _navigateUp,
-      onNavigateDown: _navigateDown,
-      onPreviousTab: _previousTab,
-      onNextTab: _nextTab,
-      onSelectItem: _handleSelectItem,
-      onBack: _closeDialog,
-    );
-
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _gamepadNav.initialize();
-      GamepadNavigationManager.pushLayer(
-        'system_emulator_settings_dialog',
-        onActivate: () => _gamepadNav.activate(),
-        onDeactivate: () => _gamepadNav.deactivate(),
-      );
-    });
-  }
-
-  void _cleanupGamepad() {
-    GamepadNavigationManager.popLayer('system_emulator_settings_dialog');
-    _gamepadNav.dispose();
-  }
-
-  void _navigateUp() {
-    if (_openMenuIndex != -1) {
-      final focusedContext = FocusManager.instance.primaryFocus?.context;
-      if (focusedContext != null) {
-        Actions.invoke(
-          focusedContext,
-          const DirectionalFocusIntent(TraversalDirection.up),
-        );
-      }
-      return;
-    }
-    if (_currentTab == 1) {
-      if (_totalEmulators == 0) return;
-
-      int newIndex = _selectedIndex;
-      // Find previous selectable item (skip headers)
-      for (int i = 1; i <= _totalEmulators; i++) {
-        final candidate = (newIndex - i + _totalEmulators) % _totalEmulators;
-        if (_displayItems[candidate] is! EmulatorHeaderItem) {
-          setState(() {
-            _selectedIndex = candidate;
-          });
-          break;
-        }
-      }
-
-      _centeredScrollController.updateSelectedIndex(_selectedIndex);
-      _scrollToSelected();
-    } else if (_currentTab == 0) {
-      setState(() {
-        _generalIndex =
-            (_generalIndex - 1 + _totalGeneralItems) % _totalGeneralItems;
-      });
-      _scrollToGeneralSelected();
-    } else if (_currentTab == 2) {
-      setState(() {
-        _appearanceIndex = (_appearanceIndex - 1 + 2) % 2;
-      });
-      _scrollToAppearanceSelected();
-    }
-  }
-
-  void _navigateDown() {
-    if (_openMenuIndex != -1) {
-      final focusedContext = FocusManager.instance.primaryFocus?.context;
-      if (focusedContext != null) {
-        Actions.invoke(
-          focusedContext,
-          const DirectionalFocusIntent(TraversalDirection.down),
-        );
-      }
-      return;
-    }
-    if (_currentTab == 1) {
-      if (_totalEmulators == 0) return;
-
-      int newIndex = _selectedIndex;
-      // Find next selectable item (skip headers)
-      for (int i = 1; i <= _totalEmulators; i++) {
-        final candidate = (newIndex + i) % _totalEmulators;
-        if (_displayItems[candidate] is! EmulatorHeaderItem) {
-          setState(() {
-            _selectedIndex = candidate;
-          });
-          break;
-        }
-      }
-
-      _centeredScrollController.updateSelectedIndex(_selectedIndex);
-      _scrollToSelected();
-    } else if (_currentTab == 0) {
-      setState(() {
-        _generalIndex = (_generalIndex + 1) % _totalGeneralItems;
-      });
-      _scrollToGeneralSelected();
-    } else if (_currentTab == 2) {
-      setState(() {
-        _appearanceIndex = (_appearanceIndex + 1) % 2;
-      });
-      _scrollToAppearanceSelected();
-    }
-  }
-
-  void _previousTab() {
-    List<int> availableTabs = [0, 2];
-    if (widget.system.folderName != 'all' &&
-        widget.system.folderName != 'android') {
-      availableTabs = [0, 1, 2];
-    }
-
-    int currentIndex = availableTabs.indexOf(_currentTab);
-    int prevIndex =
-        (currentIndex - 1 + availableTabs.length) % availableTabs.length;
-    setState(() {
-      _currentTab = availableTabs[prevIndex];
-    });
-  }
-
-  void _nextTab() {
-    List<int> availableTabs = [0, 2];
-    if (widget.system.folderName != 'all' &&
-        widget.system.folderName != 'android') {
-      availableTabs = [0, 1, 2];
-    }
-
-    int currentIndex = availableTabs.indexOf(_currentTab);
-    int nextIndex = (currentIndex + 1) % availableTabs.length;
-    setState(() {
-      _currentTab = availableTabs[nextIndex];
-    });
-  }
-
-  void _handleSelectItem() {
-    if (_openMenuIndex != -1) {
-      final focusedContext = FocusManager.instance.primaryFocus?.context;
-      if (focusedContext != null) {
-        Actions.invoke(focusedContext, const ActivateIntent());
-      }
-      return;
-    }
-    if (_currentTab == 1) {
-      _setSelectedAsDefault();
-    } else if (_currentTab == 0) {
-      if (_generalIndex == 0) {
-        _togglePreferFileName(!_system.preferFileName);
-      } else if (_generalIndex == 1) {
-        _toggleHideExtension(!_system.hideExtension);
-      } else if (_generalIndex == 2) {
-        _toggleHideParentheses(!_system.hideParentheses);
-      } else if (_generalIndex == 3) {
-        _toggleHideBrackets(!_system.hideBrackets);
-      } else if (_generalIndex == 4) {
-        _toggleHideLogo(!_system.hideLogo);
-      } else if (_generalIndex == 5 &&
-          widget.system.folderName != 'all' &&
-          widget.system.folderName != 'android') {
-        _toggleRecursiveScan(!_system.recursiveScan);
-      }
-    } else if (_currentTab == 2) {
-      if (_appearanceIndex == 0) {
-        _pickAndSaveImage();
-      } else if (_appearanceIndex == 1) {
-        _pickAndSaveLogoImage();
-      }
-    }
-  }
+  /// Bridge so `part`/`extension` files can trigger a rebuild — `State.setState`
+  /// is `@protected` and can't be invoked from an extension.
+  void rebuild(VoidCallback fn) => setState(fn);
 
   Future<void> _toggleRecursiveScan(bool value) async {
     setState(() {

--- a/lib/widgets/system_emulator_settings_dialog/gamepad_nav.dart
+++ b/lib/widgets/system_emulator_settings_dialog/gamepad_nav.dart
@@ -1,0 +1,182 @@
+part of '../system_emulator_settings_dialog.dart';
+
+/// Gamepad/keyboard navigation for the emulator settings dialog.
+///
+/// Moves the input-handling slice of [_SystemEmulatorSettingsDialogState] out of
+/// the monolith — behaviour is unchanged. All state lives on the host [State];
+/// extensions can't declare fields. `setState` calls route through the host
+/// [rebuild] bridge (`State.setState` is `@protected` and can't be invoked from
+/// an extension).
+extension _GamepadNav on _SystemEmulatorSettingsDialogState {
+  void _initializeGamepad() {
+    _gamepadNav = GamepadNavigation(
+      onNavigateUp: _navigateUp,
+      onNavigateDown: _navigateDown,
+      onPreviousTab: _previousTab,
+      onNextTab: _nextTab,
+      onSelectItem: _handleSelectItem,
+      onBack: _closeDialog,
+    );
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _gamepadNav.initialize();
+      GamepadNavigationManager.pushLayer(
+        'system_emulator_settings_dialog',
+        onActivate: () => _gamepadNav.activate(),
+        onDeactivate: () => _gamepadNav.deactivate(),
+      );
+    });
+  }
+
+  void _cleanupGamepad() {
+    GamepadNavigationManager.popLayer('system_emulator_settings_dialog');
+    _gamepadNav.dispose();
+  }
+
+  void _navigateUp() {
+    if (_openMenuIndex != -1) {
+      final focusedContext = FocusManager.instance.primaryFocus?.context;
+      if (focusedContext != null) {
+        Actions.invoke(
+          focusedContext,
+          const DirectionalFocusIntent(TraversalDirection.up),
+        );
+      }
+      return;
+    }
+    if (_currentTab == 1) {
+      if (_totalEmulators == 0) return;
+
+      int newIndex = _selectedIndex;
+      // Find previous selectable item (skip headers)
+      for (int i = 1; i <= _totalEmulators; i++) {
+        final candidate = (newIndex - i + _totalEmulators) % _totalEmulators;
+        if (_displayItems[candidate] is! EmulatorHeaderItem) {
+          rebuild(() {
+            _selectedIndex = candidate;
+          });
+          break;
+        }
+      }
+
+      _centeredScrollController.updateSelectedIndex(_selectedIndex);
+      _scrollToSelected();
+    } else if (_currentTab == 0) {
+      rebuild(() {
+        _generalIndex =
+            (_generalIndex - 1 + _totalGeneralItems) % _totalGeneralItems;
+      });
+      _scrollToGeneralSelected();
+    } else if (_currentTab == 2) {
+      rebuild(() {
+        _appearanceIndex = (_appearanceIndex - 1 + 2) % 2;
+      });
+      _scrollToAppearanceSelected();
+    }
+  }
+
+  void _navigateDown() {
+    if (_openMenuIndex != -1) {
+      final focusedContext = FocusManager.instance.primaryFocus?.context;
+      if (focusedContext != null) {
+        Actions.invoke(
+          focusedContext,
+          const DirectionalFocusIntent(TraversalDirection.down),
+        );
+      }
+      return;
+    }
+    if (_currentTab == 1) {
+      if (_totalEmulators == 0) return;
+
+      int newIndex = _selectedIndex;
+      // Find next selectable item (skip headers)
+      for (int i = 1; i <= _totalEmulators; i++) {
+        final candidate = (newIndex + i) % _totalEmulators;
+        if (_displayItems[candidate] is! EmulatorHeaderItem) {
+          rebuild(() {
+            _selectedIndex = candidate;
+          });
+          break;
+        }
+      }
+
+      _centeredScrollController.updateSelectedIndex(_selectedIndex);
+      _scrollToSelected();
+    } else if (_currentTab == 0) {
+      rebuild(() {
+        _generalIndex = (_generalIndex + 1) % _totalGeneralItems;
+      });
+      _scrollToGeneralSelected();
+    } else if (_currentTab == 2) {
+      rebuild(() {
+        _appearanceIndex = (_appearanceIndex + 1) % 2;
+      });
+      _scrollToAppearanceSelected();
+    }
+  }
+
+  void _previousTab() {
+    List<int> availableTabs = [0, 2];
+    if (widget.system.folderName != 'all' &&
+        widget.system.folderName != 'android') {
+      availableTabs = [0, 1, 2];
+    }
+
+    int currentIndex = availableTabs.indexOf(_currentTab);
+    int prevIndex =
+        (currentIndex - 1 + availableTabs.length) % availableTabs.length;
+    rebuild(() {
+      _currentTab = availableTabs[prevIndex];
+    });
+  }
+
+  void _nextTab() {
+    List<int> availableTabs = [0, 2];
+    if (widget.system.folderName != 'all' &&
+        widget.system.folderName != 'android') {
+      availableTabs = [0, 1, 2];
+    }
+
+    int currentIndex = availableTabs.indexOf(_currentTab);
+    int nextIndex = (currentIndex + 1) % availableTabs.length;
+    rebuild(() {
+      _currentTab = availableTabs[nextIndex];
+    });
+  }
+
+  void _handleSelectItem() {
+    if (_openMenuIndex != -1) {
+      final focusedContext = FocusManager.instance.primaryFocus?.context;
+      if (focusedContext != null) {
+        Actions.invoke(focusedContext, const ActivateIntent());
+      }
+      return;
+    }
+    if (_currentTab == 1) {
+      _setSelectedAsDefault();
+    } else if (_currentTab == 0) {
+      if (_generalIndex == 0) {
+        _togglePreferFileName(!_system.preferFileName);
+      } else if (_generalIndex == 1) {
+        _toggleHideExtension(!_system.hideExtension);
+      } else if (_generalIndex == 2) {
+        _toggleHideParentheses(!_system.hideParentheses);
+      } else if (_generalIndex == 3) {
+        _toggleHideBrackets(!_system.hideBrackets);
+      } else if (_generalIndex == 4) {
+        _toggleHideLogo(!_system.hideLogo);
+      } else if (_generalIndex == 5 &&
+          widget.system.folderName != 'all' &&
+          widget.system.folderName != 'android') {
+        _toggleRecursiveScan(!_system.recursiveScan);
+      }
+    } else if (_currentTab == 2) {
+      if (_appearanceIndex == 0) {
+        _pickAndSaveImage();
+      } else if (_appearanceIndex == 1) {
+        _pickAndSaveLogoImage();
+      }
+    }
+  }
+}


### PR DESCRIPTION
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Description

**Phase 3 / C — first part/extension split** of `system_emulator_settings_dialog.dart`, mirroring the neo_sync pattern and the completed A series.

Moves the gamepad/keyboard navigation slice of `_SystemEmulatorSettingsDialogState` — `_initializeGamepad`, `_cleanupGamepad`, `_navigateUp`, `_navigateDown`, `_previousTab`, `_nextTab`, `_handleSelectItem` — **verbatim** into new `system_emulator_settings_dialog/gamepad_nav.dart` as `extension _GamepadNav on _SystemEmulatorSettingsDialogState`.

All state stays on the host (extensions can't declare fields). The 8 `setState` calls route through a new host `rebuild(VoidCallback) => setState(fn)` bridge — `State.setState` is `@protected` and can't be invoked from an extension (same reason as neo_sync's `notify()`). No statics are referenced in the moved slice.

- Host **2980 → 2814** (5 insertions = `part` directive + `rebuild` bridge; 171 deletions — pure deletion diff otherwise).
- New file: 182 lines.
- Zero public-API or behaviour change.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [x] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [ ] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [ ] Android
- [ ] **Gamepad support verified** (if applicable).

## Verification

🟢 **Local-gate only** (pure (a) move, per selective-testing policy):
- `dart format --set-exit-if-changed .` — clean project-wide (only the 2 changed files touched).
- `flutter analyze` — **No issues found!**
- `flutter test` — **207/207** pass.
- Token-stream diff of the moved bodies vs `main` — **byte-identical** modulo the intended `setState`→`rebuild` substitution.
- Host diff = `part` directive + `rebuild` bridge + deletions only.