### PR TITLE
feat(dock): secondary-screen app dock + launcher

### DIFF
--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -111,7 +111,7 @@ const Map<String, dynamic> appLocaleDe = {
   AppLocale.nowPlayingDimNever: 'Nie',
   AppLocale.nowPlayingDockEnabled: 'App-Dock',
   AppLocale.nowPlayingDockEnabledSubtitle:
-      'App-Dock auf dem Now Playing-Panel des Zweitbildschirms anzeigen',
+      'App-Dock auf dem Zweitbildschirm anzeigen',
   AppLocale.nowPlayingDockSlots: 'Dock-Plätze',
   AppLocale.nowPlayingDockSlotsSubtitle:
       'Wie viele App-Plätze das Dock anzeigt (1-5)',

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -107,7 +107,7 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.nowPlayingDimNever: 'Never',
   AppLocale.nowPlayingDockEnabled: 'App dock',
   AppLocale.nowPlayingDockEnabledSubtitle:
-      'Show the app dock on the secondary Now Playing panel',
+      'Show the app dock on the secondary screen',
   AppLocale.nowPlayingDockSlots: 'Dock slots',
   AppLocale.nowPlayingDockSlotsSubtitle:
       'How many app slots the dock shows (1-5)',

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -113,7 +113,7 @@ const Map<String, dynamic> appLocaleEs = {
   AppLocale.nowPlayingDimNever: 'Nunca',
   AppLocale.nowPlayingDockEnabled: 'Dock de apps',
   AppLocale.nowPlayingDockEnabledSubtitle:
-      'Muestra el dock de apps en el panel «Reproduciendo» de la pantalla secundaria',
+      'Muestra el dock de apps en la pantalla secundaria',
   AppLocale.nowPlayingDockSlots: 'Ranuras del dock',
   AppLocale.nowPlayingDockSlotsSubtitle:
       'Cuántas ranuras de apps muestra el dock (1-5)',

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -116,7 +116,7 @@ const Map<String, dynamic> appLocaleFr = {
   AppLocale.nowPlayingDimNever: 'Jamais',
   AppLocale.nowPlayingDockEnabled: 'Dock d\'applications',
   AppLocale.nowPlayingDockEnabledSubtitle:
-      'Afficher le dock d\'applications sur le panneau Now Playing secondaire',
+      'Afficher le dock d\'applications sur l\'écran secondaire',
   AppLocale.nowPlayingDockSlots: 'Emplacements du dock',
   AppLocale.nowPlayingDockSlotsSubtitle:
       'Combien d\'emplacements le dock affiche (1-5)',

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -110,7 +110,7 @@ const Map<String, dynamic> appLocaleId = {
   AppLocale.nowPlayingDimNever: 'Jangan Pernah',
   AppLocale.nowPlayingDockEnabled: 'Dock aplikasi',
   AppLocale.nowPlayingDockEnabledSubtitle:
-      'Tampilkan dock aplikasi di panel Now Playing sekunder',
+      'Tampilkan dock aplikasi di layar sekunder',
   AppLocale.nowPlayingDockSlots: 'Slot dock',
   AppLocale.nowPlayingDockSlotsSubtitle:
       'Berapa banyak slot aplikasi yang ditampilkan dock (1-5)',

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -113,7 +113,7 @@ const Map<String, dynamic> appLocaleIt = {
   AppLocale.nowPlayingDimNever: 'Mai',
   AppLocale.nowPlayingDockEnabled: 'Dock app',
   AppLocale.nowPlayingDockEnabledSubtitle:
-      'Mostra il dock app sul panel Now Playing secondario',
+      'Mostra il dock app sullo schermo secondario',
   AppLocale.nowPlayingDockSlots: 'Posti dock',
   AppLocale.nowPlayingDockSlotsSubtitle:
       'Quanti posti app mostra il dock (1-5)',

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -97,7 +97,7 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.nowPlayingDimDarknessSubtitle: 'パネルが暗くなるときの明るさのレベル',
   AppLocale.nowPlayingDimNever: 'なし',
   AppLocale.nowPlayingDockEnabled: 'アプリドック',
-  AppLocale.nowPlayingDockEnabledSubtitle: 'セカンダリのNow Playingパネルにアプリドックを表示',
+  AppLocale.nowPlayingDockEnabledSubtitle: 'セカンダリ画面にアプリドックを表示',
   AppLocale.nowPlayingDockSlots: 'ドックスロット',
   AppLocale.nowPlayingDockSlotsSubtitle: 'ドックに表示するアプリスロット数 (1-5)',
   AppLocale.nowPlayingFanartDim: 'ファンアートを暗くする',

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -112,7 +112,7 @@ const Map<String, dynamic> appLocalePt = {
   AppLocale.nowPlayingDimNever: 'Nunca',
   AppLocale.nowPlayingDockEnabled: 'Dock de apps',
   AppLocale.nowPlayingDockEnabledSubtitle:
-      'Mostrar o dock de apps no painel Now Playing secundário',
+      'Mostrar o dock de apps na tela secundária',
   AppLocale.nowPlayingDockSlots: 'Slots do dock',
   AppLocale.nowPlayingDockSlotsSubtitle:
       'Quantos slots de apps o dock mostra (1-5)',

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -111,7 +111,7 @@ const Map<String, dynamic> appLocaleRu = {
   AppLocale.nowPlayingDimNever: 'Никогда',
   AppLocale.nowPlayingDockEnabled: 'Док приложений',
   AppLocale.nowPlayingDockEnabledSubtitle:
-      'Показывать док приложений на панели Now Playing второго экрана',
+      'Показывать док приложений на втором экране',
   AppLocale.nowPlayingDockSlots: 'Слоты дока',
   AppLocale.nowPlayingDockSlotsSubtitle:
       'Сколько слотов приложений показывает док (1-5)',

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -95,7 +95,7 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.nowPlayingDimDarknessSubtitle: '面板变暗时的暗度',
   AppLocale.nowPlayingDimNever: '从不',
   AppLocale.nowPlayingDockEnabled: '应用坞',
-  AppLocale.nowPlayingDockEnabledSubtitle: '在副屏的 Now Playing 面板上显示应用坞',
+  AppLocale.nowPlayingDockEnabledSubtitle: '在副屏上显示应用坞',
   AppLocale.nowPlayingDockSlots: '应用坞槽位',
   AppLocale.nowPlayingDockSlotsSubtitle: '应用坞显示多少个应用槽位 (1-5)',
   AppLocale.nowPlayingFanartDim: '变暗同人图',

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -95,7 +95,7 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.nowPlayingDimDarknessSubtitle: '面板變暗時的暗度',
   AppLocale.nowPlayingDimNever: '從不',
   AppLocale.nowPlayingDockEnabled: '應用程式塢',
-  AppLocale.nowPlayingDockEnabledSubtitle: '在副螢幕的 Now Playing 面板上顯示應用程式塢',
+  AppLocale.nowPlayingDockEnabledSubtitle: '在副螢幕上顯示應用程式塢',
   AppLocale.nowPlayingDockSlots: '應用程式塢槽位',
   AppLocale.nowPlayingDockSlotsSubtitle: '應用程式塢顯示多少個應用程式槽位 (1-5)',
   AppLocale.nowPlayingFanartDim: '變暗同人圖',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -449,6 +449,12 @@ class _MyAppState extends State<MyApp> {
     FlutterLocalization.instance.onTranslatedLanguage = (Locale? locale) {
       if (mounted) setState(() => _locale = locale);
     };
+    // Once the main UI has painted its first frame, tell the secondary display
+    // the app is ready so it can slide the app dock into place (rather than
+    // showing it fully-formed while the app is still cold-starting).
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      widget.sqliteConfigProvider.markAppReady();
+    });
   }
 
   @override

--- a/lib/models/secondary_display_state.dart
+++ b/lib/models/secondary_display_state.dart
@@ -197,6 +197,13 @@ class SecondaryDisplayStateData {
   /// engine; slots beyond it stay in [dockApps] but are hidden.
   final int dockSlotCount;
 
+  /// Whether the main NeoStation UI has rendered its first frame and is ready
+  /// for use. Pushed by the main engine once, on cold start. The secondary
+  /// display holds the app dock off-screen until this flips true, then slides
+  /// it up — so the dock arrives as the main UI settles rather than popping in
+  /// while the app is still loading.
+  final bool appReady;
+
   SecondaryDisplayStateData({
     required this.systemName,
     this.gameFanart,
@@ -252,6 +259,7 @@ class SecondaryDisplayStateData {
     this.dockEditTrigger = 0,
     this.dockEnabled = true,
     this.dockSlotCount = 3,
+    this.appReady = false,
   });
 
   /// Returns a new instance with the specified properties updated.
@@ -328,6 +336,7 @@ class SecondaryDisplayStateData {
     int? dockEditTrigger,
     bool? dockEnabled,
     int? dockSlotCount,
+    bool? appReady,
   }) {
     return SecondaryDisplayStateData(
       systemName: systemName ?? this.systemName,
@@ -405,6 +414,7 @@ class SecondaryDisplayStateData {
       dockEditTrigger: dockEditTrigger ?? this.dockEditTrigger,
       dockEnabled: dockEnabled ?? this.dockEnabled,
       dockSlotCount: dockSlotCount ?? this.dockSlotCount,
+      appReady: appReady ?? this.appReady,
     );
   }
 
@@ -484,6 +494,7 @@ class SecondaryDisplayStateData {
       dockEditTrigger: (json['dockEditTrigger'] as num?)?.toInt() ?? 0,
       dockEnabled: json['dockEnabled'] as bool? ?? true,
       dockSlotCount: (json['dockSlotCount'] as num?)?.toInt() ?? 3,
+      appReady: json['appReady'] as bool? ?? false,
     );
   }
 
@@ -546,6 +557,7 @@ class SecondaryDisplayStateData {
       'dockEditTrigger': dockEditTrigger,
       'dockEnabled': dockEnabled,
       'dockSlotCount': dockSlotCount,
+      'appReady': appReady,
     };
   }
 }
@@ -658,6 +670,7 @@ class SecondaryDisplayState extends SharedState<SecondaryDisplayStateData> {
     int? dockEditTrigger,
     bool? dockEnabled,
     int? dockSlotCount,
+    bool? appReady,
   }) async {
     if (!Platform.isAndroid) return;
 
@@ -739,6 +752,7 @@ class SecondaryDisplayState extends SharedState<SecondaryDisplayStateData> {
           dockEditTrigger: dockEditTrigger,
           dockEnabled: dockEnabled,
           dockSlotCount: dockSlotCount,
+          appReady: appReady,
         ),
       );
     } catch (e) {

--- a/lib/providers/sqlite_config_provider.dart
+++ b/lib/providers/sqlite_config_provider.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter_localization/flutter_localization.dart';

--- a/lib/providers/sqlite_config_provider.dart
+++ b/lib/providers/sqlite_config_provider.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'package:flutter/widgets.dart';
 import 'package:file_picker/file_picker.dart';
@@ -55,6 +56,10 @@ class SqliteConfigProvider extends ChangeNotifier with WidgetsBindingObserver {
   int _lastMuteToggleTrigger = 0;
   int _lastScreenshotTrigger = 0;
   int _lastDockEditTrigger = 0;
+  // Latched once the main UI paints its first frame; re-pushed to the secondary
+  // display so the app dock slides in as the app settles instead of popping in
+  // during cold-boot. See [markAppReady].
+  bool _appReady = false;
   bool _hasAllFilesAccess = false;
   Set<String> _hiddenSystems = {};
 

--- a/lib/providers/sqlite_config_provider/secondary_display.dart
+++ b/lib/providers/sqlite_config_provider/secondary_display.dart
@@ -152,6 +152,15 @@ extension SqliteConfigSecondaryDisplay on SqliteConfigProvider {
         // engine (the source of truth for SQLite).
         // ignore: unawaited_futures
         updateDockApps(state.dockApps);
+      } else if (_initialized &&
+          !listEquals(state.dockApps, _config.dockApps)) {
+        // No edit trigger, yet the shared dockApps disagrees with the persisted
+        // layout — this is a stale echo from the secondary, whose snapshot
+        // synced before our boot seed and shipped the old (usually empty)
+        // dockApps back, clobbering it. The main engine owns dockApps outside
+        // of user edits, so re-assert the persisted layout. (Guarded on
+        // _initialized so we don't fight before the config has loaded.)
+        _secondaryDisplayState?.updateState(dockApps: _config.dockApps);
       }
     }
   }

--- a/lib/providers/sqlite_config_provider/secondary_display.dart
+++ b/lib/providers/sqlite_config_provider/secondary_display.dart
@@ -98,6 +98,11 @@ extension SqliteConfigSecondaryDisplay on SqliteConfigProvider {
         dockApps: _config.dockApps,
         dockEnabled: _config.dockEnabled,
         dockSlotCount: _config.dockSlotCount,
+        // If the main UI is already up (e.g. a display hot-connected after
+        // launch), carry the ready latch so the dock slides in on connect;
+        // during cold boot this is still false and the dock stays parked until
+        // [markAppReady] fires at first frame.
+        appReady: _appReady,
       );
       // ignore: unawaited_futures
       refreshSecondaryScreenshotAccess();
@@ -105,6 +110,27 @@ extension SqliteConfigSecondaryDisplay on SqliteConfigProvider {
       _secondaryDisplayState!.updateState(isSecondaryActive: false);
     }
     _notify();
+  }
+
+  /// Latches the main UI as ready and pushes it to the secondary display so the
+  /// app dock slides up into place. Called once, from the main screen's first
+  /// post-frame callback. Idempotent — safe to call more than once.
+  ///
+  /// Fires at first frame, which is *before* the provider's async init assigns
+  /// [_secondaryDisplayState] and seeds the shared state, so it can't rely on
+  /// that field. It pushes through [SecondaryDisplayState.instance] directly,
+  /// after [initialSync] so it doesn't race retained-state restoration; the
+  /// copyWith-based [updateState] merges, flipping only `appReady`. Every later
+  /// push copyWith's from this local state, so the latch persists.
+  void markAppReady() {
+    if (_appReady) return;
+    _appReady = true;
+    if (!Platform.isAndroid) return;
+    final state = SecondaryDisplayState.instance;
+    unawaited(() async {
+      await state.initialSync;
+      await state.updateState(appReady: true);
+    }());
   }
 
   void _onSecondaryStateChanged() {

--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -805,8 +805,20 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                                 ),
                               ),
 
