### PR TITLE
refactor(settings): unify row/section components across settings panels

### DIFF
--- a/lib/screens/settings_screen/new_settings_options/directories_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/directories_settings_content.dart
@@ -23,7 +23,10 @@ import 'package:neostation/widgets/restart_required_dialog.dart';
 import 'package:neostation/widgets/tv_directory_picker.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:provider/provider.dart';
+import 'package:neostation/utils/adaptive_scroll.dart';
 import 'settings_title.dart';
+import 'widgets/settings_section_header.dart';
+import 'widgets/settings_action_button.dart';
 
 class DirectoriesSettingsContent extends StatefulWidget {
   final bool isContentFocused;
@@ -43,6 +46,19 @@ class DirectoriesSettingsContent extends StatefulWidget {
 class DirectoriesSettingsContentState
     extends State<DirectoriesSettingsContent> {
   final ScrollController _scrollController = ScrollController();
+  final AdaptiveScroller _scroller = AdaptiveScroller();
+
+  /// GlobalKeys for the navigable rows, used to keep the focused row visible
+  /// during gamepad navigation.
+  final List<GlobalKey> _itemKeys = [];
+
+  /// Grows [_itemKeys] to cover the current navigable-item count.
+  void _ensureKeys(int count) {
+    while (_itemKeys.length < count) {
+      _itemKeys.add(GlobalKey());
+    }
+  }
+
   List<String> _currentRomFolders = [];
   String? _currentUserDataPath;
   bool _isLoading = true;
@@ -77,18 +93,15 @@ class DirectoriesSettingsContentState
   }
 
   void scrollToIndex(int index) {
-    if (!_scrollController.hasClients) return;
-    // The visual list interleaves section-header rows among the nav items
-    // ("ROM Directories" before nav 2, "ES-DE Import" before _esdeSectionStart),
-    // so a nav item's on-screen row is offset by the headers that precede it.
-    var headersBefore = 0;
-    if (index >= 2) headersBefore++;
-    if (_esdeSectionStart >= 0 && index >= _esdeSectionStart) headersBefore++;
-    _scrollController.animateTo(
-      (index + headersBefore) * 60.h,
-      duration: const Duration(milliseconds: 200),
-      curve: Curves.easeInOut,
-    );
+    // Use the focused row's own key so scrolling tracks its real height —
+    // section headers and path-chip cards aren't a uniform height, so a
+    // fixed per-row estimate drifts and overshoots as the list scrolls.
+    if (index >= 0 && index < _itemKeys.length) {
+      final ctx = _itemKeys[index].currentContext;
+      if (ctx != null) {
+        _scroller.ensureVisible(ctx);
+      }
+    }
   }
 
   void _buildDirectoryItems() {
@@ -785,60 +798,6 @@ class DirectoriesSettingsContentState
     );
   }
 
-  Widget _buildSectionHeader(ThemeData theme, String label) {
-    return Padding(
-      padding: EdgeInsets.only(bottom: 8.r, top: 4.r, left: 2.r),
-      child: Row(
-        children: [
-          Container(
-            width: 3.r,
-            height: 14.r,
-            decoration: BoxDecoration(
-              color: theme.colorScheme.primary,
-              borderRadius: BorderRadius.circular(2.r),
-            ),
-          ),
-          SizedBox(width: 8.r),
-          Text(
-            label,
-            style: TextStyle(
-              fontSize: 11.r,
-              fontWeight: FontWeight.bold,
-              color: theme.colorScheme.primary,
-              letterSpacing: 0.5,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildActionButton(
-    ThemeData theme,
-    bool isSelected,
-    IconData icon, {
-    bool isDestructive = false,
-  }) {
-    final color = isDestructive
-        ? theme.colorScheme.error
-        : theme.colorScheme.primary;
-    return Container(
-      padding: EdgeInsets.all(4.r),
-      decoration: BoxDecoration(
-        color: color.withValues(alpha: isSelected ? 1.0 : 0.8),
-        shape: BoxShape.circle,
-        boxShadow: [
-          BoxShadow(
-            color: color.withValues(alpha: 0.3),
-            blurRadius: 4.r,
-            offset: Offset(0, 2.r),
-          ),
-        ],
-      ),
-      child: Icon(icon, color: theme.colorScheme.onPrimary, size: 16.r),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -893,6 +852,7 @@ class DirectoriesSettingsContentState
                     }
                     visualRows.add({'nav': i});
                   }
+                  _ensureKeys(_directoryItems.length);
 
                   return ListView.builder(
                     controller: _scrollController,
@@ -901,9 +861,8 @@ class DirectoriesSettingsContentState
                     itemBuilder: (context, visualIndex) {
                       final row = visualRows[visualIndex];
                       if (row.containsKey('header')) {
-                        return _buildSectionHeader(
-                          theme,
-                          row['header'] as String,
+                        return SettingsSectionHeader(
+                          label: row['header'] as String,
                         );
                       }
 
@@ -925,6 +884,7 @@ class DirectoriesSettingsContentState
                           : theme.colorScheme.outline.withValues(alpha: 0);
 
                       return Opacity(
+                        key: _itemKeys[navIndex],
                         opacity: isEsdeDisabled ? 0.4 : 1.0,
                         child: Container(
                           decoration: BoxDecoration(
@@ -1035,49 +995,42 @@ class DirectoriesSettingsContentState
                                         ),
                                       ),
                                       if (isRemoveItem)
-                                        _buildActionButton(
-                                          theme,
-                                          isSelected,
-                                          Symbols.delete_outline_rounded,
+                                        SettingsActionButton(
+                                          icon: Symbols.delete_outline_rounded,
+                                          selected: isSelected,
                                           isDestructive: true,
                                         )
                                       else if (item['action'] == 'add_rom')
-                                        _buildActionButton(
-                                          theme,
-                                          isSelected,
-                                          Symbols.add_rounded,
+                                        SettingsActionButton(
+                                          icon: Symbols.add_rounded,
+                                          selected: isSelected,
                                         )
                                       else if (item['action'] == 'rescan')
-                                        _buildActionButton(
-                                          theme,
-                                          isSelected,
-                                          Symbols.refresh_rounded,
+                                        SettingsActionButton(
+                                          icon: Symbols.refresh_rounded,
+                                          selected: isSelected,
                                         )
                                       else if (isUserData)
-                                        _buildActionButton(
-                                          theme,
-                                          isSelected,
-                                          Symbols.edit_rounded,
+                                        SettingsActionButton(
+                                          icon: Symbols.edit_rounded,
+                                          selected: isSelected,
                                         )
                                       else if (item['action'] ==
                                           'esde_select_folder')
-                                        _buildActionButton(
-                                          theme,
-                                          isSelected,
-                                          Symbols.folder_special_rounded,
+                                        SettingsActionButton(
+                                          icon: Symbols.folder_special_rounded,
+                                          selected: isSelected,
                                         )
                                       else if (item['action'] ==
                                           'esde_run_import')
-                                        _buildActionButton(
-                                          theme,
-                                          isSelected,
-                                          Symbols.download_rounded,
+                                        SettingsActionButton(
+                                          icon: Symbols.download_rounded,
+                                          selected: isSelected,
                                         )
                                       else if (item['action'] == 'esde_reset')
-                                        _buildActionButton(
-                                          theme,
-                                          isSelected,
-                                          Symbols.restart_alt_rounded,
+                                        SettingsActionButton(
+                                          icon: Symbols.restart_alt_rounded,
+                                          selected: isSelected,
                                           isDestructive: true,
                                         ),
                                     ],

--- a/lib/screens/settings_screen/new_settings_options/general_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/general_settings_content.dart
@@ -15,6 +15,7 @@ import '../../../providers/sqlite_config_provider.dart';
 import '../../../widgets/custom_toggle_switch.dart';
 import 'settings_title.dart';
 import 'widgets/setting_row.dart';
+import 'widgets/setting_value_chip.dart';
 import 'widgets/language_picker_overlay.dart';
 import '../../../services/permission_service.dart';
 
@@ -314,17 +315,21 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
     final config = provider.config;
     int currentItemIdx = 0;
 
-    return SingleChildScrollView(
-      controller: _scrollController,
-      physics: const ClampingScrollPhysics(),
-      padding: EdgeInsets.only(bottom: 24.r),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          SettingsTitle(title: AppLocale.generalSettings.getString(context)),
-          SizedBox(height: 12.r),
-
-          // Setting: Scan on Startup.
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Pinned header — stays put while the settings list scrolls beneath it.
+        SettingsTitle(title: AppLocale.generalSettings.getString(context)),
+        SizedBox(height: 12.r),
+        Expanded(
+          child: SingleChildScrollView(
+            controller: _scrollController,
+            physics: const ClampingScrollPhysics(),
+            padding: EdgeInsets.only(bottom: 24.r),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Setting: Scan on Startup.
           () {
             final index = currentItemIdx++;
             return SettingRow(
@@ -472,39 +477,11 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
               subtitle: AppLocale.languageSub.getString(context),
               trailing: GestureDetector(
                 onTap: () => _showLanguagePicker(context, _itemKeys[index]),
-                child: Container(
-                  padding: EdgeInsets.symmetric(
-                    horizontal: 10.r,
-                    vertical: 6.r,
-                  ),
-                  decoration: BoxDecoration(
-                    color: theme.colorScheme.primary.withValues(alpha: 0.15),
-                    borderRadius: BorderRadius.circular(6.r),
-                    border: Border.all(
-                      color: theme.colorScheme.primary.withValues(alpha: 0.4),
-                      width: 0.5.r,
-                    ),
-                  ),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(
-                        AppLocale.supportedLanguages[config.appLanguage] ??
-                            config.appLanguage,
-                        style: theme.textTheme.bodyMedium?.copyWith(
-                          fontSize: 9.r,
-                          fontWeight: FontWeight.w400,
-                          color: theme.colorScheme.primary,
-                        ),
-                      ),
-                      SizedBox(width: 2.r),
-                      Icon(
-                        Symbols.arrow_drop_down_rounded,
-                        size: 14.r,
-                        color: theme.colorScheme.primary,
-                      ),
-                    ],
-                  ),
+                child: SettingValueChip(
+                  text:
+                      AppLocale.supportedLanguages[config.appLanguage] ??
+                      config.appLanguage,
+                  trailingIcon: Symbols.arrow_drop_down_rounded,
                 ),
               ),
             );
@@ -538,79 +515,44 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
             SizedBox(height: 12.r),
             () {
               final index = currentItemIdx++;
-              return Container(
+              return SettingRow(
                 key: _itemKeys[index],
-                padding: EdgeInsets.only(
-                  left: 12.r,
-                  right: 12.r,
-                  top: 6.r,
-                  bottom: 6.r,
-                ),
-                decoration: BoxDecoration(
-                  color: theme.colorScheme.surface.withValues(alpha: 0.5),
-                  borderRadius: BorderRadius.circular(8.r),
-                  border: Border.all(
-                    color:
-                        widget.isContentFocused &&
-                            widget.selectedContentIndex == index
-                        ? theme.colorScheme.primary
-                        : Colors.transparent,
-                    width: 2,
-                  ),
-                ),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                focused:
+                    widget.isContentFocused &&
+                    widget.selectedContentIndex == index,
+                title: AppLocale.allFilesAccess.getString(context),
+                subtitle: '',
+                subtitleWidget: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            AppLocale.allFilesAccess.getString(context),
-                            style: theme.textTheme.bodyLarge?.copyWith(
-                              fontSize: 12.r,
-                              fontWeight: FontWeight.w500,
-                              color:
-                                  widget.isContentFocused &&
-                                      widget.selectedContentIndex == index
-                                  ? theme.colorScheme.primary
-                                  : theme.colorScheme.onSurface,
-                            ),
-                          ),
-                          SizedBox(height: 4.r),
-                          Text(
-                            provider.hasAllFilesAccess
-                                ? AppLocale.permissionGranted.getString(context)
-                                : AppLocale.permissionDisabled.getString(
-                                    context,
-                                  ),
-                            style: theme.textTheme.bodyMedium?.copyWith(
-                              fontSize: 9.r,
-                              fontWeight: FontWeight.bold,
-                              color: provider.hasAllFilesAccess
-                                  ? Colors.green
-                                  : Colors.red,
-                            ),
-                          ),
-                          SizedBox(height: 2.r),
-                          Text(
-                            AppLocale.allFilesAccessSubtitle.getString(context),
-                            style: theme.textTheme.bodyMedium?.copyWith(
-                              fontSize: 8.r,
-                              color: theme.colorScheme.onSurface.withValues(
-                                alpha: 0.5,
-                              ),
-                            ),
-                          ),
-                        ],
+                    Text(
+                      provider.hasAllFilesAccess
+                          ? AppLocale.permissionGranted.getString(context)
+                          : AppLocale.permissionDisabled.getString(context),
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        fontSize: 9.r,
+                        fontWeight: FontWeight.bold,
+                        color: provider.hasAllFilesAccess
+                            ? Colors.green
+                            : Colors.red,
                       ),
                     ),
-                    CustomToggleSwitch(
-                      value: provider.hasAllFilesAccess,
-                      onChanged: (value) => _handlePermissionToggle(provider),
-                      activeColor: theme.colorScheme.primary,
+                    SizedBox(height: 2.r),
+                    Text(
+                      AppLocale.allFilesAccessSubtitle.getString(context),
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        fontSize: 8.r,
+                        color: theme.colorScheme.onSurface.withValues(
+                          alpha: 0.5,
+                        ),
+                      ),
                     ),
                   ],
+                ),
+                trailing: CustomToggleSwitch(
+                  value: provider.hasAllFilesAccess,
+                  onChanged: (value) => _handlePermissionToggle(provider),
+                  activeColor: theme.colorScheme.primary,
                 ),
               );
             }(),
@@ -689,7 +631,10 @@ class GeneralSettingsContentState extends State<GeneralSettingsContent>
             }(),
           ],
         ],
+          ),
+        ),
       ),
+      ],
     );
   }
 

--- a/lib/screens/settings_screen/new_settings_options/secondary_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/secondary_settings_content.dart
@@ -9,6 +9,10 @@ import 'package:neostation/utils/adaptive_scroll.dart';
 import 'package:provider/provider.dart';
 
 import '../../../widgets/custom_toggle_switch.dart';
+import 'settings_title.dart';
+import 'widgets/setting_row.dart';
+import 'widgets/setting_value_chip.dart';
+import 'widgets/settings_section_header.dart';
 
 /// Settings detail panel for secondary-display options. Only reachable while a
 /// secondary display is active (the menu entry is hidden otherwise), so it
@@ -49,6 +53,11 @@ class SecondarySettingsContentState extends State<SecondarySettingsContent>
   /// Whether the screenshot accessibility service is currently granted.
   bool _screenshotAccessEnabled = false;
 
+  /// Left inset applied to option rows so they read as nested under their
+  /// section header (mirrors how Directories' icon-cards sit indented below
+  /// each subheader).
+  double get _rowIndent => 16.r;
+
   @override
   void initState() {
     super.initState();
@@ -56,6 +65,16 @@ class SecondarySettingsContentState extends State<SecondarySettingsContent>
       _itemKeys.add(GlobalKey());
     }
     WidgetsBinding.instance.addObserver(this);
+    // Seed from the last-known value the provider already holds so the toggle
+    // renders in its correct position on the first frame instead of flashing
+    // off→on once the async check below resolves.
+    _screenshotAccessEnabled =
+        context
+            .read<SqliteConfigProvider>()
+            .secondaryDisplayState
+            ?.value
+            ?.screenshotAccessEnabled ??
+        false;
     _refreshScreenshotAccess();
   }
 
@@ -184,76 +203,28 @@ class SecondarySettingsContentState extends State<SecondarySettingsContent>
     required VoidCallback onTap,
     bool enabled = true,
   }) {
-    final theme = Theme.of(context);
-    final focused =
-        widget.isContentFocused && widget.selectedContentIndex == index;
-    final row = Container(
-      key: _itemKeys[index],
-      padding: EdgeInsets.only(left: 12.r, right: 12.r, top: 6.r, bottom: 6.r),
-      decoration: BoxDecoration(
-        color: theme.colorScheme.surface.withValues(alpha: 0.5),
-        borderRadius: BorderRadius.circular(8.r),
-        border: Border.all(
-          color: focused ? theme.colorScheme.primary : Colors.transparent,
-          width: 2,
+    // When disabled (e.g. delay is Never), grey the row out and ignore input.
+    return Padding(
+      padding: EdgeInsets.only(left: _rowIndent),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: enabled ? onTap : null,
+        child: Opacity(
+          opacity: enabled ? 1.0 : 0.4,
+          child: SettingRow(
+            key: _itemKeys[index],
+            focused:
+                widget.isContentFocused &&
+                widget.selectedContentIndex == index,
+            title: title,
+            subtitle: subtitle,
+            trailing: SettingValueChip(text: valueText),
+          ),
         ),
       ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  title,
-                  style: theme.textTheme.bodyLarge?.copyWith(
-                    fontSize: 12.r,
-                    fontWeight: FontWeight.w500,
-                    color: focused
-                        ? theme.colorScheme.primary
-                        : theme.colorScheme.onSurface,
-                  ),
-                ),
-                SizedBox(height: 4.r),
-                Text(
-                  subtitle,
-                  style: theme.textTheme.bodyMedium?.copyWith(
-                    fontSize: 9.r,
-                    color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
-                  ),
-                ),
-              ],
-            ),
-          ),
-          SizedBox(width: 12.r),
-          Container(
-            padding: EdgeInsets.symmetric(horizontal: 12.r, vertical: 6.r),
-            decoration: BoxDecoration(
-              color: theme.colorScheme.primary.withValues(alpha: 0.15),
-              borderRadius: BorderRadius.circular(6.r),
-            ),
-            child: Text(
-              valueText,
-              style: theme.textTheme.bodyLarge?.copyWith(
-                fontSize: 12.r,
-                fontWeight: FontWeight.w600,
-                color: theme.colorScheme.primary,
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-    // When disabled (e.g. delay is Never), grey the row out and ignore input.
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
-      onTap: enabled ? onTap : null,
-      child: Opacity(opacity: enabled ? 1.0 : 0.4, child: row),
     );
   }
 
-  /// Toggle row for screenshot access, styled like the All Files Access row.
   /// A labelled row with a trailing on/off switch, for boolean settings.
   Widget _buildToggleRow({
     required int index,
@@ -262,54 +233,19 @@ class SecondarySettingsContentState extends State<SecondarySettingsContent>
     required bool value,
     required ValueChanged<bool> onChanged,
   }) {
-    final theme = Theme.of(context);
-    final focused =
-        widget.isContentFocused && widget.selectedContentIndex == index;
-    return Container(
-      key: _itemKeys[index],
-      padding: EdgeInsets.only(left: 12.r, right: 12.r, top: 6.r, bottom: 6.r),
-      decoration: BoxDecoration(
-        color: theme.colorScheme.surface.withValues(alpha: 0.5),
-        borderRadius: BorderRadius.circular(8.r),
-        border: Border.all(
-          color: focused ? theme.colorScheme.primary : Colors.transparent,
-          width: 2,
+    return Padding(
+      padding: EdgeInsets.only(left: _rowIndent),
+      child: SettingRow(
+        key: _itemKeys[index],
+        focused:
+            widget.isContentFocused && widget.selectedContentIndex == index,
+        title: title,
+        subtitle: subtitle,
+        trailing: CustomToggleSwitch(
+          value: value,
+          onChanged: onChanged,
+          activeColor: Theme.of(context).colorScheme.primary,
         ),
-      ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  title,
-                  style: theme.textTheme.bodyLarge?.copyWith(
-                    fontSize: 12.r,
-                    fontWeight: FontWeight.w500,
-                    color: focused
-                        ? theme.colorScheme.primary
-                        : theme.colorScheme.onSurface,
-                  ),
-                ),
-                SizedBox(height: 4.r),
-                Text(
-                  subtitle,
-                  style: theme.textTheme.bodyMedium?.copyWith(
-                    fontSize: 9.r,
-                    color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
-                  ),
-                ),
-              ],
-            ),
-          ),
-          CustomToggleSwitch(
-            value: value,
-            onChanged: onChanged,
-            activeColor: theme.colorScheme.primary,
-          ),
-        ],
       ),
     );
   }
@@ -318,85 +254,19 @@ class SecondarySettingsContentState extends State<SecondarySettingsContent>
   /// flipped programmatically) opens Android's accessibility settings.
   Widget _buildScreenshotAccessRow() {
     const index = 1;
-    final theme = Theme.of(context);
-    final focused =
-        widget.isContentFocused && widget.selectedContentIndex == index;
-    return Container(
-      key: _itemKeys[index],
-      padding: EdgeInsets.only(left: 12.r, right: 12.r, top: 6.r, bottom: 6.r),
-      decoration: BoxDecoration(
-        color: theme.colorScheme.surface.withValues(alpha: 0.5),
-        borderRadius: BorderRadius.circular(8.r),
-        border: Border.all(
-          color: focused ? theme.colorScheme.primary : Colors.transparent,
-          width: 2,
-        ),
-      ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  AppLocale.screenshotAccess.getString(context),
-                  style: theme.textTheme.bodyLarge?.copyWith(
-                    fontSize: 12.r,
-                    fontWeight: FontWeight.w500,
-                    color: focused
-                        ? theme.colorScheme.primary
-                        : theme.colorScheme.onSurface,
-                  ),
-                ),
-                SizedBox(height: 4.r),
-                Text(
-                  AppLocale.screenshotAccessSubtitle.getString(context),
-                  style: theme.textTheme.bodyMedium?.copyWith(
-                    fontSize: 9.r,
-                    color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
-                  ),
-                ),
-              ],
-            ),
-          ),
-          CustomToggleSwitch(
-            value: _screenshotAccessEnabled,
-            onChanged: (_) => ScreenshotService.openAccessSettings(),
-            activeColor: theme.colorScheme.primary,
-          ),
-        ],
-      ),
-    );
-  }
-
-  /// Non-navigable group heading (a small primary bar + bold label), matching
-  /// the section headers used elsewhere in Settings.
-  Widget _buildSectionHeader(String label) {
-    final theme = Theme.of(context);
     return Padding(
-      padding: EdgeInsets.only(bottom: 8.r, top: 4.r, left: 2.r),
-      child: Row(
-        children: [
-          Container(
-            width: 3.r,
-            height: 14.r,
-            decoration: BoxDecoration(
-              color: theme.colorScheme.primary,
-              borderRadius: BorderRadius.circular(2.r),
-            ),
-          ),
-          SizedBox(width: 8.r),
-          Text(
-            label,
-            style: TextStyle(
-              fontSize: 11.r,
-              fontWeight: FontWeight.bold,
-              color: theme.colorScheme.primary,
-              letterSpacing: 0.5,
-            ),
-          ),
-        ],
+      padding: EdgeInsets.only(left: _rowIndent),
+      child: SettingRow(
+        key: _itemKeys[index],
+        focused:
+            widget.isContentFocused && widget.selectedContentIndex == index,
+        title: AppLocale.screenshotAccess.getString(context),
+        subtitle: AppLocale.screenshotAccessSubtitle.getString(context),
+        trailing: CustomToggleSwitch(
+          value: _screenshotAccessEnabled,
+          onChanged: (_) => ScreenshotService.openAccessSettings(),
+          activeColor: Theme.of(context).colorScheme.primary,
+        ),
       ),
     );
   }
@@ -406,13 +276,22 @@ class SecondarySettingsContentState extends State<SecondarySettingsContent>
     final provider = context.watch<SqliteConfigProvider>();
     final config = provider.config;
 
-    return SingleChildScrollView(
-      controller: _scrollController,
-      padding: EdgeInsets.symmetric(horizontal: 24.r, vertical: 24.r),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          _buildSectionHeader(AppLocale.general.getString(context)),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Pinned header — stays put while the settings list scrolls beneath it.
+        SettingsTitle(title: AppLocale.secondaryDisplay.getString(context)),
+        SizedBox(height: 12.r),
+        Expanded(
+          child: SingleChildScrollView(
+            controller: _scrollController,
+            padding: EdgeInsets.only(bottom: 24.r),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SettingsSectionHeader(
+                  label: AppLocale.general.getString(context),
+                ),
           _buildValueRow(
             index: 0,
             title: AppLocale.nowPlayingFanartDim.getString(context),
@@ -423,9 +302,7 @@ class SecondarySettingsContentState extends State<SecondarySettingsContent>
           SizedBox(height: 12.r),
           _buildScreenshotAccessRow(),
           SizedBox(height: 24.r),
-          _buildSectionHeader(
-            AppLocale.secondarySectionNowPlaying.getString(context),
-          ),
+          SettingsSectionHeader(label: AppLocale.secondarySectionNowPlaying.getString(context)),
           _buildValueRow(
             index: 2,
             title: AppLocale.nowPlayingDimAfter.getString(context),
@@ -445,9 +322,7 @@ class SecondarySettingsContentState extends State<SecondarySettingsContent>
             onTap: () => _cycleDimLevel(provider),
           ),
           SizedBox(height: 24.r),
-          _buildSectionHeader(
-            AppLocale.secondarySectionDock.getString(context),
-          ),
+          SettingsSectionHeader(label: AppLocale.secondarySectionDock.getString(context)),
           _buildToggleRow(
             index: 4,
             title: AppLocale.nowPlayingDockEnabled.getString(context),
@@ -466,8 +341,11 @@ class SecondarySettingsContentState extends State<SecondarySettingsContent>
             enabled: config.dockEnabled,
             onTap: () => _cycleDockSlotCount(provider),
           ),
-        ],
-      ),
+              ],
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/screens/settings_screen/new_settings_options/systems_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/systems_settings_content.dart
@@ -11,6 +11,7 @@ import '../../../providers/sqlite_database_provider.dart';
 import '../../../widgets/custom_toggle_switch.dart';
 import '../../../constants/system_folder_names.dart';
 import 'settings_title.dart';
+import 'widgets/settings_card_row.dart';
 
 /// A specialized content panel for managing system visibility and interface components.
 ///
@@ -77,7 +78,7 @@ class SystemsSettingsContentState extends State<SystemsSettingsContent> {
     }
   }
 
-  List<_SettingsRow> _buildItems(SqliteConfigProvider provider) {
+  List<_SystemSettingRow> _buildItems(SqliteConfigProvider provider) {
     final hiddenFolders = provider.hiddenSystemFolders;
     final systems = provider.detectedSystems;
     final totalFavorites = context
@@ -85,8 +86,8 @@ class SystemsSettingsContentState extends State<SystemsSettingsContent> {
         .totalFavorites;
     final hasFavorites = totalFavorites > 0;
 
-    return <_SettingsRow>[
-      _SettingsRow(
+    return <_SystemSettingRow>[
+      _SystemSettingRow(
         icon: Symbols.access_time_rounded,
         title: AppLocale.hideRecentCard.getString(context),
         subtitle: AppLocale.hideRecentCardSubtitle.getString(context),
@@ -94,7 +95,7 @@ class SystemsSettingsContentState extends State<SystemsSettingsContent> {
         onToggle: () =>
             provider.updateHideRecentCard(!provider.config.hideRecentCard),
       ),
-      _SettingsRow(
+      _SystemSettingRow(
         icon: Symbols.favorite_rounded,
         title: AppLocale.favorite.getString(context),
         subtitle: SystemFolderNames.favorites,
@@ -110,7 +111,7 @@ class SystemsSettingsContentState extends State<SystemsSettingsContent> {
       ...systems
           .where((s) => s.folderName != SystemFolderNames.favorites)
           .map(
-            (s) => _SettingsRow(
+            (s) => _SystemSettingRow(
               icon: Symbols.videogame_asset_rounded,
               title: s.realName,
               subtitle: s.folderName,
@@ -155,15 +156,24 @@ class SystemsSettingsContentState extends State<SystemsSettingsContent> {
                       widget.isContentFocused &&
                       widget.selectedContentIndex == index;
 
-                  return _buildRow(
-                    context,
-                    item,
-                    isSelected,
-                    _itemKeys[index],
-                    () {
-                      SfxService().playNavSound();
-                      selectItem(index, provider);
-                    },
+                  void onTap() {
+                    SfxService().playNavSound();
+                    selectItem(index, provider);
+                  }
+
+                  return SettingsCardRow(
+                    key: _itemKeys[index],
+                    icon: item.icon,
+                    title: item.title,
+                    subtitle: item.subtitle,
+                    selected: isSelected,
+                    disabled: item.isDisabled,
+                    onTap: item.isDisabled ? null : onTap,
+                    trailing: CustomToggleSwitch(
+                      value: item.isEnabled,
+                      onChanged: (_) => onTap(),
+                      disabled: item.isDisabled,
+                    ),
                   );
                 },
               ),
@@ -173,101 +183,10 @@ class SystemsSettingsContentState extends State<SystemsSettingsContent> {
       },
     );
   }
-
-  /// Constructs a standardized configuration row with icon, metadata, and state toggle.
-  Widget _buildRow(
-    BuildContext context,
-    _SettingsRow item,
-    bool isSelected,
-    GlobalKey rowKey,
-    VoidCallback onTap,
-  ) {
-    final theme = Theme.of(context);
-
-    final Color borderColor = isSelected
-        ? theme.colorScheme.primary
-        : theme.colorScheme.outline.withValues(alpha: 0);
-
-    return Container(
-      key: rowKey,
-      decoration: BoxDecoration(
-        color: theme.cardColor.withValues(alpha: 0.25),
-        borderRadius: BorderRadius.circular(12.r),
-        border: Border.all(color: borderColor, width: isSelected ? 2.r : 1.r),
-      ),
-      margin: EdgeInsets.only(bottom: 8.r),
-      child: InkWell(
-        onTap: item.isDisabled ? null : onTap,
-        borderRadius: BorderRadius.circular(12.r),
-        canRequestFocus: false,
-        focusColor: Colors.transparent,
-        hoverColor: Colors.transparent,
-        highlightColor: Colors.transparent,
-        splashColor: Colors.transparent,
-        child: Padding(
-          padding: EdgeInsets.symmetric(horizontal: 12.r, vertical: 8.r),
-          child: Row(
-            children: [
-              Icon(
-                item.icon,
-                color: isSelected
-                    ? theme.colorScheme.primary
-                    : theme.colorScheme.onSurface.withValues(
-                        alpha: item.isDisabled ? 0.4 : 1.0,
-                      ),
-                size: 20.r,
-              ),
-              SizedBox(width: 12.r),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      item.title,
-                      style: theme.textTheme.titleSmall?.copyWith(
-                        fontWeight: FontWeight.bold,
-                        fontSize: 12.r,
-                        color: isSelected
-                            ? theme.colorScheme.primary
-                            : theme.colorScheme.onSurface.withValues(
-                                alpha: item.isDisabled ? 0.4 : 1.0,
-                              ),
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    if (item.subtitle.isNotEmpty) ...[
-                      SizedBox(height: 2.r),
-                      Text(
-                        item.subtitle,
-                        style: theme.textTheme.bodySmall?.copyWith(
-                          fontSize: 9.r,
-                          color: theme.colorScheme.onSurface.withValues(
-                            alpha: item.isDisabled ? 0.25 : 0.6,
-                          ),
-                        ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ],
-                  ],
-                ),
-              ),
-              CustomToggleSwitch(
-                value: item.isEnabled,
-                onChanged: (_) => onTap(),
-                disabled: item.isDisabled,
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
 }
 
 /// Metadata model for a standardized settings row.
-class _SettingsRow {
+class _SystemSettingRow {
   final IconData icon;
   final String title;
   final String subtitle;
@@ -276,7 +195,7 @@ class _SettingsRow {
   final bool isDisabled;
   final VoidCallback onToggle;
 
-  const _SettingsRow({
+  const _SystemSettingRow({
     required this.icon,
     required this.title,
     required this.subtitle,

--- a/lib/screens/settings_screen/new_settings_options/tools_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/tools_settings_content.dart
@@ -12,6 +12,8 @@ import 'package:neostation/services/logger_service.dart';
 import 'package:neostation/services/rom_folder_organizer_service.dart';
 import 'package:neostation/widgets/custom_notification.dart';
 import 'settings_title.dart';
+import 'widgets/settings_card_row.dart';
+import 'widgets/settings_action_button.dart';
 
 class ToolsSettingsContent extends StatefulWidget {
   final bool isContentFocused;
@@ -185,7 +187,6 @@ class ToolsSettingsContentState extends State<ToolsSettingsContent> {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     final isSelected =
         widget.isContentFocused && widget.selectedContentIndex == 0;
 
@@ -201,87 +202,18 @@ class ToolsSettingsContentState extends State<ToolsSettingsContent> {
           child: ListView(
             physics: const ClampingScrollPhysics(),
             children: [
-              Container(
-                decoration: BoxDecoration(
-                  color: theme.cardColor.withValues(alpha: 0.25),
-                  borderRadius: BorderRadius.circular(12.r),
-                  border: Border.all(
-                    color: isSelected
-                        ? theme.colorScheme.primary
-                        : theme.colorScheme.outline.withValues(alpha: 0),
-                    width: isSelected ? 2.r : 1.r,
-                  ),
+              SettingsCardRow(
+                icon: Symbols.folder_managed_rounded,
+                title: AppLocale.organizeMultiDiscGames.getString(context),
+                subtitle: AppLocale.organizeMultiDiscGamesSubtitle.getString(
+                  context,
                 ),
-                child: InkWell(
-                  onTap: () => _organizeMultiDiscGames(),
-                  borderRadius: BorderRadius.circular(12.r),
-                  canRequestFocus: false,
-                  focusColor: Colors.transparent,
-                  hoverColor: Colors.transparent,
-                  highlightColor: Colors.transparent,
-                  splashColor: Colors.transparent,
-                  child: Padding(
-                    padding: EdgeInsets.symmetric(
-                      horizontal: 12.r,
-                      vertical: 10.r,
-                    ),
-                    child: Row(
-                      children: [
-                        Icon(
-                          Symbols.folder_managed_rounded,
-                          color: isSelected
-                              ? theme.colorScheme.primary
-                              : theme.colorScheme.onSurface,
-                          size: 20.r,
-                        ),
-                        SizedBox(width: 12.r),
-                        Expanded(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                AppLocale.organizeMultiDiscGames.getString(
-                                  context,
-                                ),
-                                style: theme.textTheme.titleSmall?.copyWith(
-                                  fontWeight: FontWeight.bold,
-                                  fontSize: 12.r,
-                                  color: isSelected
-                                      ? theme.colorScheme.primary
-                                      : theme.colorScheme.onSurface,
-                                ),
-                              ),
-                              SizedBox(height: 2.r),
-                              Text(
-                                AppLocale.organizeMultiDiscGamesSubtitle
-                                    .getString(context),
-                                style: theme.textTheme.bodySmall?.copyWith(
-                                  color: theme.colorScheme.onSurface.withValues(
-                                    alpha: 0.6,
-                                  ),
-                                  fontSize: 9.r,
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-                        Container(
-                          padding: EdgeInsets.all(4.r),
-                          decoration: BoxDecoration(
-                            color: theme.colorScheme.primary.withValues(
-                              alpha: isSelected ? 1.0 : 0.8,
-                            ),
-                            shape: BoxShape.circle,
-                          ),
-                          child: Icon(
-                            Symbols.folder_managed_rounded,
-                            color: theme.colorScheme.onPrimary,
-                            size: 16.r,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
+                subtitleMaxLines: 2,
+                selected: isSelected,
+                onTap: () => _organizeMultiDiscGames(),
+                trailing: SettingsActionButton(
+                  icon: Symbols.folder_managed_rounded,
+                  selected: isSelected,
                 ),
               ),
             ],

--- a/lib/screens/settings_screen/new_settings_options/widgets/setting_row.dart
+++ b/lib/screens/settings_screen/new_settings_options/widgets/setting_row.dart
@@ -12,8 +12,14 @@ class SettingRow extends StatelessWidget {
   /// Primary label text.
   final String title;
 
-  /// Secondary description text shown beneath the title.
+  /// Secondary description text shown beneath the title. Ignored when
+  /// [subtitleWidget] is provided.
   final String subtitle;
+
+  /// Optional custom widget rendered beneath the title in place of the plain
+  /// [subtitle] text — for rows needing richer secondary content (e.g. a
+  /// coloured permission-status line).
+  final Widget? subtitleWidget;
 
   /// The control rendered at the trailing edge of the row.
   final Widget trailing;
@@ -30,6 +36,7 @@ class SettingRow extends StatelessWidget {
     super.key,
     required this.title,
     required this.subtitle,
+    this.subtitleWidget,
     required this.trailing,
     required this.focused,
     this.expandTitle = true,
@@ -53,13 +60,16 @@ class SettingRow extends StatelessWidget {
           ),
         ),
         SizedBox(height: 4.r),
-        Text(
-          subtitle,
-          style: theme.textTheme.bodyMedium?.copyWith(
-            fontSize: 9.r,
-            color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+        if (subtitleWidget != null)
+          subtitleWidget!
+        else
+          Text(
+            subtitle,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              fontSize: 9.r,
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+            ),
           ),
-        ),
       ],
     );
 
@@ -77,6 +87,7 @@ class SettingRow extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           expandTitle ? Expanded(child: titleColumn) : titleColumn,
+          SizedBox(width: 12.r),
           trailing,
         ],
       ),

--- a/lib/screens/settings_screen/new_settings_options/widgets/setting_value_chip.dart
+++ b/lib/screens/settings_screen/new_settings_options/widgets/setting_value_chip.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+/// Compact pill showing the current value of a settings row (language, a
+/// cyclable option, etc.). Pair it as the [SettingRow.trailing] control; wrap
+/// the owning row in a tap handler to cycle or open a picker.
+///
+/// Optionally renders a trailing glyph (e.g. a dropdown caret) to signal that
+/// tapping opens a picker.
+class SettingValueChip extends StatelessWidget {
+  /// Text of the current value.
+  final String text;
+
+  /// Optional trailing glyph, e.g. a dropdown caret for picker-backed rows.
+  final IconData? trailingIcon;
+
+  const SettingValueChip({super.key, required this.text, this.trailingIcon});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      padding: EdgeInsets.symmetric(horizontal: 10.r, vertical: 6.r),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.primary.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(6.r),
+        border: Border.all(
+          color: theme.colorScheme.primary.withValues(alpha: 0.4),
+          width: 0.5.r,
+        ),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            text,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              fontSize: 9.r,
+              fontWeight: FontWeight.w400,
+              color: theme.colorScheme.primary,
+            ),
+          ),
+          if (trailingIcon != null) ...[
+            SizedBox(width: 2.r),
+            Icon(trailingIcon, size: 14.r, color: theme.colorScheme.primary),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/settings_screen/new_settings_options/widgets/settings_action_button.dart
+++ b/lib/screens/settings_screen/new_settings_options/widgets/settings_action_button.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+/// Circular icon button used as the trailing control on actionable settings
+/// card rows (add ROM folder, rescan, edit, ES-DE import, etc.).
+///
+/// Brightens while its owning row is selected and switches to the theme's
+/// error colour for destructive actions (remove folder, reset import).
+class SettingsActionButton extends StatelessWidget {
+  /// Glyph shown inside the button.
+  final IconData icon;
+
+  /// Whether the owning row currently holds gamepad focus.
+  final bool selected;
+
+  /// Renders in the error colour instead of primary for destructive actions.
+  final bool isDestructive;
+
+  const SettingsActionButton({
+    super.key,
+    required this.icon,
+    required this.selected,
+    this.isDestructive = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final color = isDestructive
+        ? theme.colorScheme.error
+        : theme.colorScheme.primary;
+
+    return Container(
+      padding: EdgeInsets.all(4.r),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: selected ? 1.0 : 0.8),
+        shape: BoxShape.circle,
+        boxShadow: [
+          BoxShadow(
+            color: color.withValues(alpha: 0.3),
+            blurRadius: 4.r,
+            offset: Offset(0, 2.r),
+          ),
+        ],
+      ),
+      child: Icon(icon, color: theme.colorScheme.onPrimary, size: 16.r),
+    );
+  }
+}

--- a/lib/screens/settings_screen/new_settings_options/widgets/settings_card_row.dart
+++ b/lib/screens/settings_screen/new_settings_options/widgets/settings_card_row.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+/// Actionable settings tile: a bordered card with a leading icon, a
+/// title/subtitle block and a trailing control (toggle or action button).
+///
+/// This is the shared extraction of the Directories card chrome, reused by the
+/// Tools and Systems panels so every actionable settings list renders with the
+/// same background, corner radius, focus border and spacing. Richer one-off
+/// rows (destructive/monospace paths in Directories) keep their bespoke layout.
+class SettingsCardRow extends StatelessWidget {
+  /// Leading glyph.
+  final IconData icon;
+
+  /// Primary label.
+  final String title;
+
+  /// Secondary description; pass an empty string to omit it.
+  final String subtitle;
+
+  /// Maximum lines the subtitle may wrap to before it ellipsizes.
+  final int subtitleMaxLines;
+
+  /// Trailing control (e.g. [CustomToggleSwitch] or a SettingsActionButton).
+  final Widget? trailing;
+
+  /// Whether this row currently holds gamepad focus (drives the border and
+  /// title/icon accent colour).
+  final bool selected;
+
+  /// Dims the icon/title/subtitle for unavailable rows. Does not itself block
+  /// taps — pass `onTap: null` (and a disabled trailing control) to do that.
+  final bool disabled;
+
+  /// Optional extra content rendered beneath the title/subtitle row (e.g. a
+  /// current-path chip).
+  final Widget? belowContent;
+
+  /// Touch handler. Gamepad selection is driven separately by the panel.
+  final VoidCallback? onTap;
+
+  const SettingsCardRow({
+    super.key,
+    required this.icon,
+    required this.title,
+    this.subtitle = '',
+    this.subtitleMaxLines = 1,
+    this.trailing,
+    required this.selected,
+    this.disabled = false,
+    this.belowContent,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    final borderColor = selected
+        ? theme.colorScheme.primary
+        : theme.colorScheme.outline.withValues(alpha: 0);
+    final foreground = selected
+        ? theme.colorScheme.primary
+        : theme.colorScheme.onSurface.withValues(alpha: disabled ? 0.4 : 1.0);
+
+    return Container(
+      decoration: BoxDecoration(
+        color: theme.cardColor.withValues(alpha: 0.25),
+        borderRadius: BorderRadius.circular(12.r),
+        border: Border.all(color: borderColor, width: selected ? 2.r : 1.r),
+      ),
+      margin: EdgeInsets.only(bottom: 8.r),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12.r),
+        canRequestFocus: false,
+        focusColor: Colors.transparent,
+        hoverColor: Colors.transparent,
+        highlightColor: Colors.transparent,
+        splashColor: Colors.transparent,
+        child: Padding(
+          padding: EdgeInsets.symmetric(horizontal: 12.r, vertical: 8.r),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(icon, color: foreground, size: 20.r),
+                  SizedBox(width: 12.r),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          title,
+                          style: theme.textTheme.titleSmall?.copyWith(
+                            fontWeight: FontWeight.bold,
+                            fontSize: 12.r,
+                            color: foreground,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        if (subtitle.isNotEmpty) ...[
+                          SizedBox(height: 2.r),
+                          Text(
+                            subtitle,
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              fontSize: 9.r,
+                              color: theme.colorScheme.onSurface.withValues(
+                                alpha: disabled ? 0.25 : 0.6,
+                              ),
+                            ),
+                            maxLines: subtitleMaxLines,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                  if (trailing != null) SizedBox(width: 12.r),
+                  ?trailing,
+                ],
+              ),
+              ?belowContent,
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/settings_screen/new_settings_options/widgets/settings_section_header.dart
+++ b/lib/screens/settings_screen/new_settings_options/widgets/settings_section_header.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+/// Section divider used to group settings rows under a labelled heading.
+///
+/// Renders a short primary-colour accent bar followed by an uppercase-weight
+/// label. Shared by any settings content panel that groups its rows into
+/// sections (Directories, Secondary).
+class SettingsSectionHeader extends StatelessWidget {
+  /// Heading text shown beside the accent bar.
+  final String label;
+
+  const SettingsSectionHeader({super.key, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: EdgeInsets.only(bottom: 8.r, top: 4.r, left: 2.r),
+      child: Row(
+        children: [
+          Container(
+            width: 3.r,
+            height: 14.r,
+            decoration: BoxDecoration(
+              color: theme.colorScheme.primary,
+              borderRadius: BorderRadius.circular(2.r),
+            ),
+          ),
+          SizedBox(width: 8.r),
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 11.r,
+              fontWeight: FontWeight.bold,
+              color: theme.colorScheme.primary,
+              letterSpacing: 0.5,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
> 🤖 This PR was authored with [Claude Code](https://claude.com/claude-code).

# Description

The Settings menus (General, Directories, Tools, Secondary Screen, Systems) had each drifted into their own layout — three different row implementations, two duplicated section-header copies, duplicated action buttons, inconsistent padding, and one screen missing its page title. This PR unifies them onto a shared component set derived from the two original reference screens (General for toggle settings, Directories for actionable lists), then fixes a handful of layout/interaction issues surfaced while testing on device.

**New shared widgets** (`new_settings_options/widgets/`):
- `SettingsSectionHeader` — accent-bar + label (was duplicated in Directories & Secondary)
- `SettingsCardRow` — bordered icon card tile (Directories chrome), now used by Tools & Systems
- `SettingsActionButton` — circular icon button (was in Directories, re-inlined in Tools)
- `SettingValueChip` — value pill (was hand-rolled in General & Secondary)
- `SettingRow` gains an optional `subtitleWidget` so General's All Files Access row keeps its coloured permission-status line without duplicating chrome

**Per screen:**
- **General** (ref): All Files Access `Container` → `SettingRow`; Language chip → `SettingValueChip`
- **Directories** (ref): adopts `SettingsSectionHeader` + `SettingsActionButton`
- **Secondary**: now follows General — gains a page title, shared section headers, `SettingRow` + `SettingValueChip`; drops 3 hand-copied row builders and the extra inset; option rows indented under their section headers
- **Tools**: inline tile → `SettingsCardRow`; inline button → `SettingsActionButton`; two-line caption
- **Systems**: `_buildRow` → `SettingsCardRow`; renamed private `_SettingsRow` model → `_SystemSettingRow` to end the `SettingRow` name collision

**Fixes surfaced during on-device testing:**
- Secondary accessibility toggle no longer flashes off→on on open (seeds from the provider's last-known value instead of defaulting false pending the async check)
- Row/card text no longer touches the trailing toggle/icon (added a 12px gap)
- Directories gamepad scrolling no longer overshoots — switched from a fixed per-row height estimate to key-based `AdaptiveScroller.ensureVisible` (matching General/Systems)
- Page-title headers are now pinned in all five menus (lifted out of the scroll view in General & Secondary)

## Type of Change

- [x] Code refactoring
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable).

## Screenshots (if applicable)

_Layout is best reviewed on-device; the changes are consistency/spacing refinements across the five settings panels._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
