### PR TITLE
fix(secondary): fanart dim on system art + preview-audio race + stale RA snapshot

### DIFF
--- a/lib/screens/secondary_screen/background_builders.dart
+++ b/lib/screens/secondary_screen/background_builders.dart
@@ -129,39 +129,66 @@ Widget buildSystemBackground(SecondaryDisplayStateData value) {
   if (hasBg) {
     final isGif = image_utils.ImageUtils.isGif(bgPath);
 
+    Widget? art;
     if (value.isBackgroundAsset) {
       if (isGif) {
-        return ShaderGifWidget(
+        art = ShaderGifWidget(
           imagePath: bgPath,
           key: ValueKey('secondary_system_bg_$bgPath'),
         );
-      }
-      return Image.asset(
-        bgPath,
-        fit: BoxFit.cover,
-        errorBuilder: (context, error, stackTrace) =>
-            buildShaderFallback(value),
-      );
-    } else {
-      final file = File(bgPath);
-      if (file.existsSync()) {
-        if (isGif) {
-          return ShaderGifWidget(
-            imagePath: bgPath,
-            key: ValueKey('secondary_system_bg_$bgPath'),
-          );
-        }
-        return Image.file(
-          file,
+      } else {
+        art = Image.asset(
+          bgPath,
           fit: BoxFit.cover,
           errorBuilder: (context, error, stackTrace) =>
               buildShaderFallback(value),
         );
       }
+    } else {
+      final file = File(bgPath);
+      if (file.existsSync()) {
+        if (isGif) {
+          art = ShaderGifWidget(
+            imagePath: bgPath,
+            key: ValueKey('secondary_system_bg_$bgPath'),
+          );
+        } else {
+          art = Image.file(
+            file,
+            fit: BoxFit.cover,
+            errorBuilder: (context, error, stackTrace) =>
+                buildShaderFallback(value),
+          );
+        }
+      }
+    }
+
+    if (art != null) {
+      return _withFanartDim(art, value);
     }
   }
 
   return buildShaderFallback(value);
+}
+
+/// Overlays the same dim scrim used behind game logos so system console
+/// artwork doesn't clash with the system name/logo drawn on top. Mirrors the
+/// scrim in [buildFanartWithLogo]; a no-op when the dim level is 0.
+Widget _withFanartDim(Widget art, SecondaryDisplayStateData value) {
+  if (value.fanartDimLevel <= 0) return art;
+  return Stack(
+    fit: StackFit.expand,
+    children: [
+      art,
+      Positioned.fill(
+        child: ColoredBox(
+          color: Colors.black.withValues(
+            alpha: value.fanartDimLevel.clamp(0, 100) / 100.0,
+          ),
+        ),
+      ),
+    ],
+  );
 }
 
 Widget buildShaderFallback(SecondaryDisplayStateData value) {

--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -44,6 +44,12 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
   Timer? _videoTimer;
   bool _showVideo = false;
   String? _currentVideoPath;
+
+  /// Bumped every time the preview is torn down. [_initializeVideo] captures it
+  /// on entry and re-checks after each await, so an in-flight init that started
+  /// just as a game launched (which calls [_stopVideo]) throws away the
+  /// controller it created instead of leaving it playing audio over the game.
+  int _videoGeneration = 0;
   int _lastMediaRevision = 0;
 
   /// Auto-clearing timer for the "newly earned this session" celebration.
@@ -413,10 +419,14 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
   Future<void> _initializeVideo(String path) async {
     if (!mounted) return;
 
+    // Snapshot the generation: if _stopVideo runs (e.g. a game launches) while
+    // we're awaiting below, this goes stale and we abort before playing.
+    final gen = _videoGeneration;
+    VideoPlayerController? controller;
     try {
-      final controller = VideoPlayerController.file(File(path));
+      controller = VideoPlayerController.file(File(path));
       await controller.initialize();
-      if (!mounted) {
+      if (!mounted || gen != _videoGeneration) {
         await controller.dispose();
         return;
       }
@@ -428,7 +438,7 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
       await controller.setLooping(true);
       await controller.play();
 
-      if (!mounted) {
+      if (!mounted || gen != _videoGeneration) {
         await controller.dispose();
         return;
       }
@@ -439,10 +449,19 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
       });
     } catch (e) {
       debugPrint('SecondaryScreen: Error initializing video: $e');
+      // Don't leak the controller if we threw after creating it.
+      if (controller != null && _videoController != controller) {
+        try {
+          await controller.dispose();
+        } catch (_) {}
+      }
     }
   }
 
   void _stopVideo() {
+    // Invalidate any in-flight _initializeVideo so it discards its controller
+    // rather than playing audio over a game that just launched.
+    _videoGeneration++;
     _videoTimer?.cancel();
     _videoTimer = null;
     if (_videoController != null) {

--- a/lib/services/secondary_achievements_controller.dart
+++ b/lib/services/secondary_achievements_controller.dart
@@ -78,6 +78,27 @@ class SecondaryAchievementsController {
       await state.initialSync;
     }
 
+    // Refresh the in-game screenshot button's visibility on every launch. The
+    // screenshotAccessEnabled flag is otherwise seeded only once at cold start,
+    // which on a fresh install happens BEFORE the user grants access in
+    // first-run setup — so the button would stay hidden until a later cold
+    // restart or display reconnect re-seeded it.
+    //
+    // Resolved UP FRONT (with a short timeout) so it rides in the SAME atomic
+    // launch snapshot below instead of a separate push. A separate push,
+    // serialized before the async RA fetch (so carrying achievements=null), can
+    // be delivered out-of-order AFTER the achievements push and wipe the panel
+    // — the RA panel would flash in then vanish. The old comment here only
+    // reasoned about nowPlayingActive; achievements are just as vulnerable.
+    bool screenshotAccess = false;
+    try {
+      screenshotAccess = await ScreenshotService.isAccessEnabled().timeout(
+        const Duration(seconds: 2),
+        onTimeout: () => false,
+      );
+    } catch (_) {}
+    if (!_active || _state != state) return;
+
     // Show the "Now Playing" page immediately for every launched game — this
     // is independent of RetroAchievements, needs no network, and is the first
     // page the secondary display shows. The RA fetch below may then add the
@@ -85,15 +106,16 @@ class SecondaryAchievementsController {
     // ignore: unawaited_futures
     state.updateState(
       // isGameLaunching is set here — in the SAME atomic snapshot as
-      // nowPlayingActive — rather than via a separate _updateSecondaryDisplay
-      // push. The cross-engine transport delivers full snapshots without
-      // ordering guarantees, so a separate launch snapshot carrying
-      // nowPlayingActive=false could land after this one and clobber it (the
-      // intermittent "no Now Playing on PSX/GameCube" race). One snapshot = no
+      // nowPlayingActive (and screenshotAccessEnabled) — rather than via a
+      // separate push. The cross-engine transport delivers full snapshots
+      // without ordering guarantees, so a separate launch snapshot could land
+      // after this one and clobber it (the intermittent "no Now Playing on
+      // PSX/GameCube" race, and the RA-panel-flash race). One snapshot = no
       // race. It also stops the secondary preview video (the receiver keys the
       // video teardown off isGameLaunching).
       isGameLaunching: true,
       nowPlayingActive: true,
+      screenshotAccessEnabled: screenshotAccess,
       gameTitle: game.name,
       gameBoxart: boxartPath,
       clearGameBoxart: boxartPath == null,
@@ -102,19 +124,6 @@ class SecondaryAchievementsController {
       lastPlayedMillis: game.lastPlayed?.millisecondsSinceEpoch,
       clearLastPlayed: game.lastPlayed == null,
     );
-
-    // Refresh the in-game screenshot button's visibility on every launch. The
-    // screenshotAccessEnabled flag is otherwise seeded only once at cold start,
-    // which on a fresh install happens BEFORE the user grants access in
-    // first-run setup — so the button would stay hidden until a later cold
-    // restart or display reconnect re-seeded it. Pushed as its own snapshot: it
-    // doesn't touch nowPlayingActive, so there's no clobber race with the
-    // launch snapshot above.
-    final launchState = state;
-    // ignore: unawaited_futures
-    ScreenshotService.isAccessEnabled().then((enabled) {
-      launchState.updateState(screenshotAccessEnabled: enabled);
-    });
 
     if (!_active) return;
 


### PR DESCRIPTION
> 🤖 This PR was authored with [Claude Code](https://claude.com/claude-code).

# Description

Three independent secondary-screen / achievements bug fixes, split out of the dock feature branch so they can land on their own:

- **fix(secondary): apply fanart dim to system console backgrounds** — the "Dim fanart" scrim was only wired into `buildFanartWithLogo` (game fanart), so a highlighted system's console art behind the system name was never dimmed. `buildSystemBackground` now builds the art widget and wraps it in the same black scrim via a shared `_withFanartDim` helper (no-op at level 0; the solid-color fallback stays undimmed).
- **fix(secondary): stop preview audio bleeding over a game launched mid-init** — `_initializeVideo` only re-checked `mounted` after awaiting `initialize()`/`play()`, so a game launched during those awaits left the in-flight init holding an unassigned controller that went on to `play()` and kept audio alive over the game. Adds a `_videoGeneration` counter that `_stopVideo()` bumps; init snapshots it on entry and disposes + bails if it moved, and plugs a controller leak in the catch.
- **fix(achievements): stop a stale launch snapshot wiping the RA panel** — a stale launch snapshot could clear the RetroAchievements panel.

Fixes # (none)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [ ] **Gamepad support verified** (if applicable).

## Screenshots (if applicable)

Verified on-device (AYN Thor): highlighted-system console art now dims behind the system name per the "Dim fanart" level, and reads full brightness at level 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
