### PR TITLE
refactor(game): extract FavoritesService out of game_service facade

### DIFF
--- a/lib/services/game/favorites_service.dart
+++ b/lib/services/game/favorites_service.dart
@@ -1,0 +1,63 @@
+import '../../models/game_model.dart';
+import '../../repositories/game_repository.dart';
+
+/// Game catalogue mutations and aggregate stats.
+///
+/// Owns the favourite toggle, the "recently played" record write, and the
+/// per-list statistics computation ([getGameStats]) — the read/write of the
+/// game catalogue that is independent of any active launch/session. Extracted
+/// verbatim from [GameService], which now delegates these methods here.
+/// Stateless.
+class FavoritesService {
+  FavoritesService._();
+
+  /// Toggles the favorite status of a game in the persistent database.
+  static Future<void> toggleFavorite(GameModel game) async {
+    if (game.romPath == null) return;
+    await GameRepository.toggleRomFavoriteByPath(game.romPath!);
+  }
+
+  /// Records a new play instance for a game in the persistent database.
+  static Future<void> recordGamePlayed(GameModel game) async {
+    if (game.romPath == null) return;
+    await GameRepository.recordRomPlayedByPath(game.romPath!);
+  }
+
+  /// Computes aggregate statistics for a list of games.
+  static Map<String, dynamic> getGameStats(List<GameModel> games) {
+    if (games.isEmpty) {
+      return {
+        'total': 0,
+        'genres': 0,
+        'developers': 0,
+        'favorites': 0,
+        'played': 0,
+        'averageRating': 0.0,
+      };
+    }
+
+    final genres = games.map((g) => g.genre).where((g) => g.isNotEmpty).toSet();
+    final developers = games
+        .map((g) => g.developer)
+        .where((d) => d.isNotEmpty)
+        .toSet();
+    final favorites = games.where((g) => g.isFavorite == true).length;
+    final played = games.where((g) => g.lastPlayed != null).length;
+
+    final ratingsWithValue = games.map((g) => g.rating).where((r) => r > 0);
+    double averageRating = 0.0;
+    if (ratingsWithValue.isNotEmpty) {
+      averageRating =
+          ratingsWithValue.reduce((a, b) => a + b) / ratingsWithValue.length;
+    }
+
+    return {
+      'total': games.length,
+      'genres': genres.length,
+      'developers': developers.length,
+      'favorites': favorites,
+      'played': played,
+      'averageRating': averageRating,
+    };
+  }
+}

--- a/lib/services/game_service.dart
+++ b/lib/services/game_service.dart
@@ -20,6 +20,7 @@ import 'android_service.dart';
 import 'music_player_service.dart';
 import 'launcher_service.dart';
 import 'game/game_list_service.dart';
+import 'game/favorites_service.dart';
 import 'gamepad/gamepad_navigation_manager.dart';
 export 'gamepad/gamepad_navigation_manager.dart'
     show GamepadNavigationManager, NavLayer;
@@ -222,16 +223,14 @@ class GameService {
       GameListService.getRecentlyPlayedGames(games);
 
   /// Toggles the favorite status of a game in the persistent database.
-  static Future<void> toggleFavorite(GameModel game) async {
-    if (game.romPath == null) return;
-    await GameRepository.toggleRomFavoriteByPath(game.romPath!);
-  }
+  /// Delegates to [FavoritesService].
+  static Future<void> toggleFavorite(GameModel game) =>
+      FavoritesService.toggleFavorite(game);
 
   /// Records a new play instance for a game in the persistent database.
-  static Future<void> recordGamePlayed(GameModel game) async {
-    if (game.romPath == null) return;
-    await GameRepository.recordRomPlayedByPath(game.romPath!);
-  }
+  /// Delegates to [FavoritesService].
+  static Future<void> recordGamePlayed(GameModel game) =>
+      FavoritesService.recordGamePlayed(game);
 
   /// Verifies if a valid screenshots folder exists for the specified system.
   static bool hasScreenshotsFolder(String systemFolderName) {
@@ -450,42 +449,9 @@ class GameService {
   }
 
   /// Computes aggregate statistics for a list of games.
-  static Map<String, dynamic> getGameStats(List<GameModel> games) {
-    if (games.isEmpty) {
-      return {
-        'total': 0,
-        'genres': 0,
-        'developers': 0,
-        'favorites': 0,
-        'played': 0,
-        'averageRating': 0.0,
-      };
-    }
-
-    final genres = games.map((g) => g.genre).where((g) => g.isNotEmpty).toSet();
-    final developers = games
-        .map((g) => g.developer)
-        .where((d) => d.isNotEmpty)
-        .toSet();
-    final favorites = games.where((g) => g.isFavorite == true).length;
-    final played = games.where((g) => g.lastPlayed != null).length;
-
-    final ratingsWithValue = games.map((g) => g.rating).where((r) => r > 0);
-    double averageRating = 0.0;
-    if (ratingsWithValue.isNotEmpty) {
-      averageRating =
-          ratingsWithValue.reduce((a, b) => a + b) / ratingsWithValue.length;
-    }
-
-    return {
-      'total': games.length,
-      'genres': genres.length,
-      'developers': developers.length,
-      'favorites': favorites,
-      'played': played,
-      'averageRating': averageRating,
-    };
-  }
+  /// Delegates to [FavoritesService].
+  static Map<String, dynamic> getGameStats(List<GameModel> games) =>
+      FavoritesService.getGameStats(games);
 
   /// Core logic for launching a game session across all supported platforms.
   ///


### PR DESCRIPTION
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Description

Third slice of the **F** phase of the file-refactor campaign (splitting `game_service.dart`, 33 importers, into focused collaborators behind a frozen static facade — mechanism **(c)**).

Extracts the game **catalogue-mutation + stats** cluster out of `GameService` into a new `lib/services/game/favorites_service.dart` (`FavoritesService`, private ctor). `GameService` keeps the 3 public methods as **thin delegators**, so the frozen public surface — and its single external importer (`favorites_reorder.dart`) plus the 7 internal `recordGamePlayed` launch-site callers — stay unchanged.

Moved (verbatim, byte-identical vs `main`):
- `toggleFavorite` — favourite toggle (DB delegator)
- `recordGamePlayed` — recently-played write (DB delegator)
- `getGameStats` — pure per-list aggregate statistics

These three touch **no** launch/session state (`_isGameLaunched`/timers/`_currentGame`), so they move with **zero substitutions**. The playtime timer + `_savePlayTime` deliberately **stay on the facade** — they read/write session state and will move later with the `game_session_manager` slice (single-owner discipline). Host **1532 → 1499** (−33); new file 63 lines. No public-API change → no importer churn.

Fixes # (n/a)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [x] I have added tests demonstrating that my fix or feature works.
- [x] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [ ] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [ ] Android
- [ ] **Gamepad support verified** (if applicable).

## Notes

Pure verbatim move (token-normalized byte-identity vs `main`: **IDENTICAL**). 🟢 local-gate only — `dart format --set-exit-if-changed .` clean, `flutter analyze` No issues, **207/207** tests. Not device-tested (no behaviour change; delegators preserve call order). Tests checkbox reflects the existing suite staying green (no new tests — pure refactor).