### PR TITLE
refactor(systems-grid): extract pull-to-refresh/pinch gestures into a part file

### DIFF
--- a/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
@@ -42,6 +42,7 @@ import 'system_list_builder.dart';
 
 part 'my_systems_grid/gamepad_grid_nav.dart';
 part 'my_systems_grid/theme_background.dart';
+part 'my_systems_grid/pull_to_refresh.dart';
 
 /// Primary widget for the 'My Systems' view, supporting both Grid and Carousel layouts.
 ///
@@ -860,104 +861,6 @@ class _SystemCardGridViewState extends State<SystemCardGridView> {
         );
       },
     );
-  }
-
-  void _handlePointerDown(PointerDownEvent event) {
-    _activePointers[event.pointer] = event.position;
-  }
-
-  void _handlePointerMove(PointerMoveEvent event) {
-    _activePointers[event.pointer] = event.position;
-    if (_activePointers.length < 2) return;
-
-    final now = DateTime.now();
-    if (_lastPinchTime != null &&
-        now.difference(_lastPinchTime!).inMilliseconds < 120) {
-      return;
-    }
-
-    final positions = _activePointers.values.toList();
-    final distance = (positions[0] - positions[1]).distance;
-
-    if (_lastPinchDistance != null) {
-      final deltaDistance = distance - _lastPinchDistance!;
-      if (deltaDistance > 35) {
-        _adjustGridDensity(1);
-        _lastPinchDistance = distance;
-        _lastPinchTime = now;
-      } else if (deltaDistance < -35) {
-        _adjustGridDensity(-1);
-        _lastPinchDistance = distance;
-        _lastPinchTime = now;
-      }
-    } else {
-      _lastPinchDistance = distance;
-    }
-  }
-
-  void _handlePointerUp(PointerUpEvent event) {
-    _activePointers.remove(event.pointer);
-    if (_activePointers.length < 2) {
-      _lastPinchDistance = null;
-    }
-    if (_activePointers.isEmpty && _pullReady) {
-      _pullReady = false;
-      _pullProgress.value = 0.0;
-      _triggerRefresh();
-    }
-  }
-
-  void _handlePointerCancel(PointerCancelEvent event) {
-    _activePointers.remove(event.pointer);
-    if (_activePointers.length < 2) {
-      _lastPinchDistance = null;
-    }
-    if (_activePointers.isEmpty && _pullReady) {
-      _pullReady = false;
-      _pullProgress.value = 0.0;
-      _triggerRefresh();
-    }
-  }
-
-  /// Triggers ROM directory rescan when pull-to-refresh reaches 100%.
-  void _triggerRefresh() {
-    try {
-      final configProvider = context.read<SqliteConfigProvider>();
-      if (!configProvider.isScanning) {
-        SfxService().playNavSound();
-        configProvider.scanSystems();
-      }
-    } catch (_) {
-      // Ignore if context/provider is no longer valid.
-    }
-  }
-
-  /// Adjusts grid column density based on pinch gesture direction.
-  void _adjustGridDensity(int delta) {
-    try {
-      final provider = context.read<SqliteConfigProvider>();
-      final sizes = ['S', 'M', 'L', 'XL'];
-      final currentIndex = sizes.indexOf(provider.config.systemGridColumns);
-      if (currentIndex == -1) return;
-      final newIndex = (currentIndex + delta).clamp(0, sizes.length - 1);
-      if (newIndex != currentIndex) {
-        final newSize = sizes[newIndex];
-        provider.updateSystemGridColumns(newSize);
-        _cols = Responsive.getSystemsCrossAxisCountFromSize(newSize);
-        _cachedVirtualGrid = null;
-        _cachedGridCols = null;
-        _showCardSizeLabel(newSize);
-        setState(() {});
-      }
-    } catch (_) {}
-  }
-
-  void _showCardSizeLabel(String size) {
-    _cardSizeLabelTimer?.cancel();
-    _cardSizeLabel.value = size;
-    _cardSizeLabelTimer = Timer(const Duration(milliseconds: 1200), () {
-      _cardSizeLabel.value = null;
-    });
   }
 
   /// Renders a non-linear grid by manually positioning components according to their spans.