+                            // Persistent app dock + all-apps launcher. Drawn at
+                            // the top level (not inside the in-game panel) so it
+                            // stays visible while browsing systems and on the
+                            // Now Playing page — hidden on the achievement pages
+                            // and dimmed together with the panel's idle scrim.
+                            if (value.dockEnabled) _buildDockOverlay(value),
+
                             // Scraping Overlay
                             _buildScrapingOverlay(value),
+
+                            // App picker overlay (dock-slot assignment or
+                            // all-apps launcher). Top-most so it covers the dock
+                            // and any panel; available in every state.
+                            if (_pickerVisible) _buildAppPickerOverlay(),
                           ],
                         ),
                 );
@@ -939,6 +951,71 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
     );
   }
 
+  /// The persistent app dock + all-apps launcher overlay, drawn above the
+  /// in-game panel so it stays reachable while browsing systems and on the Now
+  /// Playing page.
+  ///
+  /// Two behaviours mirror the Now Playing panel so the dock reads as part of
+  /// it while a game is active:
+  ///  * Hidden while flipped to an achievements/comments page (the dock belongs
+  ///    to the Now Playing page).
+  ///  * Faded toward black in step with the panel's idle-dim scrim (which sits
+  ///    below this overlay), so the whole display darkens uniformly.
+  ///
+  /// While browsing (no game active) neither applies, so the dock is fully lit
+  /// and interactive.
+  Widget _buildDockOverlay(SecondaryDisplayStateData value) {
+    final raAvailable =
+        value.showAchievementPanel && value.achievements != null;
+    // Off the Now Playing page (achievements/comments) → hide the dock.
+    final hidden =
+        value.nowPlayingActive && raAvailable && _inGamePanelPage >= 1;
+    final dimmed = value.nowPlayingActive && _inGameDimmed;
+    // Fade to black alongside the panel scrim behind us: the scrim darkens the
+    // display to `nowPlayingDimLevel`, so drop the dock's opacity to match and
+    // let that black show through.
+    final opacity = hidden
+        ? 0.0
+        : dimmed
+        ? (1.0 - value.nowPlayingDimLevel.clamp(0, 100) / 100.0)
+        : 1.0;
+    return Positioned.fill(
+      child: IgnorePointer(
+        // Non-interactive while hidden or dimmed — when dimmed, touches fall
+        // through to the panel's wake Listener below (first touch only wakes).
+        ignoring: hidden || dimmed,
+        child: AnimatedOpacity(
+          duration: const Duration(milliseconds: 400),
+          opacity: opacity,
+          child: Stack(
+            children: [
+              Positioned(
+                left: 0,
+                right: 0,
+                bottom: 0,
+                child: AppDock(
+                  value: value,
+                  onLaunchApp: _launchDockApp,
+                  onPickSlot: _openAppPicker,
+                  onClearSlot: _clearSlot,
+                ),
+              ),
+              Positioned(
+                left: 16.r,
+                bottom: 16.r,
+                child: DockLauncherButton(
+                  value: value,
+                  onOpenLauncher: _openAppLauncher,
+                  onOpenAccessibilitySettings: _openAccessibilitySettings,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
   /// The in-game container body: shows the Now Playing page or the
   /// achievements/comments pages, with edge chevrons to flip between them when the game
   /// has a RetroAchievements set. The page index is clamped so the RA page is
@@ -981,9 +1058,6 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
               ),
             ),
           ),
-          // App picker overlay sits above the dim scrim so opening it (which
-          // also wakes the panel) is always visible.
-          if (_pickerVisible) _buildAppPickerOverlay(),
         ],
       ),
     );
@@ -1039,11 +1113,6 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                       sessionRunning: _sessionWatch.isRunning,
                       sessionTime: _formatSessionTime(),
                       onRequestScreenshot: _requestScreenshot,
-                      onLaunchApp: _launchDockApp,
-                      onPickSlot: _openAppPicker,
-                      onClearSlot: _clearSlot,
-                      onOpenLauncher: _openAppLauncher,
-                      onOpenAccessibilitySettings: _openAccessibilitySettings,
                     ),
             ),
           ),

