### PR TITLE
refactor(screenscraper): extract media downloader into a collaborator

### DIFF
--- a/lib/services/screenscraper/media_downloader.dart
+++ b/lib/services/screenscraper/media_downloader.dart
@@ -1,0 +1,190 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:neostation/services/logger_service.dart';
+import 'region_config.dart';
+import 'rom_hasher.dart';
+import 'media_resolver.dart';
+import 'screenscraper_client.dart';
+
+/// Media asset downloader for ScreenScraper.
+///
+/// Downloads a game's media assets (boxart, screenshots, etc.) in bounded
+/// concurrent batches, selecting the best regional/language variant, mapping
+/// media types to folders, and skipping assets already on disk. Delegates
+/// transport to [ScreenscraperClient], resolution to [ScreenscraperMediaResolver]
+/// / [ScreenscraperRegionConfig], and ROM naming to [ScreenscraperRomHasher].
+/// Extracted verbatim from [ScreenScraperService]; behaviour is unchanged.
+/// Stateless — holds only the shared logger.
+class ScreenscraperMediaDownloader {
+  ScreenscraperMediaDownloader._();
+
+  static final _log = LoggerService.instance;
+
+  /// Downloads and caches a media file.
+  static Future<bool> _downloadMediaFileSmart(
+    String url,
+    String relativePath,
+    String userDataDir, {
+    bool forceOverwrite = false,
+    int? maxDailyRequests,
+  }) async {
+    try {
+      final fullPath = path.join(userDataDir, relativePath);
+      final file = File(fullPath);
+      if (await file.exists() && !forceOverwrite) {
+        return true;
+      }
+
+      final response = await ScreenscraperClient.httpGetWithRetry(
+        Uri.parse(url),
+        timeout: const Duration(seconds: 60),
+        maxRetries: 2,
+        maxDailyRequests: maxDailyRequests,
+      );
+      if (response.statusCode == 200) {
+        await file.create(recursive: true);
+        await file.writeAsBytes(response.bodyBytes);
+        return true;
+      } else {
+        _log.e('Error downloading media (${response.statusCode}): $url');
+        return false;
+      }
+    } catch (e) {
+      _log.e('Error downloading media: $e');
+      return false;
+    }
+  }
+
+  /// Downloads multiple media assets for a game, managing concurrency.
+  static Future<Map<String, dynamic>> downloadGameMedia(
+    String systemFolder,
+    String romName,
+    List<dynamic> medias,
+    int maxThreads, {
+    String? appSystemId,
+    String? preferredLanguage,
+    bool Function()? shouldCancel,
+    Function(double progress)? onProgress,
+    List<String>? allowedMediaTypes,
+    bool forceOverwrite = false,
+    int? maxDailyRequests,
+  }) async {
+    if (medias.isEmpty) {
+      return {
+        'success': true,
+        'downloadedTypes': <String>[],
+        'cancelled': false,
+      };
+    }
+
+    final userDataDir = await ScreenscraperMediaResolver.getMediaDirectory();
+    final regionPriority = await ScreenscraperRegionConfig.getRegionPriority();
+    final mediaTypes =
+        allowedMediaTypes ?? ['fanart', 'ss', 'video', 'wheel', 'box2D'];
+
+    final downloadTasks = <Map<String, dynamic>>[];
+    for (final mediaType in mediaTypes) {
+      final bestMedia = ScreenscraperMediaResolver.selectBestMedia(
+        medias,
+        mediaType,
+        preferredLanguage: preferredLanguage,
+        regionPriority: regionPriority,
+      );
+      if (bestMedia != null) {
+        final folderName = ScreenscraperMediaResolver.mapMediaTypeToFolder(
+          mediaType,
+        );
+        final romBaseName = await ScreenscraperRomHasher.getCleanRomName(
+          romName,
+          appSystemId,
+        );
+        final fileName =
+            '$romBaseName.${bestMedia['format']?.toString() ?? 'png'}';
+        final relativePath = '$systemFolder/$folderName/$fileName';
+
+        downloadTasks.add({
+          'url': bestMedia['url'].toString(),
+          'relativePath': relativePath,
+          'mediaType': mediaType,
+        });
+      }
+    }
+
+    if (downloadTasks.isEmpty) {
+      return {
+        'success': true,
+        'downloadedTypes': <String>[],
+        'cancelled': false,
+      };
+    }
+
+    final batches = <List<Map<String, dynamic>>>[];
+    for (var i = 0; i < downloadTasks.length; i += maxThreads) {
+      final end = (i + maxThreads < downloadTasks.length)
+          ? i + maxThreads
+          : downloadTasks.length;
+      batches.add(downloadTasks.sublist(i, end));
+    }
+
+    final downloadedTypes = <String>[];
+    final existingTypes = <String>[];
+    bool wasCancelled = false;
+
+    int completedTasks = 0;
+    for (final batch in batches) {
+      if (shouldCancel != null && shouldCancel()) {
+        wasCancelled = true;
+        break;
+      }
+
+      final futures = batch.map((task) async {
+        final success = await _downloadMediaFileSmart(
+          task['url'],
+          task['relativePath'],
+          userDataDir,
+          forceOverwrite: forceOverwrite,
+          maxDailyRequests: maxDailyRequests,
+        );
+        return {
+          'mediaType': task['mediaType'],
+          'success': success,
+          'wasExisting':
+              !forceOverwrite &&
+              success &&
+              await ScreenscraperMediaResolver.checkFileExists(
+                task['relativePath'],
+                userDataDir,
+              ),
+        };
+      });
+
+      final results = await Future.wait(futures);
+
+      for (final result in results) {
+        if (result['success'] == true) {
+          if (result['wasExisting'] as bool) {
+            existingTypes.add(result['mediaType'] as String);
+          } else {
+            downloadedTypes.add(result['mediaType'] as String);
+          }
+        }
+      }
+
+      completedTasks += batch.length;
+      if (onProgress != null) onProgress(completedTasks / downloadTasks.length);
+
+      if (batches.length > 1) {
+        await Future.delayed(const Duration(milliseconds: 100));
+      }
+    }
+
+    final totalAvailable = downloadedTypes.length + existingTypes.length;
+    return {
+      'success': totalAvailable == downloadTasks.length && !wasCancelled,
+      'downloadedTypes': downloadedTypes,
+      'existingTypes': existingTypes,
+      'cancelled': wasCancelled,
+    };
+  }
+}

