### PR TITLE
refactor(game): extract GameListService out of game_service facade

### DIFF
--- a/lib/services/game/game_list_service.dart
+++ b/lib/services/game/game_list_service.dart
@@ -1,0 +1,415 @@
+import 'package:path/path.dart' as path;
+import 'package:neostation/services/logger_service.dart';
+import '../../models/game_model.dart';
+import '../../models/database_game_model.dart';
+import '../../models/system_model.dart';
+import '../../repositories/game_repository.dart';
+import '../../repositories/system_repository.dart';
+import '../../constants/system_folder_names.dart';
+
+/// Loads game lists/details and resolves their display names.
+///
+/// Owns the read side of the game catalogue: pulling [DatabaseGameModel]s from
+/// the repositories, applying per-system naming preferences (extension/tag
+/// stripping, scraped-title coalescing) via [_resolveListDisplayName], and
+/// mapping them to UI [GameModel]s. Also the small pure list utilities
+/// ([groupGamesByGenre]/[getFavoriteGames]/[getRecentlyPlayedGames]). Extracted
+/// verbatim from [GameService], which now delegates its list/detail methods
+/// here. Stateless aside from the shared logger and the name-cleanup regexes.
+class GameListService {
+  GameListService._();
+
+  static final _log = LoggerService.instance;
+
+  static final RegExp _parenthesesRegex = RegExp(r'\([^)]*\)');
+  static final RegExp _bracketsRegex = RegExp(r'\[[^\]]*\]');
+  static final RegExp _whitespaceRegex = RegExp(r'\s+');
+
+  static bool _hasScreenscraperRealName(DatabaseGameModel dbGame) {
+    final t = dbGame.screenscraperRealName?.trim();
+    return t != null && t.isNotEmpty;
+  }
+
+  /// Sanitizes a filename for display in the UI based on user preferences.
+  ///
+  /// Optionally strips extensions, regional tags (parentheses), and technical
+  /// tags (brackets).
+  static String _formatListNameFromFilename(
+    String filename,
+    Set<String> validExtensionsSet, {
+    required bool hideExtension,
+    required bool hideParentheses,
+    required bool hideBrackets,
+  }) {
+    String name = filename;
+    if (hideExtension) {
+      final extWithDot = path.extension(name).toLowerCase();
+      if (extWithDot.isNotEmpty) {
+        final ext = extWithDot.substring(1);
+        if (validExtensionsSet.contains(ext)) {
+          name = name.substring(0, name.length - extWithDot.length);
+        }
+      }
+    }
+    if (hideParentheses) {
+      name = name.replaceAll(_parenthesesRegex, '');
+    }
+    if (hideBrackets) {
+      name = name.replaceAll(_bracketsRegex, '');
+    }
+    name = name.replaceAll(_whitespaceRegex, ' ').trim();
+    if (!hideExtension) {
+      name = name.replaceAll(RegExp(r'\s+(?=\.[^.]+$)'), '');
+    }
+    return name;
+  }
+
+  static String _formatListNameFromScrapedTitle(String rawTitle) {
+    String name = rawTitle.trim();
+    name = name.replaceAll(_whitespaceRegex, ' ').trim();
+    name = name.replaceAll(RegExp(r'\s+(?=\.[^.]+$)'), '');
+    return name;
+  }
+
+  /// Resolves the optimal display name for a game considering scraped metadata
+  /// and user-defined naming conventions.
+  static ({String name, bool showRomFileNameSubtitle}) _resolveListDisplayName({
+    required DatabaseGameModel dbGame,
+    required bool preferFileName,
+    required bool hideExtension,
+    required bool hideParentheses,
+    required bool hideBrackets,
+    required Set<String> validExtensionsSet,
+  }) {
+    final filename = dbGame.filename;
+    final scraped = _hasScreenscraperRealName(dbGame);
+    final coalesced = dbGame.realName ?? dbGame.titleName ?? filename;
+
+    if (preferFileName) {
+      return (
+        name: _formatListNameFromFilename(
+          filename,
+          validExtensionsSet,
+          hideExtension: hideExtension,
+          hideParentheses: hideParentheses,
+          hideBrackets: hideBrackets,
+        ),
+        showRomFileNameSubtitle: false,
+      );
+    }
+    if (scraped) {
+      return (
+        name: _formatListNameFromScrapedTitle(coalesced),
+        showRomFileNameSubtitle: true,
+      );
+    }
+    if (coalesced != filename) {
+      return (name: coalesced, showRomFileNameSubtitle: false);
+    }
+    return (
+      name: _formatListNameFromFilename(
+        filename,
+        validExtensionsSet,
+        hideExtension: hideExtension,
+        hideParentheses: hideParentheses,
+        hideBrackets: hideBrackets,
+      ),
+      showRomFileNameSubtitle: false,
+    );
+  }
+
+  /// Retrieves a list of games for a specific system, applying metadata formatting.
+  ///
+  /// If the 'all' system is requested, it aggregates games across all supported
+  /// emulation systems (excluding Android and Music).
+  static Future<List<GameModel>> loadGamesForSystem(SystemModel system) async {
+    try {
+      if (system.folderName == SystemFolderNames.favorites) {
+        return _loadFavoriteGames();
+      }
+
+      if (system.folderName == 'all') {
+        final databaseGames = (await GameRepository.getAllGames())
+            .where(
+              (dbGame) =>
+                  dbGame.systemFolderName != 'android' &&
+                  dbGame.systemFolderName != 'music',
+            )
+            .toList();
+
+        final systemIds = databaseGames
+            .map((g) => g.appSystemId)
+            .whereType<String>()
+            .toSet();
+
+        final settingsBySystem = <String, Map<String, dynamic>>{};
+        final extensionsBySystem = <String, Set<String>>{};
+        for (final sid in systemIds) {
+          settingsBySystem[sid] = await SystemRepository.getSystemSettings(sid);
+          final exts = await SystemRepository.getExtensionsForSystem(sid);
+          extensionsBySystem[sid] = exts.map((e) => e.toLowerCase()).toSet();
+        }
+
+        return databaseGames.map((dbGame) {
+          final sid = dbGame.appSystemId ?? '';
+          final settings = settingsBySystem[sid] ?? {};
+          final preferFileName = (settings['prefer_file_name'] ?? 0) == 1;
+          final hideExtension = (settings['hide_extension'] ?? 1) == 1;
+          final hideParentheses = (settings['hide_parentheses'] ?? 1) == 1;
+          final hideBrackets = (settings['hide_brackets'] ?? 1) == 1;
+          final extSet = extensionsBySystem[sid] ?? {};
+
+          final resolved = _resolveListDisplayName(
+            dbGame: dbGame,
+            preferFileName: preferFileName,
+            hideExtension: hideExtension,
+            hideParentheses: hideParentheses,
+            hideBrackets: hideBrackets,
+            validExtensionsSet: extSet,
+          );
+
+          return GameModel(
+            romname: dbGame.filename,
+            realname: dbGame.realName ?? dbGame.filename,
+            name: resolved.name,
+            showRomFileNameSubtitle: resolved.showRomFileNameSubtitle,
+            descriptions: dbGame.descriptions,
+            year: dbGame.year ?? '',
+            developer: dbGame.developer ?? '',
+            publisher: dbGame.publisher ?? '',
+            genre: dbGame.genre ?? '',
+            players: dbGame.players ?? '',
+            rating: dbGame.rating ?? 0.0,
+            isFavorite: dbGame.isFavorite,
+            lastPlayed: dbGame.lastPlayed,
+            playTime: dbGame.playTime,
+            romPath: dbGame.romPath,
+            emulatorName: dbGame.emulatorName,
+            coreName: dbGame.coreName,
+            raHash: dbGame.raHash,
+            systemId: dbGame.appSystemId,
+            systemFolderName: dbGame.systemFolderName,
+            systemRealName: dbGame.systemRealName,
+            cloudSyncEnabled: dbGame.cloudSyncEnabled,
+            titleId: dbGame.titleId,
+            titleName: dbGame.titleName,
+          );
+        }).toList();
+      }
+
+      if (system.id == null) {
+        return [];
+      }
+
+      final databaseGames = await GameRepository.getGamesBySystem(system.id!);
+      final validExtensions = await SystemRepository.getExtensionsForSystem(
+        system.id!,
+      );
+
+      final settings = await SystemRepository.getSystemSettings(system.id!);
+      final preferFileName = (settings['prefer_file_name'] ?? 0) == 1;
+      final hideExtension = (settings['hide_extension'] ?? 1) == 1;
+      final hideParentheses = (settings['hide_parentheses'] ?? 1) == 1;
+      final hideBrackets = (settings['hide_brackets'] ?? 1) == 1;
+
+      final validExtensionsSet = validExtensions
+          .map((e) => e.toLowerCase())
+          .toSet();
+
+      final games = databaseGames.map((dbGame) {
+        final resolved = _resolveListDisplayName(
+          dbGame: dbGame,
+          preferFileName: preferFileName,
+          hideExtension: hideExtension,
+          hideParentheses: hideParentheses,
+          hideBrackets: hideBrackets,
+          validExtensionsSet: validExtensionsSet,
+        );
+
+        return GameModel(
+          romname: dbGame.filename,
+          realname: dbGame.realName ?? dbGame.filename,
+          name: resolved.name,
+          showRomFileNameSubtitle: resolved.showRomFileNameSubtitle,
+          descriptions: dbGame.descriptions,
+          year: dbGame.year ?? '',
+          developer: dbGame.developer ?? '',
+          publisher: dbGame.publisher ?? '',
+          genre: dbGame.genre ?? '',
+          players: dbGame.players ?? '',
+          rating: dbGame.rating ?? 0.0,
+          isFavorite: dbGame.isFavorite,
+          lastPlayed: dbGame.lastPlayed,
+          playTime: dbGame.playTime,
+          romPath: dbGame.romPath,
+          emulatorName: dbGame.emulatorName,
+          coreName: dbGame.coreName,
+          raHash: dbGame.raHash,
+          systemId: dbGame.appSystemId,
+          systemFolderName: system.folderName,
+          cloudSyncEnabled: dbGame.cloudSyncEnabled,
+          titleId: dbGame.titleId,
+          titleName: dbGame.titleName,
+        );
+      }).toList();
+
+      return games;
+    } catch (e) {
+      _log.e('Error loading games for ${system.realName}: $e');
+      return [];
+    }
+  }
+
+  static Future<List<GameModel>> _loadFavoriteGames() async {
+    final databaseGames = await GameRepository.getFavoriteGames();
+
+    final systemIds = databaseGames
+        .map((g) => g.appSystemId)
+        .whereType<String>()
+        .toSet();
+
+    final settingsBySystem = <String, Map<String, dynamic>>{};
+    final extensionsBySystem = <String, Set<String>>{};
+    for (final sid in systemIds) {
+      settingsBySystem[sid] = await SystemRepository.getSystemSettings(sid);
+      final exts = await SystemRepository.getExtensionsForSystem(sid);
+      extensionsBySystem[sid] = exts.map((e) => e.toLowerCase()).toSet();
+    }
+
+    return databaseGames.map((dbGame) {
+      final sid = dbGame.appSystemId ?? '';
+      final settings = settingsBySystem[sid] ?? {};
+      final preferFileName = (settings['prefer_file_name'] ?? 0) == 1;
+      final hideExtension = (settings['hide_extension'] ?? 1) == 1;
+      final hideParentheses = (settings['hide_parentheses'] ?? 1) == 1;
+      final hideBrackets = (settings['hide_brackets'] ?? 1) == 1;
+      final extSet = extensionsBySystem[sid] ?? {};
+
+      final resolved = _resolveListDisplayName(
+        dbGame: dbGame,
+        preferFileName: preferFileName,
+        hideExtension: hideExtension,
+        hideParentheses: hideParentheses,
+        hideBrackets: hideBrackets,
+        validExtensionsSet: extSet,
+      );
+
+      return GameModel(
+        romname: dbGame.filename,
+        realname: dbGame.realName ?? dbGame.filename,
+        name: resolved.name,
+        showRomFileNameSubtitle: resolved.showRomFileNameSubtitle,
+        descriptions: dbGame.descriptions,
+        year: dbGame.year ?? '',
+        developer: dbGame.developer ?? '',
+        publisher: dbGame.publisher ?? '',
+        genre: dbGame.genre ?? '',
+        players: dbGame.players ?? '',
+        rating: dbGame.rating ?? 0.0,
+        isFavorite: dbGame.isFavorite,
+        lastPlayed: dbGame.lastPlayed,
+        playTime: dbGame.playTime,
+        romPath: dbGame.romPath,
+        emulatorName: dbGame.emulatorName,
+        coreName: dbGame.coreName,
+        raHash: dbGame.raHash,
+        systemId: dbGame.appSystemId,
+        systemFolderName: dbGame.systemFolderName,
+        systemRealName: dbGame.systemRealName,
+        cloudSyncEnabled: dbGame.cloudSyncEnabled,
+        titleId: dbGame.titleId,
+        titleName: dbGame.titleName,
+      );
+    }).toList();
+  }
+
+  /// Fetches detailed metadata for a specific game instance.
+  static Future<GameModel?> getGameDetails(
+    SystemModel system,
+    String romName,
+  ) async {
+    try {
+      if (system.id == null) return null;
+
+      final dbGame = await GameRepository.getSingleGame(system.id!, romName);
+      if (dbGame == null) return null;
+
+      final settings = await SystemRepository.getSystemSettings(system.id!);
+      final preferFileName = (settings['prefer_file_name'] ?? 0) == 1;
+      final hideExtension = (settings['hide_extension'] ?? 1) == 1;
+      final hideParentheses = (settings['hide_parentheses'] ?? 1) == 1;
+      final hideBrackets = (settings['hide_brackets'] ?? 1) == 1;
+      final validExtensions = await SystemRepository.getExtensionsForSystem(
+        system.id!,
+      );
+      final validExtensionsSet = validExtensions
+          .map((e) => e.toLowerCase())
+          .toSet();
+
+      final resolved = _resolveListDisplayName(
+        dbGame: dbGame,
+        preferFileName: preferFileName,
+        hideExtension: hideExtension,
+        hideParentheses: hideParentheses,
+        hideBrackets: hideBrackets,
+        validExtensionsSet: validExtensionsSet,
+      );
+
+      return GameModel(
+        romname: dbGame.filename,
+        realname: dbGame.realName ?? dbGame.filename,
+        name: resolved.name,
+        showRomFileNameSubtitle: resolved.showRomFileNameSubtitle,
+        descriptions: dbGame.descriptions,
+        year: dbGame.year ?? '',
+        developer: dbGame.developer ?? '',
+        publisher: dbGame.publisher ?? '',
+        genre: dbGame.genre ?? '',
+        players: dbGame.players ?? '',
+        rating: dbGame.rating ?? 0.0,
+        isFavorite: dbGame.isFavorite,
+        lastPlayed: dbGame.lastPlayed,
+        playTime: dbGame.playTime,
+        romPath: dbGame.romPath,
+        emulatorName: dbGame.emulatorName,
+        coreName: dbGame.coreName,
+        raHash: dbGame.raHash,
+        systemId: dbGame.appSystemId,
+        systemFolderName: system.folderName,
+        cloudSyncEnabled: dbGame.cloudSyncEnabled,
+        titleId: dbGame.titleId,
+        titleName: dbGame.titleName,
+      );
+    } catch (e) {
+      _log.e('Error loading game details for $romName: $e');
+      return null;
+    }
+  }
+
+  /// Groups a list of games by their genre metadata.
+  static Map<String, List<GameModel>> groupGamesByGenre(List<GameModel> games) {
+    Map<String, List<GameModel>> grouped = {};
+
+    for (var game in games) {
+      final genre = game.genre.isEmpty ? 'Unknown' : game.genre;
+      if (!grouped.containsKey(genre)) {
+        grouped[genre] = [];
+      }
+      grouped[genre]!.add(game);
+    }
+
+    return grouped;
+  }
+
+  /// Filters a list of games to return only those marked as favorites.
+  static List<GameModel> getFavoriteGames(List<GameModel> games) {
+    return games.where((game) => game.isFavorite ?? false).toList();
+  }
+
+  /// Filters and sorts a list of games to return the 10 most recently played instances.
+  static List<GameModel> getRecentlyPlayedGames(List<GameModel> games) {
+    final playedGames = games.where((game) => game.lastPlayed != null).toList();
+    playedGames.sort((a, b) => b.lastPlayed!.compareTo(a.lastPlayed!));
+    return playedGames.take(10).toList();
+  }
+}

