### PR TITLE
refactor(screenscraper): extract region-priority config into a collaborator

### DIFF
--- a/lib/services/screenscraper/region_config.dart
+++ b/lib/services/screenscraper/region_config.dart
@@ -1,0 +1,39 @@
+import '../../repositories/scraper_repository.dart';
+
+/// Region-priority resolution for ScreenScraper media/text selection.
+///
+/// Owns the default region ordering and builds the priority map used when
+/// picking the best regional asset for a game. Extracted verbatim from
+/// [ScreenScraperService] as the first step of the facade decomposition;
+/// behaviour is unchanged.
+class ScreenscraperRegionConfig {
+  ScreenscraperRegionConfig._();
+
+  static const List<String> _defaultRegionOrder = [
+    'wor',
+    'us',
+    'eu',
+    'jp',
+    'sp',
+    'fr',
+    'de',
+    'it',
+    'kr',
+    'cn',
+  ];
+
+  static Map<String, int> _buildRegionPriorityMap(List<String> orderedRegions) {
+    return {
+      for (var i = 0; i < orderedRegions.length; i++)
+        orderedRegions[i]: (orderedRegions.length - i) * 10,
+    };
+  }
+
+  static Future<Map<String, int>> getRegionPriority() async {
+    try {
+      final regions = await ScraperRepository.getRegionPriority();
+      if (regions.isNotEmpty) return _buildRegionPriorityMap(regions);
+    } catch (_) {}
+    return _buildRegionPriorityMap(_defaultRegionOrder);
+  }
+}

--- a/lib/services/screenscraper_service.dart
+++ b/lib/services/screenscraper_service.dart
@@ -9,6 +9,7 @@ import 'package:path/path.dart' as path;
 import 'package:http/io_client.dart';
 import 'package:neostation/services/logger_service.dart';
 import '../repositories/scraper_repository.dart';
+import 'screenscraper/region_config.dart';
 import '../repositories/system_repository.dart';
 import 'config_service.dart';
 import '../utils/optimized_md5_utils.dart';
@@ -29,34 +30,6 @@ import '../widgets/scraping_summary_dialog.dart';
 class ScreenScraperService {
   static const String _baseUrl = 'https://api.screenscraper.fr/api2';
   static final _log = LoggerService.instance;
-
-  static const List<String> _defaultRegionOrder = [
-    'wor',
-    'us',
-    'eu',
-    'jp',
-    'sp',
-    'fr',
-    'de',
-    'it',
-    'kr',
-    'cn',
-  ];
-
-  static Map<String, int> _buildRegionPriorityMap(List<String> orderedRegions) {
-    return {
-      for (var i = 0; i < orderedRegions.length; i++)
-        orderedRegions[i]: (orderedRegions.length - i) * 10,
-    };
-  }
-
-  static Future<Map<String, int>> _getRegionPriority() async {
-    try {
-      final regions = await ScraperRepository.getRegionPriority();
-      if (regions.isNotEmpty) return _buildRegionPriorityMap(regions);
-    } catch (_) {}
-    return _buildRegionPriorityMap(_defaultRegionOrder);
-  }
 
   // Developer credentials — provided at build time via --dart-define
   // or at runtime via environment variables.
@@ -643,7 +616,7 @@ class ScreenScraperService {
     Map<String, dynamic> gameInfo, {
     String? preferredLanguage,
   }) async {
-    final regionPriority = await _getRegionPriority();
+    final regionPriority = await ScreenscraperRegionConfig.getRegionPriority();
     final metadata = <String, dynamic>{};
     metadata['filename'] = filename;
 
@@ -947,7 +920,7 @@ class ScreenScraperService {
     }
 
     final userDataDir = await _getMediaDirectory();
-    final regionPriority = await _getRegionPriority();
+    final regionPriority = await ScreenscraperRegionConfig.getRegionPriority();
     final mediaTypes =
         allowedMediaTypes ?? ['fanart', 'ss', 'video', 'wheel', 'box2D'];
 


### PR DESCRIPTION
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Description

Phase 4 **G** of the file-split refactor campaign — **first (c) collaborator** extracted from
the 1,534-line `ScreenScraperService`. Moves the self-contained region-priority cluster
(`_defaultRegionOrder`, `_buildRegionPriorityMap`, `_getRegionPriority`) into a new
`services/screenscraper/region_config.dart` as a `ScreenscraperRegionConfig` collaborator.

- The only externally-called member is promoted to public `getRegionPriority`; the other two
  stay private on the collaborator. The two internal callers (`_mapGameInfoToMetadata`,
  `_downloadGameMedia`) delegate to it.
- The cluster owns **no shared mutable static state**, so this is a clean move — bodies are
  **byte-identical** (token-stream verified vs `main`).
- **No public-API change** — all three moved members were private helpers; the 11 public facade
  methods are untouched, so none of the 8 importers see any change.
- Host `screenscraper_service.dart` shrinks by 30 lines; new file 39 lines.

Fixes # (issue)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [ ] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [ ] Android
- [ ] **Gamepad support verified** (if applicable).

## Notes

Local gate green: `dart format --set-exit-if-changed .` clean, `flutter analyze` **No issues
found** project-wide, **207/207** tests, token-stream body byte-identity **IDENTICAL** vs `main`,
host diff = new import + 2 caller rewrites + deletions.

**Not device-tested** — pure internal move of private helpers with no state and byte-identical
bodies; no public surface touched. This is the smallest/safest G slice, opening the facade
decomposition. Later G slices (credentials, HTTP client, media downloader, rom hasher) that
touch shared static state will get closer scrutiny.