--- a/lib/screens/systems_screen/my_systems_section/my_systems_grid/pull_to_refresh.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_grid/pull_to_refresh.dart
@@ -1,0 +1,110 @@
+part of '../my_systems_grid.dart';
+
+/// Pull-to-refresh and pinch-to-zoom gesture handling for the systems grid.
+///
+/// The pointer slice of [_SystemCardGridViewState] — tracking active pointers to
+/// drive the pull-to-refresh drag and the two-finger pinch that adjusts grid
+/// density, plus the refresh trigger and the transient card-size label — moved out
+/// of the monolith. Behaviour is unchanged. State lives on the host [State]
+/// (extensions can't declare fields); `setState` calls route through the host
+/// [rebuild] bridge (`State.setState` is `@protected` and can't be invoked from an
+/// extension).
+extension _PullToRefresh on _SystemCardGridViewState {
+  void _handlePointerDown(PointerDownEvent event) {
+    _activePointers[event.pointer] = event.position;
+  }
+
+  void _handlePointerMove(PointerMoveEvent event) {
+    _activePointers[event.pointer] = event.position;
+    if (_activePointers.length < 2) return;
+
+    final now = DateTime.now();
+    if (_lastPinchTime != null &&
+        now.difference(_lastPinchTime!).inMilliseconds < 120) {
+      return;
+    }
+
+    final positions = _activePointers.values.toList();
+    final distance = (positions[0] - positions[1]).distance;
+
+    if (_lastPinchDistance != null) {
+      final deltaDistance = distance - _lastPinchDistance!;
+      if (deltaDistance > 35) {
+        _adjustGridDensity(1);
+        _lastPinchDistance = distance;
+        _lastPinchTime = now;
+      } else if (deltaDistance < -35) {
+        _adjustGridDensity(-1);
+        _lastPinchDistance = distance;
+        _lastPinchTime = now;
+      }
+    } else {
+      _lastPinchDistance = distance;
+    }
+  }
+
+  void _handlePointerUp(PointerUpEvent event) {
+    _activePointers.remove(event.pointer);
+    if (_activePointers.length < 2) {
+      _lastPinchDistance = null;
+    }
+    if (_activePointers.isEmpty && _pullReady) {
+      _pullReady = false;
+      _pullProgress.value = 0.0;
+      _triggerRefresh();
+    }
+  }
+
+  void _handlePointerCancel(PointerCancelEvent event) {
+    _activePointers.remove(event.pointer);
+    if (_activePointers.length < 2) {
+      _lastPinchDistance = null;
+    }
+    if (_activePointers.isEmpty && _pullReady) {
+      _pullReady = false;
+      _pullProgress.value = 0.0;
+      _triggerRefresh();
+    }
+  }
+
+  /// Triggers ROM directory rescan when pull-to-refresh reaches 100%.
+  void _triggerRefresh() {
+    try {
+      final configProvider = context.read<SqliteConfigProvider>();
+      if (!configProvider.isScanning) {
+        SfxService().playNavSound();
+        configProvider.scanSystems();
+      }
+    } catch (_) {
+      // Ignore if context/provider is no longer valid.
+    }
+  }
+
+  /// Adjusts grid column density based on pinch gesture direction.
+  void _adjustGridDensity(int delta) {
+    try {
+      final provider = context.read<SqliteConfigProvider>();
+      final sizes = ['S', 'M', 'L', 'XL'];
+      final currentIndex = sizes.indexOf(provider.config.systemGridColumns);
+      if (currentIndex == -1) return;
+      final newIndex = (currentIndex + delta).clamp(0, sizes.length - 1);
+      if (newIndex != currentIndex) {
+        final newSize = sizes[newIndex];
+        provider.updateSystemGridColumns(newSize);
+        _cols = Responsive.getSystemsCrossAxisCountFromSize(newSize);
+        _cachedVirtualGrid = null;
+        _cachedGridCols = null;
+        _showCardSizeLabel(newSize);
+        rebuild(() {});
+      }
+    } catch (_) {}
+  }
+
+  void _showCardSizeLabel(String size) {
+    _cardSizeLabelTimer?.cancel();
+    _cardSizeLabel.value = size;
+    _cardSizeLabelTimer = Timer(const Duration(milliseconds: 1200), () {
+      _cardSizeLabel.value = null;
+    });
+  }
+}


### PR DESCRIPTION
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Description

Phase 3 **D** (grid controller parts) — third and **final** slice, following #152 and #153. **Closes out D.** Splits the pointer/gesture handling out of the `my_systems_grid.dart` monolith using the in-repo `neo_sync_provider` part/extension pattern.

Moves 7 contiguous methods of `_SystemCardGridViewState` verbatim into a new part file `my_systems_grid/pull_to_refresh.dart` as `extension _PullToRefresh`:
`_handlePointerDown`, `_handlePointerMove`, `_handlePointerUp`, `_handlePointerCancel`, `_triggerRefresh`, `_adjustGridDensity`, `_showCardSizeLabel`.

- **No behaviour or public-API change** — pure source split. Moved bodies are byte-identical to `main` (token-stream verified).
- All state stays on the host `State` (extensions can't declare fields). The 1 `setState` call routes through the host `rebuild()` bridge (`State.setState` is `@protected`).
- Host **1108 → 1011**; new file 111 lines. The `my_systems_grid.dart` controller monolith is now split across 3 part files (nav / theme-background / gestures) + a slimmed host.

Fixes # (issue) — n/a (refactor)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [x] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [ ] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [ ] Android
- [ ] **Gamepad support verified** (if applicable).

## Notes

🟢 **Local-gate only** (pure `(a)` move, per the selective device-testing policy): `dart format --set-exit-if-changed .` clean, `flutter analyze` "No issues found!" project-wide, `flutter test` 207/207. No device smoke.