### PR TITLE
fix(setup-wizard): eagerly load theme manifest so art pack actually applies

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -483,6 +483,14 @@ class _MyAppState extends State<MyApp> {
         ),
         ChangeNotifierProvider(create: (context) => SystemBackgroundProvider()),
         ChangeNotifierProvider(
+          // Eager: the theme manifest is a network fetch, and during first-run
+          // setup the wizard's art-pack step is the ONLY consumer of this
+          // provider. A lazy create would not start loadThemes() until that
+          // final step renders, leaving `themes` empty if the user advances
+          // before the fetch resolves — the art pack then silently fails to
+          // apply. Starting at launch gives the fetch the whole wizard to
+          // complete.
+          lazy: false,
           create: (context) => NeoAssetsProvider()..init(),
         ),
       ],

--- a/lib/widgets/setup_wizard.dart
+++ b/lib/widgets/setup_wizard.dart
@@ -1614,6 +1614,15 @@ class _SetupWizardState extends State<SetupWizard> with WidgetsBindingObserver {
     // triggers a download.
     return Consumer<NeoAssetsProvider>(
       builder: (context, neoAssets, child) {
+        // On the art-pack step, block the primary action while the theme
+        // manifest is still loading: otherwise the button reads "Finish" (no
+        // themes yet) and a press would silently complete setup with no art
+        // pack even though one is about to become available.
+        final artLoading =
+            _currentStep == _stepArtPack &&
+            !neoAssets.hasActiveTheme &&
+            neoAssets.themes.isEmpty &&
+            neoAssets.loading;
         return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
@@ -1648,7 +1657,11 @@ class _SetupWizardState extends State<SetupWizard> with WidgetsBindingObserver {
 
         // Main action button
         ElevatedButton(
-          onPressed: (_isSelectingFolder || _isImportingEsde || _isDownloadingArt)
+          onPressed:
+              (_isSelectingFolder ||
+                  _isImportingEsde ||
+                  _isDownloadingArt ||
+                  artLoading)
               ? null
               : () => _handleMainAction(),
           style: ElevatedButton.styleFrom(
@@ -1664,7 +1677,7 @@ class _SetupWizardState extends State<SetupWizard> with WidgetsBindingObserver {
               alpha: 0.3,
             ),
           ),
-          child: _isSelectingFolder
+          child: (_isSelectingFolder || artLoading)
               ? SizedBox(
                   width: 20.r,
                   height: 20.r,


### PR DESCRIPTION
> 🤖 This PR was authored with [Claude Code](https://claude.com/claude-code).

# Description

The setup wizard's **art-pack step silently completed without installing the selected pack**. On a fresh first-run, after choosing to download the NeoStation art, the app booted with no system art applied — on-device the DB showed `active_theme=''` and no `themes/` directory existed at all (nothing was downloaded).

**Root cause:** `NeoAssetsProvider` was registered as a *lazy* provider in `main.dart`. Its `init()` → `loadThemes()` performs a network fetch of the theme manifest, and during first-run setup the wizard's art-pack step (the final step) is the *only* consumer of that provider. So the fetch didn't start until that step rendered — and if the user advanced before it resolved, `neoAssets.themes` was still empty, `canDownload` was false, and `_handleMainAction` silently called `_finishSetup()` with no art. Nothing surfaced because `downloadAndApplyTheme` swallows its errors internally.

**Fix:**
- `main.dart`: mark the provider `lazy: false` (mirroring `RetroAchievementsProvider` directly above it) so the manifest loads at app launch and is ready by the time the user reaches the final wizard step.
- `setup_wizard.dart`: defensively gate the primary action on the art-pack step while the manifest is still loading — disable + spinner instead of showing "Finish" — so a slow or failed fetch can no longer silently skip the pack.

Fixes # (no issue filed)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds capability)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist

- [x] I have run `flutter analyze` and there are no errors.
- [ ] I have added tests demonstrating that my fix or feature works.
- [ ] I have updated the corresponding documentation.
- [x] My changes do not introduce secrets, credentials, or sensitive data.
- [x] I have verified that any new assets have compatible licenses.
- [x] **Tested on:** [ ] Windows | [ ] Linux | [ ] macOS | [x] Android
- [x] **Gamepad support verified** (if applicable).

## Verification (on-device, AYN Thor)

Reproduced the failure, applied the fix, and re-ran a fresh first-run wizard:

| | Before (bug) | After (fix) |
|---|---|---|
| `user_config.active_theme` | `''` | `NeoStation` |
| `themes/` cache dir | absent | present — 121 backgrounds + `theme.json` |
| `buildThemeDownloadPlan` in log | never ran | ran (covered 121/121) |

## Screenshots (if applicable)

_N/A — behavioural fix; system backgrounds now render on the home grid after first-run setup._