--- a/lib/services/screenscraper_service.dart
+++ b/lib/services/screenscraper_service.dart
@@ -9,6 +9,7 @@ import 'screenscraper/region_config.dart';
 import 'screenscraper/rom_hasher.dart';
 import 'screenscraper/media_resolver.dart';
 import 'screenscraper/screenscraper_client.dart';
+import 'screenscraper/media_downloader.dart';
 import '../providers/scraping_provider.dart';
 import '../l10n/app_locale.dart';
 import '../widgets/scraping_summary_dialog.dart';
@@ -562,173 +563,6 @@ class ScreenScraperService {
     }
   }
 
-  /// Downloads and caches a media file.
-  static Future<bool> _downloadMediaFileSmart(
-    String url,
-    String relativePath,
-    String userDataDir, {
-    bool forceOverwrite = false,
-    int? maxDailyRequests,
-  }) async {
-    try {
-      final fullPath = path.join(userDataDir, relativePath);
-      final file = File(fullPath);
-      if (await file.exists() && !forceOverwrite) {
-        return true;
-      }
-
-      final response = await ScreenscraperClient.httpGetWithRetry(
-        Uri.parse(url),
-        timeout: const Duration(seconds: 60),
-        maxRetries: 2,
-        maxDailyRequests: maxDailyRequests,
-      );
-      if (response.statusCode == 200) {
-        await file.create(recursive: true);
-        await file.writeAsBytes(response.bodyBytes);
-        return true;
-      } else {
-        _log.e('Error downloading media (${response.statusCode}): $url');
-        return false;
-      }
-    } catch (e) {
-      _log.e('Error downloading media: $e');
-      return false;
-    }
-  }
-
-  /// Downloads multiple media assets for a game, managing concurrency.
-  static Future<Map<String, dynamic>> _downloadGameMedia(
-    String systemFolder,
-    String romName,
-    List<dynamic> medias,
-    int maxThreads, {
-    String? appSystemId,
-    String? preferredLanguage,
-    bool Function()? shouldCancel,
-    Function(double progress)? onProgress,
-    List<String>? allowedMediaTypes,
-    bool forceOverwrite = false,
-    int? maxDailyRequests,
-  }) async {
-    if (medias.isEmpty) {
-      return {
-        'success': true,
-        'downloadedTypes': <String>[],
-        'cancelled': false,
-      };
-    }
-
-    final userDataDir = await ScreenscraperMediaResolver.getMediaDirectory();
-    final regionPriority = await ScreenscraperRegionConfig.getRegionPriority();
-    final mediaTypes =
-        allowedMediaTypes ?? ['fanart', 'ss', 'video', 'wheel', 'box2D'];
-
-    final downloadTasks = <Map<String, dynamic>>[];
-    for (final mediaType in mediaTypes) {
-      final bestMedia = ScreenscraperMediaResolver.selectBestMedia(
-        medias,
-        mediaType,
-        preferredLanguage: preferredLanguage,
-        regionPriority: regionPriority,
-      );
-      if (bestMedia != null) {
-        final folderName = ScreenscraperMediaResolver.mapMediaTypeToFolder(
-          mediaType,
-        );
-        final romBaseName = await ScreenscraperRomHasher.getCleanRomName(
-          romName,
-          appSystemId,
-        );
-        final fileName =
-            '$romBaseName.${bestMedia['format']?.toString() ?? 'png'}';
-        final relativePath = '$systemFolder/$folderName/$fileName';
-
-        downloadTasks.add({
-          'url': bestMedia['url'].toString(),
-          'relativePath': relativePath,
-          'mediaType': mediaType,
-        });
-      }
-    }
-
-    if (downloadTasks.isEmpty) {
-      return {
-        'success': true,
-        'downloadedTypes': <String>[],
-        'cancelled': false,
-      };
-    }
-
-    final batches = <List<Map<String, dynamic>>>[];
-    for (var i = 0; i < downloadTasks.length; i += maxThreads) {
-      final end = (i + maxThreads < downloadTasks.length)
-          ? i + maxThreads
-          : downloadTasks.length;
-      batches.add(downloadTasks.sublist(i, end));
-    }
-
-    final downloadedTypes = <String>[];
-    final existingTypes = <String>[];
-    bool wasCancelled = false;
-
-    int completedTasks = 0;
-    for (final batch in batches) {
-      if (shouldCancel != null && shouldCancel()) {
-        wasCancelled = true;
-        break;
-      }
-
-      final futures = batch.map((task) async {
-        final success = await _downloadMediaFileSmart(
-          task['url'],
-          task['relativePath'],
-          userDataDir,
-          forceOverwrite: forceOverwrite,
-          maxDailyRequests: maxDailyRequests,
-        );
-        return {
-          'mediaType': task['mediaType'],
-          'success': success,
-          'wasExisting':
-              !forceOverwrite &&
-              success &&
-              await ScreenscraperMediaResolver.checkFileExists(
-                task['relativePath'],
-                userDataDir,
-              ),
-        };
-      });
-
-      final results = await Future.wait(futures);
-
-      for (final result in results) {
-        if (result['success'] == true) {
-          if (result['wasExisting'] as bool) {
-            existingTypes.add(result['mediaType'] as String);
-          } else {
-            downloadedTypes.add(result['mediaType'] as String);
-          }
-        }
-      }
-
-      completedTasks += batch.length;
-      if (onProgress != null) onProgress(completedTasks / downloadTasks.length);
-
-      if (batches.length > 1) {
-        await Future.delayed(const Duration(milliseconds: 100));
-      }
-    }
-
-    final totalAvailable = downloadedTypes.length + existingTypes.length;
-    return {
-      'success': totalAvailable == downloadTasks.length && !wasCancelled,
-      'downloadedTypes': downloadedTypes,
-      'existingTypes': existingTypes,
-      'cancelled': wasCancelled,
-    };
-  }
-
   /// Scrapes a single game by its filename and updates its local state.
   static Future<Map<String, dynamic>> scrapeSingleGame({
     required String appSystemId,
@@ -806,19 +640,20 @@ class ScreenScraperService {
       }
 
       final medias = gameInfo['medias'] as List<dynamic>? ?? [];
-      final downloadResult = await _downloadGameMedia(
-        systemFolder,
-        romName,
-        medias,
-        1,
-        appSystemId: appSystemId,
-        preferredLanguage: preferredLanguage,
-        allowedMediaTypes: allowedMediaTypes,
-        forceOverwrite: forceOverwrite,
-        maxDailyRequests: null,
-        onProgress: (p) =>
-            onProgress?.call(AppLocale.downloadingImages, 0.2 + (p * 0.8)),
-      );
+      final downloadResult =
+          await ScreenscraperMediaDownloader.downloadGameMedia(
+            systemFolder,
+            romName,
+            medias,
+            1,
+            appSystemId: appSystemId,
+            preferredLanguage: preferredLanguage,
+            allowedMediaTypes: allowedMediaTypes,
+            forceOverwrite: forceOverwrite,
+            maxDailyRequests: null,
+            onProgress: (p) =>
+                onProgress?.call(AppLocale.downloadingImages, 0.2 + (p * 0.8)),
+          );
 
       return {
         'success': downloadResult['success'] == true,
@@ -1106,7 +941,7 @@ class ScreenScraperService {
             currentStep: ThreadProcessingStep.downloadingImages,
             progress: 0.66,
           );
-          final res = await _downloadGameMedia(
+          final res = await ScreenscraperMediaDownloader.downloadGameMedia(
             systemFolder,
             filename,
             gameInfo['medias'] ?? [],


### PR DESCRIPTION
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

Fifth (c) collaborator in the `ScreenScraperService` facade decomposition (Phase 4 / G). Moves the HTTP media-download layer out of the facade into a new `ScreenscraperMediaDownloader` under `lib/services/screenscraper/`, layered on the client foundation from #159.

- `_downloadGameMedia` (downloads a game's media assets in bounded concurrent batches) + its private helper `_downloadMediaFileSmart` move **verbatim**.
- `downloadGameMedia` promoted to public (2 internal facade callers delegate); `_downloadMediaFileSmart` stays private.
- Collaborator delegates transport to `ScreenscraperClient`, resolution to `ScreenscraperMediaResolver` / `ScreenscraperRegionConfig`, ROM naming to `ScreenscraperRomHasher`. **No new static state** (stateless aside from its own `_log`).
- Bodies **byte-identical** to the originals (token-stream verified vs `main`).
- **No public-API change** — both methods were private; the 11 public facade methods are untouched, so the 8 importers are unaffected.

Host diff = import add + 2 caller rewrites (args reflowed by formatter, unchanged) + deletions.

## Type of Change

- [x] Code refactoring (no functional changes)

## Testing

- [x] `flutter analyze` — No issues found (project-wide)
- [x] `dart format` clean (project-wide gate)
- [x] `flutter test` — 207/207 pass

### Tested on

- [ ] Linux
- [ ] Android

Local gate only. The full media-download path (this exact code) was exercised on-device in #159's scrape smoke; this PR only relocates it verbatim behind the same call sites.

## Checklist

- [x] Self-review performed
- [x] No secrets/keys committed
- [x] No new third-party licenses introduced