### PR TITLE
refactor(settings): extract LanguagePickerOverlay into its own widget file

### DIFF
--- a/lib/screens/settings_screen/new_settings_options/general_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/general_settings_content.dart
@@ -10,14 +10,12 @@ import 'package:provider/provider.dart';
 import 'package:window_manager/window_manager.dart';
 import 'package:fullscreen_window/fullscreen_window.dart';
 import 'package:neostation/services/logger_service.dart';
-import 'package:neostation/services/sfx_service.dart';
 import 'package:neostation/utils/adaptive_scroll.dart';
-import 'package:neostation/services/game_service.dart';
-import 'package:neostation/utils/gamepad_nav.dart';
 import '../../../providers/sqlite_config_provider.dart';
 import '../../../widgets/custom_toggle_switch.dart';
 import 'settings_title.dart';
 import 'widgets/setting_row.dart';
+import 'widgets/language_picker_overlay.dart';
 import '../../../services/permission_service.dart';
 
 /// A specialized content panel for system-wide configuration, including platform-specific orchestration (Windows/Android/Linux).
@@ -713,7 +711,7 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
       pageBuilder: (context, animation, _) {
         return FadeTransition(
           opacity: animation,
-          child: _LanguagePickerOverlay(
+          child: LanguagePickerOverlay(
             anchorOffset: offset + Offset(size.width, size.height / 2),
             currentLang: currentLang,
           ),
@@ -724,232 +722,5 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
     if (result != null && mounted) {
       context.read<SqliteConfigProvider>().updateAppLanguage(result);
     }
-  }
-}
-
-/// An autonomous gamepad-navigable overlay for language selection.
-class _LanguagePickerOverlay extends StatefulWidget {
-  final Offset anchorOffset;
-  final String currentLang;
-
-  const _LanguagePickerOverlay({
-    required this.anchorOffset,
-    required this.currentLang,
-  });
-
-  @override
-  State<_LanguagePickerOverlay> createState() => _LanguagePickerOverlayState();
-}
-
-class _LanguagePickerOverlayState extends State<_LanguagePickerOverlay> {
-  late GamepadNavigation _gamepadNav;
-  int _selectedIndex = 0;
-
-  static final _languages = AppLocale.supportedLanguages.entries
-      .map((e) => (e.key, e.value))
-      .toList();
-
-  final List<GlobalKey> _itemKeys = List.generate(
-    _languages.length,
-    (_) => GlobalKey(),
-  );
-  final GlobalKey _colKey = GlobalKey();
-  double _indicatorTop = -1;
-
-  @override
-  void initState() {
-    super.initState();
-    _selectedIndex = _languages.indexWhere((l) => l.$1 == widget.currentLang);
-    if (_selectedIndex < 0) _selectedIndex = 0;
-
-    _gamepadNav = GamepadNavigation(
-      onNavigateUp: () {
-        setState(() {
-          _selectedIndex =
-              (_selectedIndex - 1 + _languages.length) % _languages.length;
-        });
-        _updateIndicator();
-        SfxService().playNavSound();
-      },
-      onNavigateDown: () {
-        setState(() {
-          _selectedIndex = (_selectedIndex + 1) % _languages.length;
-        });
-        _updateIndicator();
-        SfxService().playNavSound();
-      },
-      onSelectItem: _handleSelection,
-      onBack: () => Navigator.pop(context),
-    );
-
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _gamepadNav.initialize();
-      GamepadNavigationManager.pushLayer(
-        'language_picker_overlay',
-        onActivate: () => _gamepadNav.activate(),
-        onDeactivate: () => _gamepadNav.deactivate(),
-      );
-      _updateIndicator();
-    });
-  }
-
-  @override
-  void dispose() {
-    GamepadNavigationManager.popLayer('language_picker_overlay');
-    _gamepadNav.dispose();
-    super.dispose();
-  }
-
-  /// Calculates the visual position of the selection indicator.
-  void _updateIndicator() {
-    if (!mounted) return;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      final key = _itemKeys[_selectedIndex];
-      final RenderBox? box =
-          key.currentContext?.findRenderObject() as RenderBox?;
-      final RenderBox? colBox =
-          _colKey.currentContext?.findRenderObject() as RenderBox?;
-      if (box != null && colBox != null) {
-        final pos = box.localToGlobal(Offset.zero, ancestor: colBox);
-        setState(() => _indicatorTop = pos.dy);
-      }
-    });
-  }
-
-  void _handleSelection() {
-    SfxService().playEnterSound();
-    Navigator.pop(context, _languages[_selectedIndex].$1);
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final screenSize = MediaQuery.of(context).size;
-    final overlayWidth = 180.r;
-    final itemHeight = 24;
-    final overlayHeight = itemHeight * _languages.length + 16;
-
-    // Anchor: Right-aligned relative to the trigger button, clamped to viewport boundaries.
-    double left = widget.anchorOffset.dx - overlayWidth;
-    double top = widget.anchorOffset.dy - overlayHeight.r / 1.5;
-    left = left.clamp(8.0, screenSize.width - overlayWidth - 8);
-    top = top.clamp(8.0, screenSize.height - overlayHeight - 8);
-
-    return Stack(
-      children: [
-        Positioned(
-          left: left,
-          top: top,
-          width: overlayWidth,
-          child: Material(
-            color: Colors.transparent,
-            child: Container(
-              padding: EdgeInsets.symmetric(vertical: 8.r),
-              decoration: BoxDecoration(
-                color: theme.colorScheme.surface,
-                borderRadius: BorderRadius.circular(12.r),
-                border: Border.all(
-                  color: theme.colorScheme.primary.withValues(alpha: 0.2),
-                  width: 1,
-                ),
-                boxShadow: [
-                  BoxShadow(
-                    color: Colors.black.withValues(alpha: 0.25),
-                    blurRadius: 15,
-                    offset: const Offset(0, 5),
-                  ),
-                ],
-              ),
-              child: Stack(
-                key: _colKey,
-                children: [
-                  if (_indicatorTop >= 0)
-                    AnimatedPositioned(
-                      duration: const Duration(milliseconds: 150),
-                      curve: Curves.easeInOut,
-                      top: _indicatorTop,
-                      left: 6.r,
-                      right: 4.r,
-                      height: itemHeight.r,
-                      child: Container(
-                        decoration: BoxDecoration(
-                          color: theme.colorScheme.primary.withValues(
-                            alpha: 0.15,
-                          ),
-                          borderRadius: BorderRadius.circular(8.r),
-                          border: Border.all(
-                            color: theme.colorScheme.primary.withValues(
-                              alpha: 0.3,
-                            ),
-                            width: 0.5.r,
-                          ),
-                        ),
-                      ),
-                    ),
-                  Column(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: _languages.asMap().entries.map((entry) {
-                      final i = entry.key;
-                      final lang = entry.value;
-                      final isSelected = lang.$1 == widget.currentLang;
-                      return SizedBox(
-                        key: _itemKeys[i],
-                        height: itemHeight.r,
-                        child: InkWell(
-                          onTap: () {
-                            setState(() => _selectedIndex = i);
-                            _handleSelection();
-                          },
-                          onHover: (v) {
-                            if (v) {
-                              setState(() => _selectedIndex = i);
-                              _updateIndicator();
-                            }
-                          },
-                          focusColor: Colors.transparent,
-                          hoverColor: Colors.transparent,
-                          splashColor: Colors.transparent,
-                          highlightColor: Colors.transparent,
-                          borderRadius: BorderRadius.circular(8.r),
-                          child: Padding(
-                            padding: EdgeInsets.symmetric(horizontal: 12.r),
-                            child: Row(
-                              children: [
-                                Expanded(
-                                  child: Text(
-                                    lang.$2,
-                                    style: TextStyle(
-                                      fontSize: 10.r,
-                                      color: isSelected
-                                          ? theme.colorScheme.secondary
-                                          : theme.colorScheme.onSurface,
-                                      fontWeight: isSelected
-                                          ? FontWeight.w600
-                                          : FontWeight.w400,
-                                    ),
-                                  ),
-                                ),
-                                if (isSelected)
-                                  Icon(
-                                    Symbols.check_rounded,
-                                    size: 12.r,
-                                    color: theme.colorScheme.secondary,
-                                  ),
-                              ],
-                            ),
-                          ),
-                        ),
-                      );
-                    }).toList(),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ),
-      ],
-    );
   }
 }

--- a/lib/screens/settings_screen/new_settings_options/widgets/language_picker_overlay.dart
+++ b/lib/screens/settings_screen/new_settings_options/widgets/language_picker_overlay.dart
@@ -1,0 +1,235 @@
+import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:neostation/l10n/app_locale.dart';
+import 'package:neostation/services/sfx_service.dart';
+import 'package:neostation/services/game_service.dart';
+import 'package:neostation/utils/gamepad_nav.dart';
+
+/// An autonomous gamepad-navigable overlay for language selection.
+class LanguagePickerOverlay extends StatefulWidget {
+  final Offset anchorOffset;
+  final String currentLang;
+
+  const LanguagePickerOverlay({
+    super.key,
+    required this.anchorOffset,
+    required this.currentLang,
+  });
+
+  @override
+  State<LanguagePickerOverlay> createState() => LanguagePickerOverlayState();
+}
+
+class LanguagePickerOverlayState extends State<LanguagePickerOverlay> {
+  late GamepadNavigation _gamepadNav;
+  int _selectedIndex = 0;
+
+  static final _languages = AppLocale.supportedLanguages.entries
+      .map((e) => (e.key, e.value))
+      .toList();
+
+  final List<GlobalKey> _itemKeys = List.generate(
+    _languages.length,
+    (_) => GlobalKey(),
+  );
+  final GlobalKey _colKey = GlobalKey();
+  double _indicatorTop = -1;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedIndex = _languages.indexWhere((l) => l.$1 == widget.currentLang);
+    if (_selectedIndex < 0) _selectedIndex = 0;
+
+    _gamepadNav = GamepadNavigation(
+      onNavigateUp: () {
+        setState(() {
+          _selectedIndex =
+              (_selectedIndex - 1 + _languages.length) % _languages.length;
+        });
+        _updateIndicator();
+        SfxService().playNavSound();
+      },
+      onNavigateDown: () {
+        setState(() {
+          _selectedIndex = (_selectedIndex + 1) % _languages.length;
+        });
+        _updateIndicator();
+        SfxService().playNavSound();
+      },
+      onSelectItem: _handleSelection,
+      onBack: () => Navigator.pop(context),
+    );
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _gamepadNav.initialize();
+      GamepadNavigationManager.pushLayer(
+        'language_picker_overlay',
+        onActivate: () => _gamepadNav.activate(),
+        onDeactivate: () => _gamepadNav.deactivate(),
+      );
+      _updateIndicator();
+    });
+  }
+
+  @override
+  void dispose() {
+    GamepadNavigationManager.popLayer('language_picker_overlay');
+    _gamepadNav.dispose();
+    super.dispose();
+  }
+
+  /// Calculates the visual position of the selection indicator.
+  void _updateIndicator() {
+    if (!mounted) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final key = _itemKeys[_selectedIndex];
+      final RenderBox? box =
+          key.currentContext?.findRenderObject() as RenderBox?;
+      final RenderBox? colBox =
+          _colKey.currentContext?.findRenderObject() as RenderBox?;
+      if (box != null && colBox != null) {
+        final pos = box.localToGlobal(Offset.zero, ancestor: colBox);
+        setState(() => _indicatorTop = pos.dy);
+      }
+    });
+  }
+
+  void _handleSelection() {
+    SfxService().playEnterSound();
+    Navigator.pop(context, _languages[_selectedIndex].$1);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final screenSize = MediaQuery.of(context).size;
+    final overlayWidth = 180.r;
+    final itemHeight = 24;
+    final overlayHeight = itemHeight * _languages.length + 16;
+
+    // Anchor: Right-aligned relative to the trigger button, clamped to viewport boundaries.
+    double left = widget.anchorOffset.dx - overlayWidth;
+    double top = widget.anchorOffset.dy - overlayHeight.r / 1.5;
+    left = left.clamp(8.0, screenSize.width - overlayWidth - 8);
+    top = top.clamp(8.0, screenSize.height - overlayHeight - 8);
+
+    return Stack(
+      children: [
+        Positioned(
+          left: left,
+          top: top,
+          width: overlayWidth,
+          child: Material(
+            color: Colors.transparent,
+            child: Container(
+              padding: EdgeInsets.symmetric(vertical: 8.r),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surface,
+                borderRadius: BorderRadius.circular(12.r),
+                border: Border.all(
+                  color: theme.colorScheme.primary.withValues(alpha: 0.2),
+                  width: 1,
+                ),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.25),
+                    blurRadius: 15,
+                    offset: const Offset(0, 5),
+                  ),
+                ],
+              ),
+              child: Stack(
+                key: _colKey,
+                children: [
+                  if (_indicatorTop >= 0)
+                    AnimatedPositioned(
+                      duration: const Duration(milliseconds: 150),
+                      curve: Curves.easeInOut,
+                      top: _indicatorTop,
+                      left: 6.r,
+                      right: 4.r,
+                      height: itemHeight.r,
+                      child: Container(
+                        decoration: BoxDecoration(
+                          color: theme.colorScheme.primary.withValues(
+                            alpha: 0.15,
+                          ),
+                          borderRadius: BorderRadius.circular(8.r),
+                          border: Border.all(
+                            color: theme.colorScheme.primary.withValues(
+                              alpha: 0.3,
+                            ),
+                            width: 0.5.r,
+                          ),
+                        ),
+                      ),
+                    ),
+                  Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: _languages.asMap().entries.map((entry) {
+                      final i = entry.key;
+                      final lang = entry.value;
+                      final isSelected = lang.$1 == widget.currentLang;
+                      return SizedBox(
+                        key: _itemKeys[i],
+                        height: itemHeight.r,
+                        child: InkWell(
+                          onTap: () {
+                            setState(() => _selectedIndex = i);
+                            _handleSelection();
+                          },
+                          onHover: (v) {
+                            if (v) {
+                              setState(() => _selectedIndex = i);
+                              _updateIndicator();
+                            }
+                          },
+                          focusColor: Colors.transparent,
+                          hoverColor: Colors.transparent,
+                          splashColor: Colors.transparent,
+                          highlightColor: Colors.transparent,
+                          borderRadius: BorderRadius.circular(8.r),
+                          child: Padding(
+                            padding: EdgeInsets.symmetric(horizontal: 12.r),
+                            child: Row(
+                              children: [
+                                Expanded(
+                                  child: Text(
+                                    lang.$2,
+                                    style: TextStyle(
+                                      fontSize: 10.r,
+                                      color: isSelected
+                                          ? theme.colorScheme.secondary
+                                          : theme.colorScheme.onSurface,
+                                      fontWeight: isSelected
+                                          ? FontWeight.w600
+                                          : FontWeight.w400,
+                                    ),
+                                  ),
+                                ),
+                                if (isSelected)
+                                  Icon(
+                                    Symbols.check_rounded,
+                                    size: 12.r,
+                                    color: theme.colorScheme.secondary,
+                                  ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      );
+                    }).toList(),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Description

Phase 3 **E** of the file-split refactor campaign. Extracts the self-contained
`_LanguagePickerOverlay` StatefulWidget out of the 955-line
`new_settings_options/general_settings_content.dart` into a new file,
`new_settings_options/widgets/language_picker_overlay.dart`, promoted to a public
`LanguagePickerOverlay`.

The widget is **autonomous** — it takes `anchorOffset` + `currentLang` and returns its
result via `Navigator.pop`, reading no host state. The `configProvider` read and result
handling stay in the host's `_showLanguagePicker`, which constructs the widget at the
**identical** `showGeneralDialog` call site, so context ancestry is unchanged.

- Body is **byte-identical** (verified via token-stream normalization against `main`); the
  only deltas are the private→public rename and the added `super.key` parameter.
- Dropped 3 now-overlay-only host imports (`sfx_service`, `game_service`, `gamepad_nav`).
- Host **955 → 725**; new file 234 lines.

No behaviour change, no public-API change to the host.

Fixes # (issue)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [ ] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [ ] Android
- [ ] **Gamepad support verified** (if applicable).

## Notes

Local gate green: `dart format --set-exit-if-changed .` clean, `flutter analyze` **No issues
found** project-wide, **207/207** tests pass, token-stream body byte-identity **IDENTICAL** vs
`main`, host diff = new import + caller rename + deletions.

**Not device-tested** (pure move-as-is per the selective-testing policy: the widget already
existed as its own `StatefulWidget` and moved verbatim; context ancestry is unchanged). Happy
to run a Thor smoke of the language picker as a belt-and-braces exception if preferred.
