### PR TITLE
refactor(game): extract GamepadNavigationManager/NavLayer out of game_service

### DIFF
--- a/lib/services/game_service.dart
+++ b/lib/services/game_service.dart
@@ -21,6 +21,9 @@ import 'game_session_persistence.dart';
 import 'android_service.dart';
 import 'music_player_service.dart';
 import 'launcher_service.dart';
+import 'gamepad/gamepad_navigation_manager.dart';
+export 'gamepad/gamepad_navigation_manager.dart'
+    show GamepadNavigationManager, NavLayer;
 
 /// Represents the result of a game launch attempt.
 class GameLaunchResult {
@@ -40,126 +43,6 @@ class GameLaunchResult {
 
   GameLaunchResult.failure(this.errorMessage, [this.errorDetails])
     : success = false;
-}
-
-/// Represents a single layer in the navigation stack for gamepad focus management.
-class NavLayer {
-  final String id;
-  final void Function() onActivate;
-  final void Function() onDeactivate;
-
-  NavLayer({
-    required this.id,
-    required this.onActivate,
-    required this.onDeactivate,
-  });
-}
-
-/// Global manager for gamepad/keyboard navigation focus across the application.
-///
-/// Maintains a focus stack to ensure that only the topmost UI layer receives
-/// input events, preventing "ghost" navigation in background screens.
-class GamepadNavigationManager {
-  static final _log = LoggerService.instance;
-  static final List<NavLayer> _stack = [];
-
-  /// Pushes a new navigation layer to the top of the stack and activates it.
-  ///
-  /// Automatically deactivates the previously active layer.
-  static void pushLayer(
-    String id, {
-    required void Function() onActivate,
-    required void Function() onDeactivate,
-  }) {
-    _log.i('[GamepadNavigationManager] Pushing layer: $id');
-
-    if (_stack.isNotEmpty) {
-      _log.d(
-        '[GamepadNavigationManager] Deactivating previous layer: ${_stack.last.id}',
-      );
-      try {
-        _stack.last.onDeactivate();
-      } catch (e) {
-        _log.e('Error deactivating layer ${_stack.last.id}: $e');
-      }
-    }
-
-    final newLayer = NavLayer(
-      id: id,
-      onActivate: onActivate,
-      onDeactivate: onDeactivate,
-    );
-    _stack.add(newLayer);
-
-    try {
-      onActivate();
-    } catch (e) {
-      _log.e('Error activating layer $id: $e');
-    }
-  }
-
-  /// Removes a navigation layer by its identifier and reactivates the new top layer.
-  static void popLayer(String id) {
-    if (_stack.isEmpty) return;
-
-    _log.i('[GamepadNavigationManager] Popping layer: $id');
-
-    final index = _stack.indexWhere((layer) => layer.id == id);
-    if (index == -1) {
-      _log.w('[GamepadNavigationManager] Layer $id not found in stack');
-      return;
-    }
-
-    final isTop = index == _stack.length - 1;
-    final layer = _stack.removeAt(index);
-
-    if (isTop) {
-      try {
-        layer.onDeactivate();
-      } catch (e) {
-        _log.e('Error deactivating layer $id during pop: $e');
-      }
-
-      if (_stack.isNotEmpty) {
-        _log.i(
-          '[GamepadNavigationManager] Reactivating previous layer: ${_stack.last.id}',
-        );
-        try {
-          _stack.last.onActivate();
-        } catch (e) {
-          _log.e('Error reactivating layer ${_stack.last.id}: $e');
-        }
-      }
-    }
-  }
-
-  /// Deactivates all layers in the stack.
-  ///
-  /// Typically called when launching a game to prevent UI interaction during gameplay.
-  static void deactivateAll() {
-    if (_stack.isNotEmpty) {
-      _log.i('[GamepadNavigationManager] Deactivating all layers');
-      try {
-        _stack.last.onDeactivate();
-      } catch (e) {
-        _log.e('Error deactivating top layer: $e');
-      }
-    }
-  }
-
-  /// Reactivates the topmost layer in the stack.
-  static void reactivate() {
-    if (_stack.isNotEmpty) {
-      _log.i(
-        '[GamepadNavigationManager] Reactivating top layer: ${_stack.last.id}',
-      );
-      try {
-        _stack.last.onActivate();
-      } catch (e) {
-        _log.e('Error reactivating top layer: $e');
-      }
-    }
-  }
 }
 
 /// Service responsible for game metadata management, process launching, and session tracking.

--- a/lib/services/gamepad/gamepad_navigation_manager.dart
+++ b/lib/services/gamepad/gamepad_navigation_manager.dart
@@ -1,0 +1,121 @@
+import 'package:neostation/services/logger_service.dart';
+
+/// Represents a single layer in the navigation stack for gamepad focus management.
+class NavLayer {
+  final String id;
+  final void Function() onActivate;
+  final void Function() onDeactivate;
+
+  NavLayer({
+    required this.id,
+    required this.onActivate,
+    required this.onDeactivate,
+  });
+}
+
+/// Global manager for gamepad/keyboard navigation focus across the application.
+///
+/// Maintains a focus stack to ensure that only the topmost UI layer receives
+/// input events, preventing "ghost" navigation in background screens.
+class GamepadNavigationManager {
+  static final _log = LoggerService.instance;
+  static final List<NavLayer> _stack = [];
+
+  /// Pushes a new navigation layer to the top of the stack and activates it.
+  ///
+  /// Automatically deactivates the previously active layer.
+  static void pushLayer(
+    String id, {
+    required void Function() onActivate,
+    required void Function() onDeactivate,
+  }) {
+    _log.i('[GamepadNavigationManager] Pushing layer: $id');
+
+    if (_stack.isNotEmpty) {
+      _log.d(
+        '[GamepadNavigationManager] Deactivating previous layer: ${_stack.last.id}',
+      );
+      try {
+        _stack.last.onDeactivate();
+      } catch (e) {
+        _log.e('Error deactivating layer ${_stack.last.id}: $e');
+      }
+    }
+
+    final newLayer = NavLayer(
+      id: id,
+      onActivate: onActivate,
+      onDeactivate: onDeactivate,
+    );
+    _stack.add(newLayer);
+
+    try {
+      onActivate();
+    } catch (e) {
+      _log.e('Error activating layer $id: $e');
+    }
+  }
+
+  /// Removes a navigation layer by its identifier and reactivates the new top layer.
+  static void popLayer(String id) {
+    if (_stack.isEmpty) return;
+
+    _log.i('[GamepadNavigationManager] Popping layer: $id');
+
+    final index = _stack.indexWhere((layer) => layer.id == id);
+    if (index == -1) {
+      _log.w('[GamepadNavigationManager] Layer $id not found in stack');
+      return;
+    }
+
+    final isTop = index == _stack.length - 1;
+    final layer = _stack.removeAt(index);
+
+    if (isTop) {
+      try {
+        layer.onDeactivate();
+      } catch (e) {
+        _log.e('Error deactivating layer $id during pop: $e');
+      }
+
+      if (_stack.isNotEmpty) {
+        _log.i(
+          '[GamepadNavigationManager] Reactivating previous layer: ${_stack.last.id}',
+        );
+        try {
+          _stack.last.onActivate();
+        } catch (e) {
+          _log.e('Error reactivating layer ${_stack.last.id}: $e');
+        }
+      }
+    }
+  }
+
+  /// Deactivates all layers in the stack.
+  ///
+  /// Typically called when launching a game to prevent UI interaction during gameplay.
+  static void deactivateAll() {
+    if (_stack.isNotEmpty) {
+      _log.i('[GamepadNavigationManager] Deactivating all layers');
+      try {
+        _stack.last.onDeactivate();
+      } catch (e) {
+        _log.e('Error deactivating top layer: $e');
+      }
+    }
+  }
+
+  /// Reactivates the topmost layer in the stack.
+  static void reactivate() {
+    if (_stack.isNotEmpty) {
+      _log.i(
+        '[GamepadNavigationManager] Reactivating top layer: ${_stack.last.id}',
+      );
+      try {
+        _stack.last.onActivate();
+      } catch (e) {
+        _log.e('Error reactivating top layer: $e');
+      }
+    }
+  }
+}


### PR DESCRIPTION
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

First slice of the Phase 4 / F `game_service.dart` decomposition (2014 lines, 33 importers). Moves the two **self-contained** gamepad-focus classes — `NavLayer` and `GamepadNavigationManager` — out of the god-file into a new `lib/services/gamepad/gamepad_navigation_manager.dart`.

These classes are unrelated to `GameService`'s launch/session logic and reference nothing from it (only `LoggerService`), so this is a pure **(d) move**.

**Zero importer churn.** `game_service.dart` re-exports both symbols and imports the file for its own internal `reactivate()`/`deactivateAll()` calls:

```dart
import 'gamepad/gamepad_navigation_manager.dart';
export 'gamepad/gamepad_navigation_manager.dart'
    show GamepadNavigationManager, NavLayer;
```

All 32 files that use these symbols — including the 3 that `import '.../game_service.dart' show GamepadNavigationManager` — keep resolving them through `game_service.dart` unchanged. The library's public surface is identical.

- Bodies **byte-identical** to the originals (verified vs `main`).
- Host **−120 lines** (2014 → 1894).
- Host diff = import + re-export + deletions only.

## Type of Change

- [x] Code refactoring (no functional changes)

## Testing

- [x] `flutter analyze` — No issues found (project-wide)
- [x] `dart format` clean (project-wide gate)
- [x] `flutter test` — 207/207 pass

### Tested on

- [ ] Linux
- [ ] Android

Local gate only — pure move + re-export with byte-identical bodies and zero importer/behaviour change.

## Checklist

- [x] Self-review performed
- [x] No secrets/keys committed
- [x] No new third-party licenses introduced