--- a/lib/services/game_service.dart
+++ b/lib/services/game_service.dart
@@ -7,7 +7,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
 import 'package:neostation/services/logger_service.dart';
 import '../models/game_model.dart';
-import '../models/database_game_model.dart';
 import '../models/system_model.dart';
 import '../models/emulator_model.dart';
 import '../models/core_emulator_model.dart';
@@ -15,12 +14,12 @@ import '../providers/file_provider.dart';
 import '../repositories/game_repository.dart';
 import '../repositories/system_repository.dart';
 import '../repositories/emulator_repository.dart';
-import '../constants/system_folder_names.dart';
 import 'config_service.dart';
 import 'game_session_persistence.dart';
 import 'android_service.dart';
 import 'music_player_service.dart';
 import 'launcher_service.dart';
+import 'game/game_list_service.dart';
 import 'gamepad/gamepad_navigation_manager.dart';
 export 'gamepad/gamepad_navigation_manager.dart'
     show GamepadNavigationManager, NavLayer;
@@ -105,10 +104,6 @@ class GameService {
   static DateTime? _lastPlaytimeSave;
 
   static final _log = LoggerService.instance;
-
-  static final RegExp _parenthesesRegex = RegExp(r'\([^)]*\)');
-  static final RegExp _bracketsRegex = RegExp(r'\[[^\]]*\]');
-  static final RegExp _whitespaceRegex = RegExp(r'\s+');
 
   /// Initializes the platform-specific listener for Android game lifecycle events.
   static void initializeAndroidGameListener() {
@@ -198,393 +193,33 @@ class GameService {
     _onProcessExitCallback = null;
   }
 
-  static bool _hasScreenscraperRealName(DatabaseGameModel dbGame) {
-    final t = dbGame.screenscraperRealName?.trim();
-    return t != null && t.isNotEmpty;
-  }
+  /// Retrieves games for a system with metadata formatting applied.
+  /// Delegates to [GameListService].
+  static Future<List<GameModel>> loadGamesForSystem(SystemModel system) =>
+      GameListService.loadGamesForSystem(system);
 
-  /// Sanitizes a filename for display in the UI based on user preferences.
-  ///
-  /// Optionally strips extensions, regional tags (parentheses), and technical
-  /// tags (brackets).
-  static String _formatListNameFromFilename(
-    String filename,
-    Set<String> validExtensionsSet, {
-    required bool hideExtension,
-    required bool hideParentheses,
-    required bool hideBrackets,
-  }) {
-    String name = filename;
-    if (hideExtension) {
-      final extWithDot = path.extension(name).toLowerCase();
-      if (extWithDot.isNotEmpty) {
-        final ext = extWithDot.substring(1);
-        if (validExtensionsSet.contains(ext)) {
-          name = name.substring(0, name.length - extWithDot.length);
-        }
-      }
-    }
-    if (hideParentheses) {
-      name = name.replaceAll(_parenthesesRegex, '');
-    }
-    if (hideBrackets) {
-      name = name.replaceAll(_bracketsRegex, '');
-    }
-    name = name.replaceAll(_whitespaceRegex, ' ').trim();
-    if (!hideExtension) {
-      name = name.replaceAll(RegExp(r'\s+(?=\.[^.]+$)'), '');
-    }
-    return name;
-  }
-
-  static String _formatListNameFromScrapedTitle(String rawTitle) {
-    String name = rawTitle.trim();
-    name = name.replaceAll(_whitespaceRegex, ' ').trim();
-    name = name.replaceAll(RegExp(r'\s+(?=\.[^.]+$)'), '');
-    return name;
-  }
-
-  /// Resolves the optimal display name for a game considering scraped metadata
-  /// and user-defined naming conventions.
-  static ({String name, bool showRomFileNameSubtitle}) _resolveListDisplayName({
-    required DatabaseGameModel dbGame,
-    required bool preferFileName,
-    required bool hideExtension,
-    required bool hideParentheses,
-    required bool hideBrackets,
-    required Set<String> validExtensionsSet,
-  }) {
-    final filename = dbGame.filename;
-    final scraped = _hasScreenscraperRealName(dbGame);
-    final coalesced = dbGame.realName ?? dbGame.titleName ?? filename;
-
-    if (preferFileName) {
-      return (
-        name: _formatListNameFromFilename(
-          filename,
-          validExtensionsSet,
-          hideExtension: hideExtension,
-          hideParentheses: hideParentheses,
-          hideBrackets: hideBrackets,
-        ),
-        showRomFileNameSubtitle: false,
-      );
-    }
-    if (scraped) {
-      return (
-        name: _formatListNameFromScrapedTitle(coalesced),
-        showRomFileNameSubtitle: true,
-      );
-    }
-    if (coalesced != filename) {
-      return (name: coalesced, showRomFileNameSubtitle: false);
-    }
-    return (
-      name: _formatListNameFromFilename(
-        filename,
-        validExtensionsSet,
-        hideExtension: hideExtension,
-        hideParentheses: hideParentheses,
-        hideBrackets: hideBrackets,
-      ),
-      showRomFileNameSubtitle: false,
-    );
-  }
-
-  /// Retrieves a list of games for a specific system, applying metadata formatting.
-  ///
-  /// If the 'all' system is requested, it aggregates games across all supported
-  /// emulation systems (excluding Android and Music).
-  static Future<List<GameModel>> loadGamesForSystem(SystemModel system) async {
-    try {
-      if (system.folderName == SystemFolderNames.favorites) {
-        return _loadFavoriteGames();
-      }
-
-      if (system.folderName == 'all') {
-        final databaseGames = (await GameRepository.getAllGames())
-            .where(
-              (dbGame) =>
-                  dbGame.systemFolderName != 'android' &&
-                  dbGame.systemFolderName != 'music',
-            )
-            .toList();
-
-        final systemIds = databaseGames
-            .map((g) => g.appSystemId)
-            .whereType<String>()
-            .toSet();
-
-        final settingsBySystem = <String, Map<String, dynamic>>{};
-        final extensionsBySystem = <String, Set<String>>{};
-        for (final sid in systemIds) {
-          settingsBySystem[sid] = await SystemRepository.getSystemSettings(sid);
-          final exts = await SystemRepository.getExtensionsForSystem(sid);
-          extensionsBySystem[sid] = exts.map((e) => e.toLowerCase()).toSet();
-        }
-
-        return databaseGames.map((dbGame) {
-          final sid = dbGame.appSystemId ?? '';
-          final settings = settingsBySystem[sid] ?? {};
-          final preferFileName = (settings['prefer_file_name'] ?? 0) == 1;
-          final hideExtension = (settings['hide_extension'] ?? 1) == 1;
-          final hideParentheses = (settings['hide_parentheses'] ?? 1) == 1;
-          final hideBrackets = (settings['hide_brackets'] ?? 1) == 1;
-          final extSet = extensionsBySystem[sid] ?? {};
-
-          final resolved = _resolveListDisplayName(
-            dbGame: dbGame,
-            preferFileName: preferFileName,
-            hideExtension: hideExtension,
-            hideParentheses: hideParentheses,
-            hideBrackets: hideBrackets,
-            validExtensionsSet: extSet,
-          );
-
-          return GameModel(
-            romname: dbGame.filename,
-            realname: dbGame.realName ?? dbGame.filename,
-            name: resolved.name,
-            showRomFileNameSubtitle: resolved.showRomFileNameSubtitle,
-            descriptions: dbGame.descriptions,
-            year: dbGame.year ?? '',
-            developer: dbGame.developer ?? '',
-            publisher: dbGame.publisher ?? '',
-            genre: dbGame.genre ?? '',
-            players: dbGame.players ?? '',
-            rating: dbGame.rating ?? 0.0,
-            isFavorite: dbGame.isFavorite,
-            lastPlayed: dbGame.lastPlayed,
-            playTime: dbGame.playTime,
-            romPath: dbGame.romPath,
-            emulatorName: dbGame.emulatorName,
-            coreName: dbGame.coreName,
-            raHash: dbGame.raHash,
-            systemId: dbGame.appSystemId,
-            systemFolderName: dbGame.systemFolderName,
-            systemRealName: dbGame.systemRealName,
-            cloudSyncEnabled: dbGame.cloudSyncEnabled,
-            titleId: dbGame.titleId,
-            titleName: dbGame.titleName,
-          );
-        }).toList();
-      }
-
-      if (system.id == null) {
-        return [];
-      }
-
-      final databaseGames = await GameRepository.getGamesBySystem(system.id!);
-      final validExtensions = await SystemRepository.getExtensionsForSystem(
-        system.id!,
-      );
-
-      final settings = await SystemRepository.getSystemSettings(system.id!);
-      final preferFileName = (settings['prefer_file_name'] ?? 0) == 1;
-      final hideExtension = (settings['hide_extension'] ?? 1) == 1;
-      final hideParentheses = (settings['hide_parentheses'] ?? 1) == 1;
-      final hideBrackets = (settings['hide_brackets'] ?? 1) == 1;
-
-      final validExtensionsSet = validExtensions
-          .map((e) => e.toLowerCase())
-          .toSet();
-
-      final games = databaseGames.map((dbGame) {
-        final resolved = _resolveListDisplayName(
-          dbGame: dbGame,
-          preferFileName: preferFileName,
-          hideExtension: hideExtension,
-          hideParentheses: hideParentheses,
-          hideBrackets: hideBrackets,
-          validExtensionsSet: validExtensionsSet,
-        );
-
-        return GameModel(
-          romname: dbGame.filename,
-          realname: dbGame.realName ?? dbGame.filename,
-          name: resolved.name,
-          showRomFileNameSubtitle: resolved.showRomFileNameSubtitle,
-          descriptions: dbGame.descriptions,
-          year: dbGame.year ?? '',
-          developer: dbGame.developer ?? '',
-          publisher: dbGame.publisher ?? '',
-          genre: dbGame.genre ?? '',
-          players: dbGame.players ?? '',
-          rating: dbGame.rating ?? 0.0,
-          isFavorite: dbGame.isFavorite,
-          lastPlayed: dbGame.lastPlayed,
-          playTime: dbGame.playTime,
-          romPath: dbGame.romPath,
-          emulatorName: dbGame.emulatorName,
-          coreName: dbGame.coreName,
-          raHash: dbGame.raHash,
-          systemId: dbGame.appSystemId,
-          systemFolderName: system.folderName,
-          cloudSyncEnabled: dbGame.cloudSyncEnabled,
-          titleId: dbGame.titleId,
-          titleName: dbGame.titleName,
-        );
-      }).toList();
-
-      return games;
-    } catch (e) {
-      _log.e('Error loading games for ${system.realName}: $e');
-      return [];
-    }
-  }
-
-  static Future<List<GameModel>> _loadFavoriteGames() async {
-    final databaseGames = await GameRepository.getFavoriteGames();
-
-    final systemIds = databaseGames
-        .map((g) => g.appSystemId)
-        .whereType<String>()
-        .toSet();
-
-    final settingsBySystem = <String, Map<String, dynamic>>{};
-    final extensionsBySystem = <String, Set<String>>{};
-    for (final sid in systemIds) {
-      settingsBySystem[sid] = await SystemRepository.getSystemSettings(sid);
-      final exts = await SystemRepository.getExtensionsForSystem(sid);
-      extensionsBySystem[sid] = exts.map((e) => e.toLowerCase()).toSet();
-    }
-
-    return databaseGames.map((dbGame) {
-      final sid = dbGame.appSystemId ?? '';
-      final settings = settingsBySystem[sid] ?? {};
-      final preferFileName = (settings['prefer_file_name'] ?? 0) == 1;
-      final hideExtension = (settings['hide_extension'] ?? 1) == 1;
-      final hideParentheses = (settings['hide_parentheses'] ?? 1) == 1;
-      final hideBrackets = (settings['hide_brackets'] ?? 1) == 1;
-      final extSet = extensionsBySystem[sid] ?? {};
-
-      final resolved = _resolveListDisplayName(
-        dbGame: dbGame,
-        preferFileName: preferFileName,
-        hideExtension: hideExtension,
-        hideParentheses: hideParentheses,
-        hideBrackets: hideBrackets,
-        validExtensionsSet: extSet,
-      );
-
-      return GameModel(
-        romname: dbGame.filename,
-        realname: dbGame.realName ?? dbGame.filename,
-        name: resolved.name,
-        showRomFileNameSubtitle: resolved.showRomFileNameSubtitle,
-        descriptions: dbGame.descriptions,
-        year: dbGame.year ?? '',
-        developer: dbGame.developer ?? '',
-        publisher: dbGame.publisher ?? '',
-        genre: dbGame.genre ?? '',
-        players: dbGame.players ?? '',
-        rating: dbGame.rating ?? 0.0,
-        isFavorite: dbGame.isFavorite,
-        lastPlayed: dbGame.lastPlayed,
-        playTime: dbGame.playTime,
-        romPath: dbGame.romPath,
-        emulatorName: dbGame.emulatorName,
-        coreName: dbGame.coreName,
-        raHash: dbGame.raHash,
-        systemId: dbGame.appSystemId,
-        systemFolderName: dbGame.systemFolderName,
-        systemRealName: dbGame.systemRealName,
-        cloudSyncEnabled: dbGame.cloudSyncEnabled,
-        titleId: dbGame.titleId,
-        titleName: dbGame.titleName,
-      );
-    }).toList();
-  }
-
-  /// Fetches detailed metadata for a specific game instance.
+  /// Fetches detailed metadata for a specific game.
+  /// Delegates to [GameListService].
   static Future<GameModel?> getGameDetails(
     SystemModel system,
     String romName,
-  ) async {
-    try {
-      if (system.id == null) return null;
-
-      final dbGame = await GameRepository.getSingleGame(system.id!, romName);
-      if (dbGame == null) return null;
-
-      final settings = await SystemRepository.getSystemSettings(system.id!);
-      final preferFileName = (settings['prefer_file_name'] ?? 0) == 1;
-      final hideExtension = (settings['hide_extension'] ?? 1) == 1;
-      final hideParentheses = (settings['hide_parentheses'] ?? 1) == 1;
-      final hideBrackets = (settings['hide_brackets'] ?? 1) == 1;
-      final validExtensions = await SystemRepository.getExtensionsForSystem(
-        system.id!,
-      );
-      final validExtensionsSet = validExtensions
-          .map((e) => e.toLowerCase())
-          .toSet();
-
-      final resolved = _resolveListDisplayName(
-        dbGame: dbGame,
-        preferFileName: preferFileName,
-        hideExtension: hideExtension,
-        hideParentheses: hideParentheses,
-        hideBrackets: hideBrackets,
-        validExtensionsSet: validExtensionsSet,
-      );
-
-      return GameModel(
-        romname: dbGame.filename,
-        realname: dbGame.realName ?? dbGame.filename,
-        name: resolved.name,
-        showRomFileNameSubtitle: resolved.showRomFileNameSubtitle,
-        descriptions: dbGame.descriptions,
-        year: dbGame.year ?? '',
-        developer: dbGame.developer ?? '',
-        publisher: dbGame.publisher ?? '',
-        genre: dbGame.genre ?? '',
-        players: dbGame.players ?? '',
-        rating: dbGame.rating ?? 0.0,
-        isFavorite: dbGame.isFavorite,
-        lastPlayed: dbGame.lastPlayed,
-        playTime: dbGame.playTime,
-        romPath: dbGame.romPath,
-        emulatorName: dbGame.emulatorName,
-        coreName: dbGame.coreName,
-        raHash: dbGame.raHash,
-        systemId: dbGame.appSystemId,
-        systemFolderName: system.folderName,
-        cloudSyncEnabled: dbGame.cloudSyncEnabled,
-        titleId: dbGame.titleId,
-        titleName: dbGame.titleName,
-      );
-    } catch (e) {
-      _log.e('Error loading game details for $romName: $e');
-      return null;
-    }
-  }
+  ) => GameListService.getGameDetails(system, romName);
 
   /// Groups a list of games by their genre metadata.
-  static Map<String, List<GameModel>> groupGamesByGenre(List<GameModel> games) {
-    Map<String, List<GameModel>> grouped = {};
-
-    for (var game in games) {
-      final genre = game.genre.isEmpty ? 'Unknown' : game.genre;
-      if (!grouped.containsKey(genre)) {
-        grouped[genre] = [];
-      }
-      grouped[genre]!.add(game);
-    }
-
-    return grouped;
-  }
+  /// Delegates to [GameListService].
+  static Map<String, List<GameModel>> groupGamesByGenre(
+    List<GameModel> games,
+  ) => GameListService.groupGamesByGenre(games);
 
   /// Filters a list of games to return only those marked as favorites.
-  static List<GameModel> getFavoriteGames(List<GameModel> games) {
-    return games.where((game) => game.isFavorite ?? false).toList();
-  }
+  /// Delegates to [GameListService].
+  static List<GameModel> getFavoriteGames(List<GameModel> games) =>
+      GameListService.getFavoriteGames(games);
 
-  /// Filters and sorts a list of games to return the 10 most recently played instances.
-  static List<GameModel> getRecentlyPlayedGames(List<GameModel> games) {
-    final playedGames = games.where((game) => game.lastPlayed != null).toList();
-    playedGames.sort((a, b) => b.lastPlayed!.compareTo(a.lastPlayed!));
-    return playedGames.take(10).toList();
-  }
+  /// Filters and sorts a list of games to return the 10 most recently played.
+  /// Delegates to [GameListService].
+  static List<GameModel> getRecentlyPlayedGames(List<GameModel> games) =>
+      GameListService.getRecentlyPlayedGames(games);
 
   /// Toggles the favorite status of a game in the persistent database.
   static Future<void> toggleFavorite(GameModel game) async {


### PR DESCRIPTION
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Description

Second slice of the **F** phase of the file-refactor campaign (splitting `game_service.dart`, 33 importers, into focused collaborators behind a frozen static facade — mechanism **(c)**).

Extracts the game **list/detail load + display-name formatting** cluster out of `GameService` into a new `lib/services/game/game_list_service.dart` (`GameListService`, private ctor). `GameService` keeps the 5 public methods as **thin delegators**, so the frozen public surface — and every importer — is unchanged.

Moved (verbatim, byte-identical vs `main`):
- `loadGamesForSystem` / `getGameDetails` / `groupGamesByGenre` / `getFavoriteGames` / `getRecentlyPlayedGames` (public — now delegated to)
- private helpers `_resolveListDisplayName`, `_formatListNameFromFilename`, `_formatListNameFromScrapedTitle`, `_hasScreenscraperRealName`, `_loadFavoriteGames`
- the 3 name-cleanup regexes (`_parenthesesRegex` / `_bracketsRegex` / `_whitespaceRegex`)

The cluster references no `GameService` launch/session state and nothing outside it references the regexes or private helpers, so it moves with **zero substitutions**. Dropped now-unused host imports (`database_game_model`, `system_folder_names`). Host **1897 → 1533** (−364); new file 415 lines. No public-API change → no importer churn.

Fixes # (n/a)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works.
- [x] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [ ] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [ ] Android
- [ ] **Gamepad support verified** (if applicable).

## Notes

Pure verbatim move (token-normalized byte-identity vs `main`: **IDENTICAL**). 🟢 local-gate only — `dart format --set-exit-if-changed .` clean, `flutter analyze` No issues, **207/207** tests. Not device-tested (no behaviour change; delegators preserve call order). Tests checkbox reflects the existing suite staying green (no new tests — pure refactor).