--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -89,6 +89,10 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
   /// Whether the app picker overlay is currently visible in either mode.
   bool get _pickerVisible => _pickerSlot != null || _launcherOpen;
 
+  /// Whether the "enable Screen Return" explainer dialog is showing. Raised
+  /// when the launcher is tapped while the accessibility service is off.
+  bool _accessDialogVisible = false;
+
   /// Installed-app list backing the picker; null until first loaded.
   List<Map<String, dynamic>>? _pickerApps;
   bool _loadingPickerApps = false;
@@ -819,6 +823,11 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                             // all-apps launcher). Top-most so it covers the dock
                             // and any panel; available in every state.
                             if (_pickerVisible) _buildAppPickerOverlay(),
+
+                            // Accessibility explainer, top-most so it sits over
+                            // the dock and picker.
+                            if (_accessDialogVisible)
+                              _buildAccessibilityDialog(value),
                           ],
                         ),
                 );
@@ -1006,7 +1015,7 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                 child: DockLauncherButton(
                   value: value,
                   onOpenLauncher: _openAppLauncher,
-                  onOpenAccessibilitySettings: _openAccessibilitySettings,
+                  onOpenAccessibilitySettings: _showAccessibilityDialog,
                 ),
               ),
             ],
@@ -1172,6 +1181,161 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
     _wakeInGamePanel();
     SfxService().playNavSound();
     SecondaryAppsService.openAccessibilitySettings();
