### PR TITLE
fix(system-art): stop re-probing uncovered systems on every theme select

### DIFF
--- a/lib/providers/neo_assets_provider.dart
+++ b/lib/providers/neo_assets_provider.dart
@@ -101,7 +101,7 @@ class NeoAssetsProvider extends ChangeNotifier {
         if (plan.forceRedownload) {
           await NeoAssetsService.downloadAllThemeAssets(
             themeFolder,
-            systemFolderNames,
+            plan.systemsToDownload,
             forceRedownload: true,
             onProgress: (done, t) {
               _downloadProgress = t == 0 ? 1.0 : done / t;
@@ -111,7 +111,7 @@ class NeoAssetsProvider extends ChangeNotifier {
         } else {
           await NeoAssetsService.downloadMissingThemeAssets(
             themeFolder,
-            systemFolderNames,
+            plan.systemsToDownload,
             missingTotal: plan.totalAssetsToDownload,
             onProgress: (done, t) {
               _downloadProgress = t == 0 ? 1.0 : done / t;

--- a/lib/services/neo_assets_service.dart
+++ b/lib/services/neo_assets_service.dart
@@ -28,12 +28,19 @@ class ThemeDownloadPlan {
   /// Full metadata retrieved from the remote theme configuration.
   final Map<String, dynamic>? remoteMetadata;
 
+  /// The system folders whose backgrounds this theme actually provides,
+  /// intersected with the user's systems. When the theme declares a `systems`
+  /// list in `theme.json` this excludes uncovered systems entirely (no 404
+  /// probes); otherwise it falls back to all of the user's systems.
+  final List<String> systemsToDownload;
+
   const ThemeDownloadPlan({
     required this.forceRedownload,
     required this.totalAssetsToDownload,
     required this.localVersion,
     required this.remoteVersion,
     required this.remoteMetadata,
+    required this.systemsToDownload,
   });
 }
 
@@ -390,13 +397,84 @@ class NeoAssetsService {
   ) async {
     int missing = 0;
     for (final system in systemFolderNames) {
-      final bgWebp = await backgroundCachePath(themeFolder, system);
-      final bgGif = await backgroundCachePath(themeFolder, system, ext: 'gif');
-      if (!await File(bgWebp).exists() && !await File(bgGif).exists()) {
+      if (!await _backgroundResolvedOrKnownMissing(themeFolder, system)) {
         missing++;
       }
     }
     return missing;
+  }
+
+  /// Local path of the negative-cache marker for a system whose background is
+  /// not provided by the theme. Lives inside the theme's `backgrounds/` dir so
+  /// it is wiped by [clearThemeCache] on a version bump, re-enabling probing.
+  static Future<String> _backgroundMissingMarkerPath(
+    String themeFolder,
+    String systemFolderName,
+  ) async {
+    final dir = await _cacheDir();
+    return path.join(
+      dir,
+      themeFolder,
+      'backgrounds',
+      '$systemFolderName.missing',
+    );
+  }
+
+  /// True when a system's background is cached (.webp/.gif) OR is known to be
+  /// absent from the theme (a `.missing` marker exists). Prevents re-probing
+  /// systems the pack simply does not cover on every re-selection.
+  static Future<bool> _backgroundResolvedOrKnownMissing(
+    String themeFolder,
+    String systemFolderName,
+  ) async {
+    final bgWebp = await backgroundCachePath(themeFolder, systemFolderName);
+    final bgGif = await backgroundCachePath(
+      themeFolder,
+      systemFolderName,
+      ext: 'gif',
+    );
+    final marker = await _backgroundMissingMarkerPath(
+      themeFolder,
+      systemFolderName,
+    );
+    return await File(bgWebp).exists() ||
+        await File(bgGif).exists() ||
+        await File(marker).exists();
+  }
+
+  /// Records that a system's background is absent from the theme so it is not
+  /// re-downloaded on subsequent selections (cleared on version bump).
+  static Future<void> _writeMissingMarker(
+    String themeFolder,
+    String systemFolderName,
+  ) async {
+    try {
+      final marker = File(
+        await _backgroundMissingMarkerPath(themeFolder, systemFolderName),
+      );
+      await marker.parent.create(recursive: true);
+      await marker.writeAsString('');
+    } catch (e) {
+      _log.w(
+        'Error writing missing marker for "$themeFolder/$systemFolderName": $e',
+      );
+    }
+  }
+
+  /// Resolves which of the user's systems this theme actually covers.
+  ///
+  /// When `theme.json` declares a `systems` list, returns the intersection with
+  /// the user's systems so uncovered systems are never probed (no 404s). When
+  /// the list is absent (older themes / offline metadata), returns all of the
+  /// user's systems and relies on the `.missing` negative-cache fallback.
+  static List<String> _resolveCoveredSystems(
+    Map<String, dynamic>? remoteMetadata,
+    List<String> systemFolderNames,
+  ) {
+    final declared = remoteMetadata?['systems'];
+    if (declared is! List) return systemFolderNames;
+    final covered = declared.map((e) => e.toString()).toSet();
+    return systemFolderNames.where(covered.contains).toList();
   }
 
   /// Compares local and remote versions to build a prioritized download plan.
@@ -408,6 +486,11 @@ class NeoAssetsService {
     final localVersion = await readLocalThemeVersion(themeFolder);
     final remoteVersion = remoteMetadata?['version']?.toString();
 
+    final coveredSystems = _resolveCoveredSystems(
+      remoteMetadata,
+      systemFolderNames,
+    );
+
     final forceRedownload =
         localVersion != null &&
         remoteVersion != null &&
@@ -416,8 +499,16 @@ class NeoAssetsService {
         localVersion != remoteVersion;
 
     final totalAssetsToDownload = forceRedownload
-        ? systemFolderNames.length
-        : await countMissingThemeAssets(themeFolder, systemFolderNames);
+        ? coveredSystems.length
+        : await countMissingThemeAssets(themeFolder, coveredSystems);
+
+    _log.i(
+      'buildThemeDownloadPlan[$themeFolder]: '
+      'localVersion=$localVersion remoteVersion=$remoteVersion '
+      'forceRedownload=$forceRedownload '
+      'covered=${coveredSystems.length}/${systemFolderNames.length} '
+      'missing=$totalAssetsToDownload',
+    );
 
     return ThemeDownloadPlan(
       forceRedownload: forceRedownload,
@@ -425,6 +516,7 @@ class NeoAssetsService {
       localVersion: localVersion,
       remoteVersion: remoteVersion,
       remoteMetadata: remoteMetadata,
+      systemsToDownload: coveredSystems,
     );
   }
 
@@ -448,6 +540,9 @@ class NeoAssetsService {
     result = await downloadAndCacheAsset(gifUrl, gifPath);
     if (result != null) return result;
 
+    // Neither format exists remotely: record a negative-cache marker so this
+    // system is not re-probed on every re-selection of the theme.
+    await _writeMissingMarker(themeFolder, systemFolderName);
     return null;
   }
 
@@ -459,6 +554,41 @@ class NeoAssetsService {
     final localPath = await logoCachePath(themeFolder, systemFolderName);
     final url = getLogoUrl(themeFolder, systemFolderName);
     return downloadAndCacheAsset(url, localPath);
+  }
+
+  /// Max background downloads in flight at once. Theme assets are small,
+  /// independent HTTP GETs, so a bounded pool cuts wall-clock time roughly
+  /// linearly without overwhelming the network or the host.
+  static const int _downloadConcurrency = 8;
+
+  /// Runs [task] over [items] with at most [concurrency] tasks in flight,
+  /// invoking [onEach] after each completion (for progress). A single failing
+  /// task never aborts the batch. Safe on Dart's single-threaded event loop:
+  /// the `next++` cursor and progress counter are only touched synchronously.
+  static Future<void> _runBounded<T>(
+    List<T> items,
+    int concurrency,
+    Future<void> Function(T item) task, {
+    void Function()? onEach,
+  }) async {
+    if (items.isEmpty) return;
+    int next = 0;
+
+    Future<void> worker() async {
+      while (true) {
+        final i = next++;
+        if (i >= items.length) return;
+        try {
+          await task(items[i]);
+        } catch (e) {
+          _log.w('Bounded task failed for item ${items[i]}: $e');
+        }
+        onEach?.call();
+      }
+    }
+
+    final workerCount = concurrency < items.length ? concurrency : items.length;
+    await Future.wait(List.generate(workerCount, (_) => worker()));
   }
 
   /// Downloads all background and logo assets for a theme, optionally
@@ -475,11 +605,12 @@ class NeoAssetsService {
 
     final total = systemFolderNames.length;
     int done = 0;
-    for (final system in systemFolderNames) {
-      await getCachedBackground(themeFolder, system);
-      done++;
-      onProgress?.call(done, total);
-    }
+    await _runBounded<String>(
+      systemFolderNames,
+      _downloadConcurrency,
+      (system) => getCachedBackground(themeFolder, system),
+      onEach: () => onProgress?.call(++done, total),
+    );
   }
 
   /// Downloads only the missing background and logo assets for a theme.
@@ -491,21 +622,23 @@ class NeoAssetsService {
   }) async {
     if (missingTotal <= 0) return;
 
-    int done = 0;
+    // Skip systems already cached or known to be absent from the theme.
+    final pending = <String>[];
     for (final system in systemFolderNames) {
-      final bgWebp = await backgroundCachePath(themeFolder, system);
-      final bgGif = await backgroundCachePath(themeFolder, system, ext: 'gif');
-      if (!await File(bgWebp).exists() && !await File(bgGif).exists()) {
-        final bgUrl = getBackgroundUrl(themeFolder, system);
-        var result = await downloadAndCacheAsset(bgUrl, bgWebp);
-        if (result == null) {
-          final gifUrl = getBackgroundUrl(themeFolder, system, ext: 'gif');
-          await downloadAndCacheAsset(gifUrl, bgGif);
-        }
-        done++;
-        onProgress?.call(done, missingTotal);
+      if (!await _backgroundResolvedOrKnownMissing(themeFolder, system)) {
+        pending.add(system);
       }
     }
+
+    int done = 0;
+    // getCachedBackground tries .webp then .gif and records a negative-cache
+    // marker when neither exists remotely.
+    await _runBounded<String>(
+      pending,
+      _downloadConcurrency,
+      (system) => getCachedBackground(themeFolder, system),
+      onEach: () => onProgress?.call(++done, missingTotal),
+    );
   }
 
   /// Deletes all cached assets for a specific theme folder.


### PR DESCRIPTION
> 🤖 This PR was generated with the assistance of [Claude Code](https://claude.com/claude-code).

# Description

Selecting a system-art pack right after choosing **None** *appeared* to delete the pack and re-download it. Investigation (via an on-device `buildThemeDownloadPlan` log) showed it never deleted anything — `clearTheme()` only nulls the active-theme pointer.

The real cause: `countMissingThemeAssets` counted a system as "missing" whenever no local background existed, **including the ~29 systems the NeoStation pack simply has no art for**. Those systems 404'd, wrote no file, and were re-attempted on **every** re-selection — 58 failed sequential HTTP requests plus a spurious download spinner, which read as "delete + full redownload".

### Changes
- **Negative cache** — on a both-formats (`.webp`+`.gif`) 404, write a `<system>.missing` marker so uncovered systems aren't re-probed. The marker lives in the theme dir wiped by `clearThemeCache`, so it self-invalidates on a version bump.
- **Manifest filtering** — `buildThemeDownloadPlan` reads an optional `systems` list from `theme.json` and only counts/attempts the systems the pack actually covers (intersected with the user's systems). Falls back to the probe + negative-cache path when the list is absent, so it's fully backward compatible with the current assets repo. (A companion change to `neostation-assets` will publish that list, CI-generated from `backgrounds/`.)
- **Parallel downloads** — a bounded worker pool (`_runBounded`, concurrency 8) replaces the serial download loop.
- Kept a `buildThemeDownloadPlan` diagnostic log line.

### Measured impact (AYN Thor, full 121-asset download, cache cleared)
| Build | Concurrency | Time |
|---|---|---|
| Before (serial) | 1 | 44,749 ms |
| After (parallel) | 8 | 3,347 ms |

**~13× faster.** After the first pass, re-selecting a cached pack reports `missing=0` → no download, no spinner.

Fixes # (n/a — internal report)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [x] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [ ] **Gamepad support verified** (if applicable).

## Screenshots (if applicable)

N/A — behavior/perf change; verified via on-device logs and timing (see table above).