+  }
+
+  /// Shows the explainer dialog raised when the launcher is tapped while the
+  /// Screen Return accessibility service is off.
+  void _showAccessibilityDialog() {
+    _wakeInGamePanel();
+    SfxService().playNavSound();
+    setState(() => _accessDialogVisible = true);
+  }
+
+  void _dismissAccessibilityDialog() {
+    SfxService().playNavSound();
+    setState(() => _accessDialogVisible = false);
+  }
+
+  /// Accepts the explainer: closes it and jumps to accessibility settings.
+  void _confirmAccessibilityDialog() {
+    setState(() => _accessDialogVisible = false);
+    _openAccessibilitySettings();
+  }
+
+  /// Modal explainer shown before sending the user to accessibility settings.
+  /// Tells them why the Screen Return service is needed and what to do once the
+  /// settings screen opens. Tapping the backdrop or CANCEL dismisses; OPEN
+  /// SETTINGS jumps straight to the accessibility page.
+  Widget _buildAccessibilityDialog(SecondaryDisplayStateData value) {
+    final scheme = panelScheme(value);
+    return Positioned.fill(
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: _dismissAccessibilityDialog,
+        child: ColoredBox(
+          color: Colors.black.withValues(alpha: 0.72),
+          child: Center(
+            child: GestureDetector(
+              // Swallow taps on the card so they don't dismiss via the backdrop.
+              onTap: () {},
+              child: Container(
+                width: 480.r,
+                padding: EdgeInsets.all(28.r),
+                decoration: BoxDecoration(
+                  color: scheme.surface,
+                  borderRadius: BorderRadius.circular(20.r),
+                  border: Border.all(
+                    color: scheme.onSurface.withValues(alpha: 0.15),
+                  ),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withValues(alpha: 0.6),
+                      blurRadius: 24.r,
+                      offset: Offset(0, 8.r),
+                    ),
+                  ],
+                ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Icon(
+                          Symbols.accessibility_new_rounded,
+                          color: scheme.primary,
+                          size: 30.r,
+                        ),
+                        SizedBox(width: 12.r),
+                        Expanded(
+                          child: Text(
+                            'Enable Screen Return',
+                            style: TextStyle(
+                              color: scheme.onSurface,
+                              fontSize: 20.r,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    SizedBox(height: 18.r),
+                    Text(
+                      'To launch apps from the dock, NeoStation needs the '
+                      'Screen Return accessibility service. It lets NeoStation '
+                      'bring you back here after you close the app you opened. '
+                      "Without it you could be left with no way back.\n\n"
+                      'On the next screen, find NeoStation in the list of '
+                      'services and switch it on.',
+                      style: TextStyle(
+                        color: scheme.onSurface.withValues(alpha: 0.8),
+                        fontSize: 14.r,
+                        height: 1.45,
+                      ),
+                    ),
+                    SizedBox(height: 26.r),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.end,
+                      children: [
+                        _buildDialogButton(
+                          label: 'CANCEL',
+                          onTap: _dismissAccessibilityDialog,
+                          scheme: scheme,
+                          filled: false,
+                        ),
+                        SizedBox(width: 12.r),
+                        _buildDialogButton(
+                          label: 'OPEN SETTINGS',
+                          onTap: _confirmAccessibilityDialog,
+                          scheme: scheme,
+                          filled: true,
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// A flat dialog action button — filled with the accent for the primary
+  /// action, outlined for the secondary. Custom (not a Material button) to match
+  /// the rest of the secondary screen, which has no Material ancestor.
+  Widget _buildDialogButton({
+    required String label,
+    required VoidCallback onTap,
+    required ColorScheme scheme,
+    required bool filled,
+  }) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: EdgeInsets.symmetric(horizontal: 20.r, vertical: 12.r),
+        decoration: BoxDecoration(
+          color: filled ? scheme.primary : Colors.transparent,
+          borderRadius: BorderRadius.circular(12.r),
+          border: Border.all(
+            color: filled
+                ? scheme.primary
+                : scheme.onSurface.withValues(alpha: 0.30),
+            width: 1.5.r,
+          ),
+        ),
+        child: Text(
+          label,
+          style: TextStyle(
+            color: filled ? scheme.onPrimary : scheme.onSurface,
+            fontSize: 13.r,
+            fontWeight: FontWeight.w700,
+            letterSpacing: 1.r,
+          ),
+        ),
+      ),
+    );
   }
 
   /// Full-panel overlay for choosing an app for the pending dock slot. Tapping

--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -34,6 +34,11 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
   SecondaryDisplayState? _secondaryDisplayState;
   VideoPlayerController? _videoController;
 
+  /// Latches true the first time the main engine reports `appReady`; drives the
+  /// app dock's one-shot slide-up. Local so the oscillating shared-state flag
+  /// can't un-reveal the dock. See [_buildDockOverlay].
+  bool _dockRevealed = false;
+
   /// A BuildContext captured from *under* this screen's MaterialApp (and its
   /// Localizations). The _buildXxx helpers below run as methods on this State,
   /// so a bare `context` resolves to `this.context` — which sits ABOVE the
@@ -974,6 +979,12 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
   /// While browsing (no game active) neither applies, so the dock is fully lit
   /// and interactive.
   Widget _buildDockOverlay(SecondaryDisplayStateData value) {
+    // `appReady` is a one-way "main UI has painted" latch, but the shared state
+    // is written by BOTH engines: the secondary's own pushes (isSecondaryActive,
+    // mute/screenshot toggles) copyWith from a local snapshot that may still
+    // carry appReady=false, so the incoming flag oscillates. Latch it locally on
+    // first true and ignore later falses, so the dock slides up once and stays.
+    if (value.appReady) _dockRevealed = true;
     final raAvailable =
         value.showAchievementPanel && value.achievements != null;
     // Off the Now Playing page (achievements/comments) → hide the dock.
@@ -996,29 +1007,43 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
         child: AnimatedOpacity(
           duration: const Duration(milliseconds: 400),
           opacity: opacity,
-          child: Stack(
-            children: [
-              Positioned(
-                left: 0,
-                right: 0,
-                bottom: 0,
-                child: AppDock(
-                  value: value,
-                  onLaunchApp: _launchDockApp,
-                  onPickSlot: _openAppPicker,
-                  onClearSlot: _clearSlot,
+          // Slide-up keyed to main-UI readiness: the dock starts parked fully
+          // below the bottom edge (t=1) and stays there until the main engine
+          // reports its first frame via `appReady`, then eases into place. This
+          // syncs the dock's arrival with the app becoming usable instead of
+          // firing on the secondary display's own (earlier) first paint.
+          child: TweenAnimationBuilder<double>(
+            tween: Tween(begin: 1.0, end: _dockRevealed ? 0.0 : 1.0),
+            duration: const Duration(milliseconds: 550),
+            curve: Curves.easeOutCubic,
+            builder: (context, t, child) => Transform.translate(
+              offset: Offset(0, t * 140.r),
+              child: child,
+            ),
+            child: Stack(
+              children: [
+                Positioned(
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  child: AppDock(
+                    value: value,
+                    onLaunchApp: _launchDockApp,
+                    onPickSlot: _openAppPicker,
+                    onClearSlot: _clearSlot,
+                  ),
                 ),
-              ),
-              Positioned(
-                left: 16.r,
-                bottom: 16.r,
-                child: DockLauncherButton(
-                  value: value,
-                  onOpenLauncher: _openAppLauncher,
-                  onOpenAccessibilitySettings: _showAccessibilityDialog,
+                Positioned(
+                  left: 16.r,
+                  bottom: 16.r,
+                  child: DockLauncherButton(
+                    value: value,
+                    onOpenLauncher: _openAppLauncher,
+                    onOpenAccessibilitySettings: _showAccessibilityDialog,
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/screens/secondary_screen/secondary_screen.dart
+++ b/lib/screens/secondary_screen/secondary_screen.dart
@@ -1050,6 +1050,7 @@ class _SecondaryScreenState extends State<SecondaryScreen> {
                     onLaunchApp: _launchDockApp,
                     onPickSlot: _openAppPicker,
                     onClearSlot: _clearSlot,
+                    onOpenAccessibilitySettings: _showAccessibilityDialog,
                   ),
                 ),
                 Positioned(

--- a/lib/screens/secondary_screen/widgets/app_dock.dart
+++ b/lib/screens/secondary_screen/widgets/app_dock.dart
@@ -21,6 +21,7 @@ class AppDock extends StatelessWidget {
     required this.onLaunchApp,
     required this.onPickSlot,
     required this.onClearSlot,
+    required this.onOpenAccessibilitySettings,
   });
 
   final SecondaryDisplayStateData value;
@@ -34,11 +35,18 @@ class AppDock extends StatelessWidget {
   /// Clears the app assigned to slot [index].
   final void Function(int index) onClearSlot;
 
+  /// Opens the Screen Return accessibility explainer/settings. Filled slots
+  /// route here instead of launching when the service is off — launching an app
+  /// without it would strand the user with no way back to the home screen.
+  final VoidCallback onOpenAccessibilitySettings;
+
   @override
   Widget build(BuildContext context) {
     if (!value.dockEnabled) return const SizedBox.shrink();
     final apps = ConfigModel.normalizeDock(value.dockApps);
     final scheme = panelScheme(value);
+    // Screen Return off → guard filled slots (see [onOpenAccessibilitySettings]).
+    final accessOk = value.screenshotAccessEnabled;
     final visibleSlots = value.dockSlotCount.clamp(
       ConfigModel.dockMinSlotCount,
       ConfigModel.dockMaxSlotCount,
@@ -50,18 +58,36 @@ class AppDock extends StatelessWidget {
         children: [
           for (var i = 0; i < visibleSlots; i++) ...[
             if (i > 0) SizedBox(width: 14.r),
-            _buildDockSlot(i, apps[i], scheme),
+            _buildDockSlot(i, apps[i], scheme, accessOk),
           ],
         ],
       ),
     );
   }
 
-  /// A single dock slot. [package] empty = free slot.
-  Widget _buildDockSlot(int index, String package, ColorScheme scheme) {
+  /// A single dock slot. [package] empty = free slot. When [accessOk] is false,
+  /// a filled slot is guarded: tapping opens the Screen Return explainer instead
+  /// of launching, and the slot wears an accent border to nudge the user to
+  /// enable the service for the best experience. Empty slots are unaffected —
+  /// assigning an app doesn't launch anything, so there's nothing to strand.
+  Widget _buildDockSlot(
+    int index,
+    String package,
+    ColorScheme scheme,
+    bool accessOk,
+  ) {
     final filled = package.isNotEmpty;
+    final guarded = filled && !accessOk;
     return GestureDetector(
-      onTap: () => filled ? onLaunchApp(package) : onPickSlot(index),
+      onTap: () {
+        if (!filled) {
+          onPickSlot(index);
+        } else if (guarded) {
+          onOpenAccessibilitySettings();
+        } else {
+          onLaunchApp(package);
+        }
+      },
       onLongPress: filled ? () => onClearSlot(index) : null,
       child: Container(
         width: 56.r,
@@ -76,8 +102,10 @@ class AppDock extends StatelessWidget {
           ),
           borderRadius: BorderRadius.circular(14.r),
           border: Border.all(
-            color: scheme.onSurface.withValues(alpha: filled ? 0.55 : 0.40),
-            width: 1.5.r,
+            color: guarded
+                ? scheme.primary
+                : scheme.onSurface.withValues(alpha: filled ? 0.55 : 0.40),
+            width: guarded ? 2.r : 1.5.r,
           ),
           boxShadow: [
             BoxShadow(

--- a/lib/screens/secondary_screen/widgets/app_dock.dart
+++ b/lib/screens/secondary_screen/widgets/app_dock.dart
@@ -43,18 +43,8 @@ class AppDock extends StatelessWidget {
       ConfigModel.dockMinSlotCount,
       ConfigModel.dockMaxSlotCount,
     );
-    return Container(
-      padding: EdgeInsets.symmetric(horizontal: 16.r, vertical: 12.r),
-      decoration: BoxDecoration(
-        gradient: LinearGradient(
-          begin: Alignment.bottomCenter,
-          end: Alignment.topCenter,
-          colors: [
-            scheme.shadow.withValues(alpha: 0.55),
-            scheme.shadow.withValues(alpha: 0.0),
-          ],
-        ),
-      ),
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: 16.r, vertical: 20.r),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
@@ -77,11 +67,26 @@ class AppDock extends StatelessWidget {
         width: 56.r,
         height: 56.r,
         decoration: BoxDecoration(
-          color: scheme.onSurface.withValues(alpha: filled ? 0.10 : 0.05),
+          // Fully-opaque chip in the panel's own surface colour so slots stay
+          // legible over busy background art, with a bright border + drop
+          // shadow to separate them from the dark backing and the art.
+          color: Color.alphaBlend(
+            scheme.onSurface.withValues(alpha: filled ? 0.14 : 0.08),
+            scheme.surface,
+          ),
           borderRadius: BorderRadius.circular(14.r),
           border: Border.all(
-            color: scheme.onSurface.withValues(alpha: filled ? 0.22 : 0.14),
+            color: scheme.onSurface.withValues(alpha: filled ? 0.55 : 0.40),
+            width: 1.5.r,
           ),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.6),
+              blurRadius: 12.r,
+              spreadRadius: 1.r,
+              offset: Offset(0, 3.r),
+            ),
+          ],
         ),
         child: filled
             ? Padding(
@@ -93,6 +98,103 @@ class AppDock extends StatelessWidget {
                 color: scheme.onSurface.withValues(alpha: 0.45),
                 size: 26.r,
               ),
+      ),
+    );
+  }
+}
+
+/// The all-apps launcher button, pinned to the bottom-left of the secondary
+/// display alongside the [AppDock]. Normally opens the app picker in launch
+/// mode. When the Screen Return accessibility service isn't enabled, it's
+/// highlighted with an accent border + warning badge and instead opens
+/// accessibility settings — launching an app without that service would strand
+/// the user with no way back to the home screen.
+///
+/// Pure, input-driven subtree — the owner passes the current state snapshot and
+/// the two callbacks, so the button re-reads no provider state of its own.
+class DockLauncherButton extends StatelessWidget {
+  const DockLauncherButton({
+    super.key,
+    required this.value,
+    required this.onOpenLauncher,
+    required this.onOpenAccessibilitySettings,
+  });
+
+  final SecondaryDisplayStateData value;
+
+  /// Opens the app picker in launch mode (all-apps launcher).
+  final VoidCallback onOpenLauncher;
+
+  /// Opens Android accessibility settings to enable the Screen Return service.
+  final VoidCallback onOpenAccessibilitySettings;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = panelScheme(value);
+    final accessOk = value.screenshotAccessEnabled;
+    return GestureDetector(
+      onTap: accessOk ? onOpenLauncher : onOpenAccessibilitySettings,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Container(
+            width: 56.r,
+            height: 56.r,
+            decoration: BoxDecoration(
+              // Opaque chip (see [AppDock]) so it reads over background art.
+              color: accessOk
+                  ? Color.alphaBlend(
+                      scheme.onSurface.withValues(alpha: 0.08),
+                      scheme.surface,
+                    )
+                  : Color.alphaBlend(
+                      scheme.primary.withValues(alpha: 0.30),
+                      scheme.surface,
+                    ),
+              borderRadius: BorderRadius.circular(14.r),
+              border: Border.all(
+                color: accessOk
+                    ? scheme.onSurface.withValues(alpha: 0.40)
+                    : scheme.primary,
+                width: accessOk ? 1.5.r : 2.r,
+              ),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: 0.6),
+                  blurRadius: 12.r,
+                  spreadRadius: 1.r,
+                  offset: Offset(0, 3.r),
+                ),
+              ],
+            ),
+            child: Icon(
+              Symbols.apps_rounded,
+              color: accessOk
+                  ? scheme.onSurface.withValues(alpha: 0.65)
+                  : scheme.primary,
+              size: 28.r,
+            ),
+          ),
+          if (!accessOk)
+            Positioned(
+              top: -4.r,
+              right: -4.r,
+              child: Container(
+                width: 20.r,
+                height: 20.r,
+                decoration: BoxDecoration(
+                  color: scheme.primary,
+                  shape: BoxShape.circle,
+                  border: Border.all(color: scheme.surface, width: 2.r),
+                ),
+                child: Icon(
+                  Symbols.priority_high_rounded,
+                  size: 12.r,
+                  color: scheme.onPrimary,
+                ),
+              ),
+            ),
+        ],
       ),
     );
   }

--- a/lib/screens/secondary_screen/widgets/now_playing_panel.dart
+++ b/lib/screens/secondary_screen/widgets/now_playing_panel.dart
@@ -3,11 +3,13 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:material_symbols_icons/symbols.dart';
 import '../../../models/secondary_display_state.dart';
 import '../now_playing_helpers.dart';
-import 'app_dock.dart';
 
 /// The Now Playing page shown on the secondary display: boxart + game/system
-/// title + play-time / session / last-played stats, the app dock, and the
-/// all-apps launcher button.
+/// title + play-time / session / last-played stats.
+///
+/// The app dock and all-apps launcher are no longer part of this panel — they
+/// are drawn as a persistent overlay by [SecondaryScreen] so they stay visible
+/// in every state (browsing and in-game), not just while a game is active.
 ///
 /// Pure, input-driven subtree — the owning [SecondaryScreen] passes the current
 /// state snapshot, the live session readout ([sessionRunning] / [sessionTime]),
@@ -19,11 +21,6 @@ class NowPlayingPanel extends StatelessWidget {
     required this.sessionRunning,
     required this.sessionTime,
     required this.onRequestScreenshot,
-    required this.onLaunchApp,
-    required this.onPickSlot,
-    required this.onClearSlot,
-    required this.onOpenLauncher,
-    required this.onOpenAccessibilitySettings,
   });
 
   final SecondaryDisplayStateData value;
@@ -37,21 +34,6 @@ class NowPlayingPanel extends StatelessWidget {
 
   /// Asks the main engine to capture a screenshot of the main screen.
   final VoidCallback onRequestScreenshot;
-
-  /// Launches the docked app in `package` (prefers the bottom display).
-  final void Function(String package) onLaunchApp;
-
-  /// Opens the app picker to assign an app to the empty slot `index`.
-  final void Function(int index) onPickSlot;
-
-  /// Clears the app assigned to slot `index`.
-  final void Function(int index) onClearSlot;
-
-  /// Opens the app picker in launch mode (all-apps launcher).
-  final VoidCallback onOpenLauncher;
-
-  /// Opens Android accessibility settings to enable the Screen Return service.
-  final VoidCallback onOpenAccessibilitySettings;
 
   @override
   Widget build(BuildContext context) {
@@ -142,24 +124,6 @@ class NowPlayingPanel extends StatelessWidget {
               ],
             ),
           ),
-          Positioned(
-            left: 0,
-            right: 0,
-            bottom: 0,
-            child: AppDock(
-              value: value,
-              onLaunchApp: onLaunchApp,
-              onPickSlot: onPickSlot,
-              onClearSlot: onClearSlot,
-            ),
-          ),
-          // All-apps launcher pinned to the bottom-left corner.
-          if (value.dockEnabled)
-            Positioned(
-              left: 16.r,
-              bottom: 16.r,
-              child: _buildLauncherButton(value),
-            ),
         ],
       ),
     );
@@ -197,67 +161,6 @@ class NowPlayingPanel extends StatelessWidget {
             ),
           ],
         ),
-      ),
-    );
-  }
-
-  /// The all-apps launcher, pinned to the bottom-left of the Now Playing
-  /// screen. Normally opens the app picker in launch mode. When the Screen
-  /// Return accessibility service isn't enabled, it's highlighted with an
-  /// accent border + warning badge and instead opens accessibility settings —
-  /// launching an app without that service would strand the user with no way
-  /// back to Now Playing.
-  Widget _buildLauncherButton(SecondaryDisplayStateData value) {
-    final scheme = panelScheme(value);
-    final accessOk = value.screenshotAccessEnabled;
-    return GestureDetector(
-      onTap: accessOk ? onOpenLauncher : onOpenAccessibilitySettings,
-      child: Stack(
-        clipBehavior: Clip.none,
-        children: [
-          Container(
-            width: 56.r,
-            height: 56.r,
-            decoration: BoxDecoration(
-              color: accessOk
-                  ? scheme.onSurface.withValues(alpha: 0.05)
-                  : scheme.primary.withValues(alpha: 0.15),
-              borderRadius: BorderRadius.circular(14.r),
-              border: Border.all(
-                color: accessOk
-                    ? scheme.onSurface.withValues(alpha: 0.14)
-                    : scheme.primary,
-                width: accessOk ? 1.r : 2.r,
-              ),
-            ),
-            child: Icon(
-              Symbols.apps_rounded,
-              color: accessOk
-                  ? scheme.onSurface.withValues(alpha: 0.65)
-                  : scheme.primary,
-              size: 28.r,
-            ),
-          ),
-          if (!accessOk)
-            Positioned(
-              top: -4.r,
-              right: -4.r,
-              child: Container(
-                width: 20.r,
-                height: 20.r,
-                decoration: BoxDecoration(
-                  color: scheme.primary,
-                  shape: BoxShape.circle,
-                  border: Border.all(color: scheme.surface, width: 2.r),
-                ),
-                child: Icon(
-                  Symbols.priority_high_rounded,
-                  size: 12.r,
-                  color: scheme.onPrimary,
-                ),
-              ),
-            ),
-        ],
       ),
     );
   }


### PR DESCRIPTION
> 🤖 This PR was authored with [Claude Code](https://claude.com/claude-code).

# Description

Adds an app dock + launcher to the secondary (bottom) display and polishes its behaviour. The dock lets you assign, launch, and clear installed apps from the bottom screen while a game or the home UI is showing.

Highlights in this branch:

- **Always-on dock + launcher** on the secondary screen (not just the Now Playing panel).
- **Slide-in on ready:** the dock parks below the bottom edge on cold boot and slides up once the main UI paints its first frame (`appReady` latch), so it arrives as NeoStation settles instead of popping in mid-load.
- **Screen Return guard:** when the accessibility service is off, filled dock slots (and the launcher) route to the Screen Return explainer instead of launching — launching without it would strand the user on the secondary app with no way home. Guarded slots wear an accent border to nudge enabling it.
- **Persistence fix:** dock slot assignments were saved to SQLite but wiped from the display on cold boot by a cross-engine state race (the secondary echoed a stale empty `dockApps` snapshot back over the main's boot seed). The main now re-asserts the persisted layout when the shared state drifts without a user edit.
- Reworded the dock setting subtitle (all locales) to drop the stale "Now Playing panel" reference.

Fixes # (N/A)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [ ] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable).

## Screenshots (if applicable)

_Verified on the AYN Thor bottom screen: slide-in timing, Screen Return guard state, and slot persistence across relaunch._
